### PR TITLE
chore: bump app version to 0.0.32

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION

## Summary by DiffHawk

### Overview
Incrementing the application version to 0.0.32 for proper release management and version tracking. This routine update maintains consistent versioning for the Tauri application in preparation for upcoming builds.

### Key Changes
- Updated version number in Tauri configuration file

### Impact
- No breaking changes or migration steps required
- No performance or dependency impacts
- This is a standard version increment for release management