### PR TITLE
Add Edit submenu to app menu

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,7 +75,22 @@ pub fn run() {
                 ],
             )?;
 
-            Menu::with_items(app_handle, &[&app_submenu])
+            let edit_submenu = Submenu::with_items(
+                app_handle,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::undo(app_handle, Some("Undo"))?,
+                    &PredefinedMenuItem::redo(app_handle, Some("Redo"))?,
+                    &PredefinedMenuItem::separator(app_handle)?,
+                    &PredefinedMenuItem::cut(app_handle, Some("Cut"))?,
+                    &PredefinedMenuItem::copy(app_handle, Some("Copy"))?,
+                    &PredefinedMenuItem::paste(app_handle, Some("Paste"))?,
+                    &PredefinedMenuItem::select_all(app_handle, Some("Select All"))?,
+                ],
+            )?;
+
+            Menu::with_items(app_handle, &[&app_submenu, &edit_submenu])
         })
         .setup(|app| {
             #[cfg(desktop)]


### PR DESCRIPTION

## Summary by DiffHawk

### Overview
This change introduces an Edit submenu to the application's main menu, providing users organized access to common editing functionality. The change improves the user experience by implementing a standard menu structure that users expect from desktop applications.

### Key Changes
- Modified the Tauri backend menu configuration in `src-tauri/src/lib.rs`
- Added a new Edit submenu section to the application's native menu bar
- Enhanced menu initialization to include the new submenu with appropriate menu items

### Impact
- No breaking changes or migration steps required
- No performance implications or additional dependencies
- Purely additive change that improves user interface consistency