### PR TITLE
feat: embed MCP server with HTTP/SSE transport in Tauri app

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -278,6 +278,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +567,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +696,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,8 +805,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -752,12 +834,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.111",
 ]
@@ -768,12 +874,14 @@ version = "0.1.0"
 dependencies = [
  "async-ssh2-lite",
  "async-trait",
+ "axum",
  "chrono",
  "dirs 5.0.1",
  "futures-util",
  "hex",
  "redis",
  "reqwest",
+ "rmcp",
  "serde",
  "serde_json",
  "sqlx",
@@ -788,6 +896,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-util",
  "uuid",
 ]
 
@@ -887,7 +996,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1079,7 +1188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1515,9 +1624,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1803,6 +1926,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +1944,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1978,6 +2108,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2198,6 +2334,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,6 +2502,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
@@ -2977,6 +3125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3406,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,7 +3553,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.1",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3406,6 +3570,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -3440,6 +3610,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3498,6 +3679,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_hc"
@@ -3721,6 +3908,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.0",
+ "rmcp-macros",
+ "schemars 1.1.0",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3765,7 +3996,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3841,7 +4072,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -3866,8 +4097,10 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.1.0",
  "serde",
  "serde_json",
 ]
@@ -3877,6 +4110,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301858a4023d78debd2353c7426dc486001bddc91ae31a76fb1f55132f7e2633"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4015,6 +4260,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4080,7 +4336,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -4125,7 +4381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4142,7 +4398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4485,6 +4741,19 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -5039,7 +5308,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5331,6 +5600,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5521,6 +5791,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5649,7 +5925,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5717,6 +6002,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.12.1",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5727,6 +6034,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.12.1",
+ "semver",
 ]
 
 [[package]]
@@ -5930,7 +6249,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6441,6 +6760,94 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.12.1",
+ "prettyplease",
+ "syn 2.0.111",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "indexmap 2.12.1",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.12.1",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,9 @@ reqwest = { version = "0.12", features = [
     "stream",
 ], default-features = false }
 futures-util = "0.3"
+rmcp = { version = "1", features = ["server", "transport-streamable-http-server"] }
+axum = "0.8"
+tokio-util = "0.7"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/src/commands/pool.rs
+++ b/src-tauri/src/commands/pool.rs
@@ -2,6 +2,8 @@
 //!
 //! Commands for managing the connection pool: connect, disconnect, status, health check.
 
+use std::sync::Arc;
+
 use crate::database::pool_manager::{ConnectionConfig, ConnectionStatus, PoolManager};
 use crate::db::models::TestConnectionResult;
 use serde::{Deserialize, Serialize};
@@ -18,7 +20,7 @@ pub struct ConnectionStatusResponse {
 /// Connect to a database and add to pool
 #[tauri::command]
 pub async fn pool_connect(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     sqlite_pool: State<'_, SqlitePool>,
     uuid: String,
 ) -> Result<ConnectionStatusResponse, String> {
@@ -78,7 +80,7 @@ pub async fn pool_connect(
 /// Disconnect from a database and remove from pool
 #[tauri::command]
 pub async fn pool_disconnect(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     uuid: String,
 ) -> Result<(), String> {
     pool_manager.disconnect(&uuid).await;
@@ -88,7 +90,7 @@ pub async fn pool_disconnect(
 /// Get the current status of a connection
 #[tauri::command]
 pub async fn pool_get_status(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     uuid: String,
 ) -> Result<ConnectionStatusResponse, String> {
     let status = pool_manager.get_status(&uuid).await;
@@ -99,7 +101,7 @@ pub async fn pool_get_status(
 /// Perform a health check on a connection
 #[tauri::command]
 pub async fn pool_health_check(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     uuid: String,
 ) -> Result<TestConnectionResult, String> {
     pool_manager.health_check(&uuid).await
@@ -192,7 +194,7 @@ async fn reconnect(
 /// List tables using the pooled connection (auto-connects if needed, auto-retries on error)
 #[tauri::command]
 pub async fn pool_list_tables(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     sqlite_pool: State<'_, SqlitePool>,
     uuid: String,
 ) -> Result<Vec<crate::db::models::TableInfo>, String> {
@@ -217,7 +219,7 @@ pub async fn pool_list_tables(
 /// Get table data using the pooled connection (auto-connects if needed, auto-retries on error)
 #[tauri::command]
 pub async fn pool_get_table_data(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     sqlite_pool: State<'_, SqlitePool>,
     uuid: String,
     schema: String,
@@ -269,7 +271,7 @@ pub async fn pool_get_table_data(
 /// Get table structure using the pooled connection (auto-connects if needed, auto-retries on error)
 #[tauri::command]
 pub async fn pool_get_table_structure(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     sqlite_pool: State<'_, SqlitePool>,
     uuid: String,
     schema: String,
@@ -298,7 +300,7 @@ pub async fn pool_get_table_structure(
 /// Execute query using the pooled connection (auto-connects if needed, auto-retries on error)
 #[tauri::command]
 pub async fn pool_execute_query(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     sqlite_pool: State<'_, SqlitePool>,
     uuid: String,
     query: String,
@@ -321,7 +323,7 @@ pub async fn pool_execute_query(
 /// Get schema overview using the pooled connection (auto-connects if needed, auto-retries on error)
 #[tauri::command]
 pub async fn pool_get_schema_overview(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     sqlite_pool: State<'_, SqlitePool>,
     uuid: String,
 ) -> Result<crate::db::models::SchemaOverview, String> {
@@ -343,7 +345,7 @@ pub async fn pool_get_schema_overview(
 /// Get a function definition using the pooled connection (auto-connects if needed, auto-retries on error)
 #[tauri::command]
 pub async fn pool_get_function_definition(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     sqlite_pool: State<'_, SqlitePool>,
     uuid: String,
     schema: String,
@@ -379,7 +381,7 @@ use crate::commands::database::{escape_sql_identifier, format_sql_value, validat
 /// Update a row in a table using the pooled connection
 #[tauri::command]
 pub async fn pool_update_table_row(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     sqlite_pool: State<'_, SqlitePool>,
     uuid: String,
     schema: String,
@@ -487,7 +489,7 @@ pub async fn pool_update_table_row(
 /// Delete a row from a table using the pooled connection
 #[tauri::command]
 pub async fn pool_delete_table_row(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     sqlite_pool: State<'_, SqlitePool>,
     uuid: String,
     schema: String,
@@ -551,7 +553,7 @@ pub async fn pool_delete_table_row(
 /// Insert a new row into a table using the pooled connection
 #[tauri::command]
 pub async fn pool_insert_table_row(
-    pool_manager: State<'_, PoolManager>,
+    pool_manager: State<'_, Arc<PoolManager>>,
     sqlite_pool: State<'_, SqlitePool>,
     uuid: String,
     schema: String,

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -6,6 +6,7 @@ pub mod postgres;
 pub mod queries;
 pub mod redis;
 pub mod sqlite;
+pub mod utils;
 
 use crate::db::models::{
     FunctionDefinition, QueryResult, SchemaOverview, TableDataResponse, TableInfo, TableStructure,

--- a/src-tauri/src/database/utils.rs
+++ b/src-tauri/src/database/utils.rs
@@ -1,0 +1,49 @@
+use super::pool_manager::ConnectionConfig;
+use sqlx::SqlitePool;
+
+/// Build a ConnectionConfig from a saved connection record in SQLite.
+/// Shared between Tauri commands and the MCP server.
+pub async fn get_connection_config(
+    sqlite_pool: &SqlitePool,
+    uuid: &str,
+) -> Result<ConnectionConfig, String> {
+    let conn: crate::db::models::Connection =
+        sqlx::query_as("SELECT * FROM connections WHERE uuid = ?")
+            .bind(uuid)
+            .fetch_one(sqlite_pool)
+            .await
+            .map_err(|e| format!("Failed to get connection: {}", e))?;
+
+    Ok(ConnectionConfig {
+        db_type: conn.db_type,
+        host: Some(conn.host),
+        port: Some(conn.port),
+        database: Some(conn.database),
+        username: Some(conn.username),
+        password: Some(conn.password),
+        ssl: Some(conn.ssl == 1),
+        file_path: conn.file_path,
+        ssh_enabled: conn.ssh_enabled == 1,
+        ssh_host: if conn.ssh_host.is_empty() {
+            None
+        } else {
+            Some(conn.ssh_host)
+        },
+        ssh_port: Some(conn.ssh_port),
+        ssh_user: if conn.ssh_user.is_empty() {
+            None
+        } else {
+            Some(conn.ssh_user)
+        },
+        ssh_password: if conn.ssh_password.is_empty() {
+            None
+        } else {
+            Some(conn.ssh_password)
+        },
+        ssh_key_path: if conn.ssh_key_path.is_empty() {
+            None
+        } else {
+            Some(conn.ssh_key_path)
+        },
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod commands;
 pub mod database;
 pub mod db;
+pub mod mcp;
 mod ssh_tunnel;
 
 use commands::ai::{generate_sql, select_tables_for_query};
@@ -28,6 +29,8 @@ use commands::queries::{
     create_saved_query, delete_saved_query, get_saved_queries, update_saved_query,
 };
 use commands::settings::{get_all_settings, get_setting, set_setting};
+use std::sync::Arc;
+
 use database::pool_manager::PoolManager;
 use tauri::menu::{AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::{Manager, WebviewUrl};
@@ -143,10 +146,26 @@ pub fn run() {
             let pool = rt
                 .block_on(db::init_pool())
                 .expect("Failed to initialize database");
-            app.manage(pool);
+            app.manage(pool.clone());
 
             // Initialize connection pool manager
             app.manage(PoolManager::new());
+
+            // Start embedded MCP HTTP server
+            let mcp_pool = pool;
+            let mcp_pool_manager = Arc::new(PoolManager::new());
+            tauri::async_runtime::spawn(async move {
+                match mcp::server::start_mcp_server(mcp_pool, mcp_pool_manager, true).await {
+                    Ok(handle) => {
+                        eprintln!(
+                            "MCP server listening on http://127.0.0.1:{}/mcp",
+                            handle.port
+                        );
+                        handle.cancellation_token.cancelled().await;
+                    }
+                    Err(e) => eprintln!("Failed to start MCP server: {}", e),
+                }
+            });
 
             Ok(())
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -148,12 +148,13 @@ pub fn run() {
                 .expect("Failed to initialize database");
             app.manage(pool.clone());
 
-            // Initialize connection pool manager
-            app.manage(PoolManager::new());
+            // Initialize connection pool manager (shared between Tauri and MCP)
+            let pool_manager = Arc::new(PoolManager::new());
+            app.manage(pool_manager.clone());
 
             // Start embedded MCP HTTP server
             let mcp_pool = pool;
-            let mcp_pool_manager = Arc::new(PoolManager::new());
+            let mcp_pool_manager = pool_manager;
             tauri::async_runtime::spawn(async move {
                 match mcp::server::start_mcp_server(mcp_pool, mcp_pool_manager, true).await {
                     Ok(handle) => {

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -1,0 +1,112 @@
+pub mod resources;
+pub mod server;
+pub mod tools;
+
+use std::sync::Arc;
+
+use crate::database::pool_manager::PoolManager;
+use crate::database::utils::get_connection_config;
+use rmcp::model::*;
+use rmcp::{ErrorData as McpError, ServerHandler};
+use sqlx::SqlitePool;
+
+pub struct McpServer {
+    pub sqlite_pool: SqlitePool,
+    pub pool_manager: Arc<PoolManager>,
+    pub read_only: bool,
+}
+
+impl McpServer {
+    pub fn new(sqlite_pool: SqlitePool, pool_manager: Arc<PoolManager>, read_only: bool) -> Self {
+        Self {
+            sqlite_pool,
+            pool_manager,
+            read_only,
+        }
+    }
+
+    /// Ensure a connection exists in the pool, connecting if needed.
+    pub async fn ensure_connected(&self, uuid: &str) -> Result<(), McpError> {
+        if self.pool_manager.get_cached(uuid).await.is_some() {
+            return Ok(());
+        }
+
+        let config = get_connection_config(&self.sqlite_pool, uuid)
+            .await
+            .map_err(|e| McpError::internal_error(e, None))?;
+
+        self.pool_manager
+            .connect(uuid, config)
+            .await
+            .map_err(|e| McpError::internal_error(e, None))?;
+
+        Ok(())
+    }
+}
+
+impl ServerHandler for McpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(
+            ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .build(),
+        )
+        .with_server_info(Implementation::new(
+            "dbcooper-mcp",
+            env!("CARGO_PKG_VERSION"),
+        ))
+        .with_instructions(
+            "DBcooper MCP server — query databases, introspect schemas, and manage connections.",
+        )
+    }
+
+    fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::service::RoleServer>,
+    ) -> impl std::future::Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
+        std::future::ready(Ok(ListToolsResult::with_all_items(tools::tool_definitions())))
+    }
+
+    fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: rmcp::service::RequestContext<rmcp::service::RoleServer>,
+    ) -> impl std::future::Future<Output = Result<CallToolResult, McpError>> + Send + '_ {
+        tools::dispatch_tool(self, request)
+    }
+
+    fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::service::RoleServer>,
+    ) -> impl std::future::Future<Output = Result<ListResourcesResult, McpError>> + Send + '_ {
+        resources::list_resources(self)
+    }
+
+    fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: rmcp::service::RequestContext<rmcp::service::RoleServer>,
+    ) -> impl std::future::Future<Output = Result<ReadResourceResult, McpError>> + Send + '_ {
+        resources::read_resource(self, request)
+    }
+
+    fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<rmcp::service::RoleServer>,
+    ) -> impl std::future::Future<Output = Result<ListResourceTemplatesResult, McpError>> + Send + '_
+    {
+        std::future::ready(Ok(ListResourceTemplatesResult::with_all_items(vec![
+            RawResourceTemplate::new(
+                "dbcooper://connection/{uuid}/schema",
+                "Connection Schema",
+            )
+            .with_description("Full schema overview for a connected database")
+            .with_mime_type("application/json")
+            .no_annotation(),
+        ])))
+    }
+}

--- a/src-tauri/src/mcp/resources.rs
+++ b/src-tauri/src/mcp/resources.rs
@@ -1,0 +1,107 @@
+use super::McpServer;
+use rmcp::model::*;
+use rmcp::ErrorData as McpError;
+use serde_json::json;
+
+/// List available resources — returns the static `dbcooper://connections` resource
+/// plus a resource for each currently-connected database's schema.
+pub async fn list_resources(server: &McpServer) -> Result<ListResourcesResult, McpError> {
+    let mut resources = vec![RawResource::new("dbcooper://connections", "Database Connections")
+        .with_description("All saved database connections (credentials redacted)")
+        .with_mime_type("application/json")
+        .no_annotation()];
+
+    let connections: Vec<crate::db::models::Connection> =
+        sqlx::query_as("SELECT * FROM connections ORDER BY id DESC")
+            .fetch_all(&server.sqlite_pool)
+            .await
+            .map_err(|e| McpError::internal_error(format!("Database error: {}", e), None))?;
+
+    for conn in &connections {
+        if server.pool_manager.get_cached(&conn.uuid).await.is_some() {
+            resources.push(
+                RawResource::new(
+                    format!("dbcooper://connection/{}/schema", conn.uuid),
+                    format!("{} Schema", conn.name),
+                )
+                .with_description(format!("Schema overview for {} ({})", conn.name, conn.db_type))
+                .with_mime_type("application/json")
+                .no_annotation(),
+            );
+        }
+    }
+
+    Ok(ListResourcesResult::with_all_items(resources))
+}
+
+/// Read a specific resource by URI.
+pub async fn read_resource(
+    server: &McpServer,
+    request: ReadResourceRequestParams,
+) -> Result<ReadResourceResult, McpError> {
+    let uri = request.uri.as_str();
+
+    if uri == "dbcooper://connections" {
+        return read_connections(server).await;
+    }
+
+    if let Some(uuid) = uri
+        .strip_prefix("dbcooper://connection/")
+        .and_then(|rest| rest.strip_suffix("/schema"))
+    {
+        return read_schema(server, uuid).await;
+    }
+
+    Err(McpError::resource_not_found(
+        format!("Unknown resource: {}", uri),
+        None,
+    ))
+}
+
+async fn read_connections(server: &McpServer) -> Result<ReadResourceResult, McpError> {
+    let connections: Vec<crate::db::models::Connection> =
+        sqlx::query_as("SELECT * FROM connections ORDER BY id DESC")
+            .fetch_all(&server.sqlite_pool)
+            .await
+            .map_err(|e| McpError::internal_error(format!("Database error: {}", e), None))?;
+
+    let safe: Vec<serde_json::Value> = connections
+        .into_iter()
+        .map(|c| {
+            json!({
+                "uuid": c.uuid,
+                "name": c.name,
+                "db_type": c.db_type,
+                "host": c.host,
+                "port": c.port,
+                "database": c.database,
+                "ssl": c.ssl == 1,
+                "ssh_enabled": c.ssh_enabled == 1,
+            })
+        })
+        .collect();
+
+    let text = serde_json::to_string_pretty(&safe).unwrap_or_else(|_| "[]".to_string());
+
+    Ok(ReadResourceResult::new(vec![ResourceContents::text(
+        text,
+        "dbcooper://connections",
+    )]))
+}
+
+async fn read_schema(server: &McpServer, uuid: &str) -> Result<ReadResourceResult, McpError> {
+    server.ensure_connected(uuid).await?;
+
+    let overview = server
+        .pool_manager
+        .get_schema_overview(uuid)
+        .await
+        .map_err(|e| McpError::internal_error(format!("Failed to get schema: {}", e), None))?;
+
+    let text = serde_json::to_string_pretty(&overview).unwrap_or_else(|_| "{}".to_string());
+
+    Ok(ReadResourceResult::new(vec![ResourceContents::text(
+        text,
+        format!("dbcooper://connection/{}/schema", uuid),
+    )]))
+}

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+use sqlx::SqlitePool;
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+
+use super::McpServer;
+use crate::database::pool_manager::PoolManager;
+
+const DEFAULT_PORT: u16 = 9420;
+const MAX_PORT_ATTEMPTS: u16 = 10;
+
+pub struct McpServerHandle {
+    pub port: u16,
+    pub cancellation_token: CancellationToken,
+}
+
+pub async fn start_mcp_server(
+    sqlite_pool: SqlitePool,
+    pool_manager: Arc<PoolManager>,
+    read_only: bool,
+) -> Result<McpServerHandle, Box<dyn std::error::Error + Send + Sync>> {
+    let ct = CancellationToken::new();
+
+    let (listener, port) = bind_with_retry(DEFAULT_PORT, MAX_PORT_ATTEMPTS).await?;
+
+    let config = StreamableHttpServerConfig::default()
+        .with_cancellation_token(ct.child_token());
+
+    let service = StreamableHttpService::new(
+        move || {
+            Ok(McpServer::new(
+                sqlite_pool.clone(),
+                pool_manager.clone(),
+                read_only,
+            ))
+        },
+        Arc::new(LocalSessionManager::default()),
+        config,
+    );
+
+    let router = axum::Router::new().nest_service("/mcp", service);
+
+    let shutdown_ct = ct.clone();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router)
+            .with_graceful_shutdown(async move { shutdown_ct.cancelled().await })
+            .await;
+    });
+
+    Ok(McpServerHandle {
+        port,
+        cancellation_token: ct,
+    })
+}
+
+async fn bind_with_retry(
+    start_port: u16,
+    max_attempts: u16,
+) -> Result<(TcpListener, u16), Box<dyn std::error::Error + Send + Sync>> {
+    for offset in 0..max_attempts {
+        let port = start_port + offset;
+        match TcpListener::bind(("127.0.0.1", port)).await {
+            Ok(listener) => return Ok((listener, port)),
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => continue,
+            Err(e) => return Err(e.into()),
+        }
+    }
+    Err(format!(
+        "Could not bind to any port in range {}-{}",
+        start_port,
+        start_port + max_attempts - 1
+    )
+    .into())
+}

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -1,0 +1,392 @@
+use super::McpServer;
+use crate::database::utils::get_connection_config;
+use rmcp::model::*;
+use rmcp::ErrorData as McpError;
+use serde_json::json;
+
+const MAX_ROWS: usize = 1000;
+
+/// Return the list of all tool definitions.
+pub fn tool_definitions() -> Vec<Tool> {
+    vec![
+        Tool::new(
+            "list_connections",
+            "List all saved database connections (credentials are redacted)",
+            object(json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            })),
+        )
+        .with_annotations(
+            ToolAnnotations::new()
+                .read_only(true)
+                .destructive(false)
+                .idempotent(true),
+        ),
+        Tool::new(
+            "connect",
+            "Connect to a saved database by its UUID",
+            object(json!({
+                "type": "object",
+                "properties": {
+                    "connection_uuid": {
+                        "type": "string",
+                        "description": "UUID of the saved connection"
+                    }
+                },
+                "required": ["connection_uuid"]
+            })),
+        ),
+        Tool::new(
+            "disconnect",
+            "Disconnect from a database",
+            object(json!({
+                "type": "object",
+                "properties": {
+                    "connection_uuid": {
+                        "type": "string",
+                        "description": "UUID of the connection to disconnect"
+                    }
+                },
+                "required": ["connection_uuid"]
+            })),
+        ),
+        Tool::new(
+            "list_tables",
+            "List all tables in a connected database",
+            object(json!({
+                "type": "object",
+                "properties": {
+                    "connection_uuid": {
+                        "type": "string",
+                        "description": "UUID of the connected database"
+                    }
+                },
+                "required": ["connection_uuid"]
+            })),
+        )
+        .with_annotations(
+            ToolAnnotations::new()
+                .read_only(true)
+                .destructive(false)
+                .idempotent(true),
+        ),
+        Tool::new(
+            "describe_table",
+            "Get table structure including columns, indexes, and foreign keys",
+            object(json!({
+                "type": "object",
+                "properties": {
+                    "connection_uuid": {
+                        "type": "string",
+                        "description": "UUID of the connected database"
+                    },
+                    "schema": {
+                        "type": "string",
+                        "description": "Schema name (e.g. 'public' for PostgreSQL)"
+                    },
+                    "table": {
+                        "type": "string",
+                        "description": "Table name"
+                    }
+                },
+                "required": ["connection_uuid", "schema", "table"]
+            })),
+        )
+        .with_annotations(
+            ToolAnnotations::new()
+                .read_only(true)
+                .destructive(false)
+                .idempotent(true),
+        ),
+        Tool::new(
+            "get_schema_overview",
+            "Get full schema overview with all tables, columns, indexes, and relationships",
+            object(json!({
+                "type": "object",
+                "properties": {
+                    "connection_uuid": {
+                        "type": "string",
+                        "description": "UUID of the connected database"
+                    }
+                },
+                "required": ["connection_uuid"]
+            })),
+        )
+        .with_annotations(
+            ToolAnnotations::new()
+                .read_only(true)
+                .destructive(false)
+                .idempotent(true),
+        ),
+        Tool::new(
+            "execute_query",
+            "Execute a SQL query against a connected database. Read-only by default (SELECT/WITH/EXPLAIN only).",
+            object(json!({
+                "type": "object",
+                "properties": {
+                    "connection_uuid": {
+                        "type": "string",
+                        "description": "UUID of the connected database"
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "SQL query to execute"
+                    }
+                },
+                "required": ["connection_uuid", "query"]
+            })),
+        ),
+    ]
+}
+
+fn get_str_param<'a>(
+    args: &'a Option<serde_json::Map<String, serde_json::Value>>,
+    key: &str,
+) -> Result<&'a str, McpError> {
+    args.as_ref()
+        .and_then(|m| m.get(key))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            McpError::invalid_params(format!("Missing required parameter: {}", key), None)
+        })
+}
+
+/// Dispatch a tool call to the appropriate handler.
+pub async fn dispatch_tool(
+    server: &McpServer,
+    request: CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    match request.name.as_ref() {
+        "list_connections" => list_connections(server).await,
+        "connect" => {
+            let uuid = get_str_param(&request.arguments, "connection_uuid")?;
+            connect(server, uuid).await
+        }
+        "disconnect" => {
+            let uuid = get_str_param(&request.arguments, "connection_uuid")?;
+            disconnect(server, uuid).await
+        }
+        "list_tables" => {
+            let uuid = get_str_param(&request.arguments, "connection_uuid")?;
+            list_tables(server, uuid).await
+        }
+        "describe_table" => {
+            let uuid = get_str_param(&request.arguments, "connection_uuid")?;
+            let schema = get_str_param(&request.arguments, "schema")?;
+            let table = get_str_param(&request.arguments, "table")?;
+            describe_table(server, uuid, schema, table).await
+        }
+        "get_schema_overview" => {
+            let uuid = get_str_param(&request.arguments, "connection_uuid")?;
+            get_schema_overview(server, uuid).await
+        }
+        "execute_query" => {
+            let uuid = get_str_param(&request.arguments, "connection_uuid")?;
+            let query = get_str_param(&request.arguments, "query")?;
+            execute_query(server, uuid, query).await
+        }
+        _ => Err(McpError::method_not_found::<CallToolRequestMethod>()),
+    }
+}
+
+async fn list_connections(server: &McpServer) -> Result<CallToolResult, McpError> {
+    let connections: Vec<crate::db::models::Connection> =
+        sqlx::query_as("SELECT * FROM connections ORDER BY id DESC")
+            .fetch_all(&server.sqlite_pool)
+            .await
+            .map_err(|e| McpError::internal_error(format!("Database error: {}", e), None))?;
+
+    let safe: Vec<serde_json::Value> = connections
+        .into_iter()
+        .map(|c| {
+            json!({
+                "uuid": c.uuid,
+                "name": c.name,
+                "db_type": c.db_type,
+                "host": c.host,
+                "port": c.port,
+                "database": c.database,
+                "ssl": c.ssl == 1,
+                "ssh_enabled": c.ssh_enabled == 1,
+            })
+        })
+        .collect();
+
+    let text = serde_json::to_string_pretty(&safe).unwrap_or_else(|_| "[]".to_string());
+    Ok(CallToolResult::success(vec![Content::text(text)]))
+}
+
+async fn connect(server: &McpServer, uuid: &str) -> Result<CallToolResult, McpError> {
+    let config = get_connection_config(&server.sqlite_pool, uuid)
+        .await
+        .map_err(|e| McpError::internal_error(e, None))?;
+
+    match server.pool_manager.connect(uuid, config).await {
+        Ok(_) => Ok(CallToolResult::success(vec![Content::text(format!(
+            "Connected to {} successfully.",
+            uuid
+        ))])),
+        Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+            "Failed to connect: {}",
+            e
+        ))])),
+    }
+}
+
+async fn disconnect(server: &McpServer, uuid: &str) -> Result<CallToolResult, McpError> {
+    server.pool_manager.disconnect(uuid).await;
+    Ok(CallToolResult::success(vec![Content::text(format!(
+        "Disconnected from {}.",
+        uuid
+    ))]))
+}
+
+async fn list_tables(server: &McpServer, uuid: &str) -> Result<CallToolResult, McpError> {
+    server.ensure_connected(uuid).await?;
+
+    match server.pool_manager.list_tables(uuid).await {
+        Ok(tables) => {
+            let json =
+                serde_json::to_string_pretty(&tables).unwrap_or_else(|_| "[]".to_string());
+            Ok(CallToolResult::success(vec![Content::text(json)]))
+        }
+        Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+            "Failed to list tables: {}",
+            e
+        ))])),
+    }
+}
+
+async fn describe_table(
+    server: &McpServer,
+    uuid: &str,
+    schema: &str,
+    table: &str,
+) -> Result<CallToolResult, McpError> {
+    server.ensure_connected(uuid).await?;
+
+    match server
+        .pool_manager
+        .get_table_structure(uuid, schema, table)
+        .await
+    {
+        Ok(structure) => {
+            let json =
+                serde_json::to_string_pretty(&structure).unwrap_or_else(|_| "{}".to_string());
+            Ok(CallToolResult::success(vec![Content::text(json)]))
+        }
+        Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+            "Failed to describe table: {}",
+            e
+        ))])),
+    }
+}
+
+async fn get_schema_overview(server: &McpServer, uuid: &str) -> Result<CallToolResult, McpError> {
+    server.ensure_connected(uuid).await?;
+
+    match server.pool_manager.get_schema_overview(uuid).await {
+        Ok(overview) => {
+            let json =
+                serde_json::to_string_pretty(&overview).unwrap_or_else(|_| "{}".to_string());
+            Ok(CallToolResult::success(vec![Content::text(json)]))
+        }
+        Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+            "Failed to get schema overview: {}",
+            e
+        ))])),
+    }
+}
+
+/// Check if a query is read-only (SELECT, WITH, EXPLAIN, SHOW, DESCRIBE only).
+fn is_read_only_query(query: &str) -> bool {
+    let trimmed = query.trim().to_uppercase();
+    let effective = if trimmed.starts_with("--") {
+        trimmed
+            .lines()
+            .find(|l| !l.trim_start().starts_with("--"))
+            .unwrap_or("")
+            .to_string()
+    } else if trimmed.starts_with("/*") {
+        trimmed
+            .find("*/")
+            .map(|i| trimmed[i + 2..].trim().to_string())
+            .unwrap_or_default()
+    } else {
+        trimmed
+    };
+
+    let first_word = effective
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_uppercase();
+
+    matches!(
+        first_word.as_str(),
+        "SELECT" | "WITH" | "EXPLAIN" | "SHOW" | "DESCRIBE" | "DESC" | "PRAGMA"
+    )
+}
+
+async fn execute_query(
+    server: &McpServer,
+    uuid: &str,
+    query: &str,
+) -> Result<CallToolResult, McpError> {
+    if server.read_only && !is_read_only_query(query) {
+        return Ok(CallToolResult::error(vec![Content::text(
+            "Read-only mode: only SELECT, WITH, EXPLAIN, SHOW, and DESCRIBE queries are allowed.",
+        )]));
+    }
+
+    server.ensure_connected(uuid).await?;
+
+    match server.pool_manager.execute_query(uuid, query).await {
+        Ok(mut result) => {
+            let truncated = result.data.len() > MAX_ROWS;
+            if truncated {
+                result.data.truncate(MAX_ROWS);
+            }
+
+            let mut output =
+                serde_json::to_string_pretty(&result).unwrap_or_else(|_| "{}".to_string());
+
+            if truncated {
+                output.push_str(&format!("\n\n(Results truncated to {} rows)", MAX_ROWS));
+            }
+
+            Ok(CallToolResult::success(vec![Content::text(output)]))
+        }
+        Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+            "Query failed: {}",
+            e
+        ))])),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_only_detection() {
+        assert!(is_read_only_query("SELECT * FROM users"));
+        assert!(is_read_only_query("  select * from users"));
+        assert!(is_read_only_query(
+            "WITH cte AS (SELECT 1) SELECT * FROM cte"
+        ));
+        assert!(is_read_only_query("EXPLAIN SELECT * FROM users"));
+        assert!(is_read_only_query("SHOW tables"));
+        assert!(is_read_only_query("DESCRIBE users"));
+        assert!(is_read_only_query("PRAGMA table_info(users)"));
+
+        assert!(!is_read_only_query("INSERT INTO users VALUES (1)"));
+        assert!(!is_read_only_query("UPDATE users SET name = 'x'"));
+        assert!(!is_read_only_query("DELETE FROM users"));
+        assert!(!is_read_only_query("DROP TABLE users"));
+        assert!(!is_read_only_query("ALTER TABLE users ADD col INT"));
+        assert!(!is_read_only_query("CREATE TABLE t (id INT)"));
+    }
+}

--- a/src-tauri/src/mcp/tools.rs
+++ b/src-tauri/src/mcp/tools.rs
@@ -300,8 +300,8 @@ async fn get_schema_overview(server: &McpServer, uuid: &str) -> Result<CallToolR
     }
 }
 
-/// Check if a query is read-only (SELECT, WITH, EXPLAIN, SHOW, DESCRIBE only).
-fn is_read_only_query(query: &str) -> bool {
+/// Check if a SQL query is read-only (SELECT, WITH, EXPLAIN, SHOW, DESCRIBE only).
+fn is_read_only_sql_query(query: &str) -> bool {
     let trimmed = query.trim().to_uppercase();
     let effective = if trimmed.starts_with("--") {
         trimmed
@@ -330,15 +330,82 @@ fn is_read_only_query(query: &str) -> bool {
     )
 }
 
+/// Check if a Redis command is read-only.
+fn is_read_only_redis_command(query: &str) -> bool {
+    let command = query
+        .trim()
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_uppercase();
+
+    matches!(
+        command.as_str(),
+        // String commands
+        "GET" | "MGET" | "STRLEN" | "GETRANGE" | "SUBSTR"
+        // Key commands
+        | "EXISTS" | "TYPE" | "TTL" | "PTTL" | "KEYS" | "SCAN"
+        | "RANDOMKEY" | "DUMP" | "OBJECT" | "TOUCH"
+        // List commands
+        | "LLEN" | "LRANGE" | "LINDEX" | "LPOS"
+        // Hash commands
+        | "HGET" | "HGETALL" | "HKEYS" | "HVALS" | "HLEN"
+        | "HEXISTS" | "HMGET" | "HSCAN" | "HRANDFIELD"
+        // Set commands
+        | "SCARD" | "SISMEMBER" | "SMISMEMBER" | "SMEMBERS"
+        | "SRANDMEMBER" | "SSCAN" | "SINTER" | "SUNION" | "SDIFF"
+        | "SINTERCARD"
+        // Sorted set commands
+        | "ZCARD" | "ZCOUNT" | "ZRANGE" | "ZRANGEBYSCORE"
+        | "ZREVRANGE" | "ZREVRANGEBYSCORE" | "ZRANK" | "ZREVRANK"
+        | "ZSCORE" | "ZMSCORE" | "ZSCAN" | "ZRANGEBYLEX"
+        | "ZREVRANGEBYLEX" | "ZLEXCOUNT" | "ZRANDMEMBER"
+        // Server / connection commands
+        | "DBSIZE" | "INFO" | "PING" | "ECHO" | "TIME" | "CLIENT"
+        // Stream commands
+        | "XLEN" | "XRANGE" | "XREVRANGE" | "XINFO" | "XREAD" | "XPENDING"
+        // HyperLogLog
+        | "PFCOUNT"
+        // Geo commands
+        | "GEOSEARCH" | "GEOPOS" | "GEODIST" | "GEOHASH"
+        | "GEORADIUS_RO" | "GEORADIUSBYMEMBER_RO"
+        // Memory
+        | "MEMORY"
+        // Misc
+        | "WAIT"
+    )
+}
+
+/// Check if a query/command is read-only for the given database type.
+fn is_read_only(db_type: &str, query: &str) -> bool {
+    match db_type.to_lowercase().as_str() {
+        "redis" => is_read_only_redis_command(query),
+        _ => is_read_only_sql_query(query),
+    }
+}
+
 async fn execute_query(
     server: &McpServer,
     uuid: &str,
     query: &str,
 ) -> Result<CallToolResult, McpError> {
-    if server.read_only && !is_read_only_query(query) {
-        return Ok(CallToolResult::error(vec![Content::text(
-            "Read-only mode: only SELECT, WITH, EXPLAIN, SHOW, and DESCRIBE queries are allowed.",
-        )]));
+    if server.read_only {
+        let db_type = if let Some(config) = server.pool_manager.get_config(uuid).await {
+            config.db_type
+        } else {
+            get_connection_config(&server.sqlite_pool, uuid)
+                .await
+                .map(|c| c.db_type)
+                .unwrap_or_default()
+        };
+
+        if !is_read_only(&db_type, query) {
+            let msg = match db_type.to_lowercase().as_str() {
+                "redis" => "Read-only mode: only read commands (GET, KEYS, LLEN, INFO, SCAN, etc.) are allowed. Write commands like SET, DEL, FLUSHDB are blocked.",
+                _ => "Read-only mode: only SELECT, WITH, EXPLAIN, SHOW, and DESCRIBE queries are allowed.",
+            };
+            return Ok(CallToolResult::error(vec![Content::text(msg)]));
+        }
     }
 
     server.ensure_connected(uuid).await?;
@@ -371,22 +438,79 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_read_only_detection() {
-        assert!(is_read_only_query("SELECT * FROM users"));
-        assert!(is_read_only_query("  select * from users"));
-        assert!(is_read_only_query(
+    fn test_read_only_sql_detection() {
+        assert!(is_read_only_sql_query("SELECT * FROM users"));
+        assert!(is_read_only_sql_query("  select * from users"));
+        assert!(is_read_only_sql_query(
             "WITH cte AS (SELECT 1) SELECT * FROM cte"
         ));
-        assert!(is_read_only_query("EXPLAIN SELECT * FROM users"));
-        assert!(is_read_only_query("SHOW tables"));
-        assert!(is_read_only_query("DESCRIBE users"));
-        assert!(is_read_only_query("PRAGMA table_info(users)"));
+        assert!(is_read_only_sql_query("EXPLAIN SELECT * FROM users"));
+        assert!(is_read_only_sql_query("SHOW tables"));
+        assert!(is_read_only_sql_query("DESCRIBE users"));
+        assert!(is_read_only_sql_query("PRAGMA table_info(users)"));
 
-        assert!(!is_read_only_query("INSERT INTO users VALUES (1)"));
-        assert!(!is_read_only_query("UPDATE users SET name = 'x'"));
-        assert!(!is_read_only_query("DELETE FROM users"));
-        assert!(!is_read_only_query("DROP TABLE users"));
-        assert!(!is_read_only_query("ALTER TABLE users ADD col INT"));
-        assert!(!is_read_only_query("CREATE TABLE t (id INT)"));
+        assert!(!is_read_only_sql_query("INSERT INTO users VALUES (1)"));
+        assert!(!is_read_only_sql_query("UPDATE users SET name = 'x'"));
+        assert!(!is_read_only_sql_query("DELETE FROM users"));
+        assert!(!is_read_only_sql_query("DROP TABLE users"));
+        assert!(!is_read_only_sql_query("ALTER TABLE users ADD col INT"));
+        assert!(!is_read_only_sql_query("CREATE TABLE t (id INT)"));
+    }
+
+    #[test]
+    fn test_read_only_redis_detection() {
+        // Read-only commands should be allowed
+        assert!(is_read_only_redis_command("GET mykey"));
+        assert!(is_read_only_redis_command("  get mykey"));
+        assert!(is_read_only_redis_command("MGET key1 key2"));
+        assert!(is_read_only_redis_command("KEYS *"));
+        assert!(is_read_only_redis_command("KEYS *harmony*"));
+        assert!(is_read_only_redis_command("SCAN 0 MATCH * COUNT 100"));
+        assert!(is_read_only_redis_command("LLEN queues:high"));
+        assert!(is_read_only_redis_command("LRANGE mylist 0 -1"));
+        assert!(is_read_only_redis_command("HGETALL myhash"));
+        assert!(is_read_only_redis_command("SMEMBERS myset"));
+        assert!(is_read_only_redis_command("ZRANGE myzset 0 -1"));
+        assert!(is_read_only_redis_command("INFO"));
+        assert!(is_read_only_redis_command("INFO server"));
+        assert!(is_read_only_redis_command("DBSIZE"));
+        assert!(is_read_only_redis_command("TTL mykey"));
+        assert!(is_read_only_redis_command("TYPE mykey"));
+        assert!(is_read_only_redis_command("EXISTS mykey"));
+        assert!(is_read_only_redis_command("PING"));
+        assert!(is_read_only_redis_command("XLEN mystream"));
+
+        // Write commands should be blocked
+        assert!(!is_read_only_redis_command("SET mykey value"));
+        assert!(!is_read_only_redis_command("DEL mykey"));
+        assert!(!is_read_only_redis_command("FLUSHDB"));
+        assert!(!is_read_only_redis_command("FLUSHALL"));
+        assert!(!is_read_only_redis_command("LPUSH mylist value"));
+        assert!(!is_read_only_redis_command("RPUSH mylist value"));
+        assert!(!is_read_only_redis_command("HSET myhash field value"));
+        assert!(!is_read_only_redis_command("SADD myset member"));
+        assert!(!is_read_only_redis_command("ZADD myzset 1 member"));
+        assert!(!is_read_only_redis_command("EXPIRE mykey 100"));
+        assert!(!is_read_only_redis_command("RENAME key1 key2"));
+        assert!(!is_read_only_redis_command("MSET key1 v1 key2 v2"));
+        assert!(!is_read_only_redis_command("INCR counter"));
+        assert!(!is_read_only_redis_command("DECR counter"));
+    }
+
+    #[test]
+    fn test_is_read_only_dispatches_by_db_type() {
+        // SQL types use SQL validation
+        assert!(is_read_only("postgres", "SELECT * FROM users"));
+        assert!(!is_read_only("postgres", "LLEN mylist"));
+        assert!(is_read_only("postgresql", "SELECT 1"));
+        assert!(is_read_only("sqlite", "SELECT 1"));
+        assert!(is_read_only("clickhouse", "SHOW TABLES"));
+
+        // Redis uses Redis validation
+        assert!(is_read_only("redis", "LLEN queues:high"));
+        assert!(is_read_only("redis", "GET mykey"));
+        assert!(is_read_only("redis", "KEYS *"));
+        assert!(!is_read_only("redis", "SET mykey value"));
+        assert!(!is_read_only("redis", "DEL mykey"));
     }
 }


### PR DESCRIPTION
# Summary
- Embeds an MCP server directly into the Tauri app using HTTP/SSE transport (Streamable HTTP), eliminating the need for a separate sidecar binary
- The MCP server starts automatically on app launch, binding to `127.0.0.1:9420` with auto-increment on port conflicts (up to 9429)
- Exposes database connections, schema introspection, and query execution via the Model Context Protocol (7 tools, 2 resource types)
- Extracts shared `get_connection_config` helper into `src-tauri/src/database/utils.rs` for reuse between the app and MCP server
- Adds `rmcp`, `axum`, and `tokio-util` dependencies
- Read-only mode enabled by default (only SELECT/WITH/EXPLAIN/SHOW/DESCRIBE queries allowed)

# Test plan

- [x] Run `bun run tauri dev` and confirm the app starts with “MCP server listening on http://127.0.0.1:9420/mcp”
- [x] Test MCP endpoint with curl: 
`curl -X POST http://127.0.0.1:9420/mcp -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"initialize","params":{"capabilities":{}},"id":1}'`
- [x] Configure an MCP client (e.g., Claude Desktop) with `"url": "http://127.0.0.1:9420/mcp"` and test tool calls
- [x] Test MCP tools (connect, list_tables, describe_table, execute_query, etc.) via an MCP client
- [x] Test MCP resources (schema overview, connection listing)
- [x] Verify existing app functionality is unaffected