### PR TITLE
Bump Tauri app version

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- bump the Tauri app version in `src-tauri/tauri.conf.json`
- update the packaged app version from `0.0.51` to `0.0.52`

## Why
A new app release/version bump was requested in the Tauri config.

## Impact
New builds produced from this branch will report version `0.0.52` in the Tauri application metadata.

## Validation
- inspected the config diff to confirm the change is limited to `src-tauri/tauri.conf.json`