### PR TITLE
Prepare v0.0.53 DB update fixes

### DIFF
--- a/src-tauri/src/commands/postgres.rs
+++ b/src-tauri/src/commands/postgres.rs
@@ -1,3 +1,4 @@
+use crate::database::query_returns_rows;
 use crate::db::models::{
     ColumnInfo, ForeignKeyInfo, IndexInfo, QueryResult, TableDataResponse, TableInfo,
     TableStructure, TestConnectionResult,
@@ -475,6 +476,32 @@ pub async fn execute_query(
         .await
         .map_err(|e| e.to_string())?;
 
+    if !query_returns_rows(&query) {
+        return match sqlx::query(&query).execute(&pool).await {
+            Ok(result) => {
+                pool.close().await;
+                let rows_affected = result.rows_affected();
+                Ok(QueryResult {
+                    data: vec![],
+                    row_count: rows_affected as i64,
+                    rows_affected: Some(rows_affected),
+                    error: None,
+                    time_taken_ms: Some(start_time.elapsed().as_millis()),
+                })
+            }
+            Err(e) => {
+                pool.close().await;
+                Ok(QueryResult {
+                    data: vec![],
+                    row_count: 0,
+                    rows_affected: None,
+                    error: Some(e.to_string()),
+                    time_taken_ms: Some(start_time.elapsed().as_millis()),
+                })
+            }
+        };
+    }
+
     match sqlx::query(&query).fetch_all(&pool).await {
         Ok(rows) => {
             pool.close().await;
@@ -555,6 +582,7 @@ pub async fn execute_query(
             Ok(QueryResult {
                 data,
                 row_count,
+                rows_affected: None,
                 error: None,
                 time_taken_ms: Some(start_time.elapsed().as_millis()),
             })
@@ -564,6 +592,7 @@ pub async fn execute_query(
             Ok(QueryResult {
                 data: vec![],
                 row_count: 0,
+                rows_affected: None,
                 error: Some(e.to_string()),
                 time_taken_ms: Some(start_time.elapsed().as_millis()),
             })

--- a/src-tauri/src/database/clickhouse.rs
+++ b/src-tauri/src/database/clickhouse.rs
@@ -514,6 +514,7 @@ impl DatabaseDriver for ClickhouseDriver {
                     Ok(QueryResult {
                         data: rows,
                         row_count,
+                        rows_affected: None,
                         error: None,
                         time_taken_ms: Some(start_time.elapsed().as_millis()),
                     })
@@ -521,6 +522,7 @@ impl DatabaseDriver for ClickhouseDriver {
                 Err(e) => Ok(QueryResult {
                     data: vec![],
                     row_count: 0,
+                    rows_affected: None,
                     error: Some(e),
                     time_taken_ms: Some(start_time.elapsed().as_millis()),
                 }),
@@ -531,12 +533,14 @@ impl DatabaseDriver for ClickhouseDriver {
                 Ok(_) => Ok(QueryResult {
                     data: vec![json!({"result": "Query executed successfully"})],
                     row_count: 0,
+                    rows_affected: Some(0),
                     error: None,
                     time_taken_ms: Some(start_time.elapsed().as_millis()),
                 }),
                 Err(e) => Ok(QueryResult {
                     data: vec![],
                     row_count: 0,
+                    rows_affected: None,
                     error: Some(e),
                     time_taken_ms: Some(start_time.elapsed().as_millis()),
                 }),

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -12,6 +12,153 @@ use crate::db::models::{
     TestConnectionResult,
 };
 
+fn is_identifier_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || ch == '_'
+}
+
+fn starts_with_keyword(sql: &str, keyword: &str) -> bool {
+    sql.get(..keyword.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(keyword))
+        && sql[keyword.len()..]
+            .chars()
+            .next()
+            .map_or(true, |ch| !is_identifier_char(ch))
+}
+
+fn strip_leading_sql_comments(mut sql: &str) -> &str {
+    loop {
+        sql = sql.trim_start();
+
+        if let Some(rest) = sql.strip_prefix("--") {
+            if let Some(newline_index) = rest.find('\n') {
+                sql = &rest[newline_index + 1..];
+                continue;
+            }
+            return "";
+        }
+
+        if let Some(rest) = sql.strip_prefix("/*") {
+            if let Some(end_index) = rest.find("*/") {
+                sql = &rest[end_index + 2..];
+                continue;
+            }
+            return "";
+        }
+
+        return sql;
+    }
+}
+
+fn contains_keyword_outside_literals(sql: &str, keyword: &str) -> bool {
+    let mut chars = sql.char_indices().peekable();
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
+
+    while let Some((index, ch)) = chars.next() {
+        let next = chars.peek().map(|(_, next_ch)| *next_ch);
+
+        if in_line_comment {
+            if ch == '\n' {
+                in_line_comment = false;
+            }
+            continue;
+        }
+
+        if in_block_comment {
+            if ch == '*' && next == Some('/') {
+                chars.next();
+                in_block_comment = false;
+            }
+            continue;
+        }
+
+        if in_single_quote {
+            if ch == '\'' {
+                if next == Some('\'') {
+                    chars.next();
+                } else {
+                    in_single_quote = false;
+                }
+            }
+            continue;
+        }
+
+        if in_double_quote {
+            if ch == '"' {
+                if next == Some('"') {
+                    chars.next();
+                } else {
+                    in_double_quote = false;
+                }
+            }
+            continue;
+        }
+
+        if ch == '-' && next == Some('-') {
+            chars.next();
+            in_line_comment = true;
+            continue;
+        }
+
+        if ch == '/' && next == Some('*') {
+            chars.next();
+            in_block_comment = true;
+            continue;
+        }
+
+        if ch == '\'' {
+            in_single_quote = true;
+            continue;
+        }
+
+        if ch == '"' {
+            in_double_quote = true;
+            continue;
+        }
+
+        let end = index + keyword.len();
+        if sql
+            .get(index..end)
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(keyword))
+        {
+            let prev_is_boundary = sql[..index]
+                .chars()
+                .next_back()
+                .map_or(true, |prev| !is_identifier_char(prev));
+            let next_is_boundary = sql[end..]
+                .chars()
+                .next()
+                .map_or(true, |next_ch| !is_identifier_char(next_ch));
+
+            if prev_is_boundary && next_is_boundary {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+pub fn query_returns_rows(query: &str) -> bool {
+    let sql = strip_leading_sql_comments(query);
+
+    if [
+        "SELECT", "WITH", "VALUES", "SHOW", "DESCRIBE", "PRAGMA", "EXPLAIN",
+    ]
+    .iter()
+    .any(|keyword| starts_with_keyword(sql, keyword))
+    {
+        return true;
+    }
+
+    ["INSERT", "UPDATE", "DELETE", "MERGE"]
+        .iter()
+        .any(|keyword| starts_with_keyword(sql, keyword))
+        && contains_keyword_outside_literals(sql, "RETURNING")
+}
+
 /// Common trait for all database drivers
 #[async_trait]
 pub trait DatabaseDriver: Send + Sync {

--- a/src-tauri/src/database/postgres.rs
+++ b/src-tauri/src/database/postgres.rs
@@ -5,7 +5,7 @@ use sqlx::{Column, Row, TypeInfo};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use super::{DatabaseDriver, PostgresConfig};
+use super::{query_returns_rows, DatabaseDriver, PostgresConfig};
 use crate::database::queries::postgres::{
     FUNCTION_DEFINITION_QUERY, FUNCTION_SUMMARIES_QUERY, SCHEMA_OVERVIEW_QUERY,
 };
@@ -93,6 +93,34 @@ impl PostgresDriver {
         Ok(())
     }
 
+    async fn query_error_result(
+        &self,
+        error: sqlx::Error,
+        start_time: std::time::Instant,
+    ) -> Result<QueryResult, String> {
+        let error_str = error.to_string();
+        let should_reset = error_str.contains("Connection reset by peer")
+            || error_str.contains("broken pipe")
+            || error_str.contains("connection closed")
+            || error_str.contains("server closed the connection");
+
+        if should_reset {
+            println!(
+                "[Postgres] Connection error detected, resetting pool: {}",
+                error_str
+            );
+            let _ = self.reset_pool().await;
+        }
+
+        Ok(QueryResult {
+            data: vec![],
+            row_count: 0,
+            rows_affected: None,
+            error: Some(error_str),
+            time_taken_ms: Some(start_time.elapsed().as_millis()),
+        })
+    }
+
     async fn get_pool_with_retry(&self) -> Result<sqlx::PgPool, String> {
         match self.get_pool().await {
             Ok(pool) => Ok(pool),
@@ -102,6 +130,34 @@ impl PostgresDriver {
                 self.get_pool().await
             }
         }
+    }
+
+    async fn get_primary_key_columns(
+        pool: &sqlx::PgPool,
+        schema: &str,
+        table: &str,
+    ) -> Result<Vec<String>, String> {
+        let rows = sqlx::query_as::<_, (String,)>(
+            r#"
+            SELECT kcu.column_name
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+              ON tc.constraint_name = kcu.constraint_name
+             AND tc.table_schema = kcu.table_schema
+             AND tc.table_name = kcu.table_name
+            WHERE tc.constraint_type = 'PRIMARY KEY'
+              AND tc.table_schema = $1
+              AND tc.table_name = $2
+            ORDER BY kcu.ordinal_position
+            "#,
+        )
+        .bind(schema)
+        .bind(table)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| e.to_string())?;
+
+        Ok(rows.into_iter().map(|(column,)| column).collect())
     }
 
     fn row_to_json(row: &sqlx::postgres::PgRow) -> Value {
@@ -269,24 +325,33 @@ impl DatabaseDriver for PostgresDriver {
             })
             .unwrap_or_default();
 
-        let order_clause = sort_column
-            .as_ref()
-            .map(|col| {
-                // Validate sort_direction to prevent SQL injection
-                let dir = match sort_direction
-                    .as_deref()
-                    .map(|s| s.to_lowercase())
-                    .as_deref()
-                {
-                    Some("asc") => "ASC",
-                    Some("desc") => "DESC",
-                    _ => "ASC", // Default to ASC for invalid/missing values
-                };
-                // Escape double quotes in column name to prevent SQL injection
-                let escaped_col = col.replace('"', "\"\"");
-                format!(" ORDER BY \"{}\" {}", escaped_col, dir)
-            })
-            .unwrap_or_default();
+        let order_clause = if let Some(col) = sort_column.as_ref() {
+            // Validate sort_direction to prevent SQL injection
+            let dir = match sort_direction
+                .as_deref()
+                .map(|s| s.to_lowercase())
+                .as_deref()
+            {
+                Some("asc") => "ASC",
+                Some("desc") => "DESC",
+                _ => "ASC", // Default to ASC for invalid/missing values
+            };
+            // Escape double quotes in column name to prevent SQL injection
+            let escaped_col = col.replace('"', "\"\"");
+            format!(" ORDER BY \"{}\" {}", escaped_col, dir)
+        } else {
+            let primary_key_columns = Self::get_primary_key_columns(&pool, schema, table).await?;
+            if primary_key_columns.is_empty() {
+                String::new()
+            } else {
+                let order_columns = primary_key_columns
+                    .iter()
+                    .map(|col| format!("\"{}\" ASC", col.replace('"', "\"\"")))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(" ORDER BY {}", order_columns)
+            }
+        };
 
         let count_query = format!(
             "SELECT COUNT(*) as count FROM {}{}",
@@ -483,38 +548,34 @@ impl DatabaseDriver for PostgresDriver {
         let start_time = std::time::Instant::now();
         let pool = self.get_pool_with_retry().await?;
 
-        match sqlx::query(query).fetch_all(&pool).await {
-            Ok(rows) => {
-                let data: Vec<Value> = rows.iter().map(Self::row_to_json).collect();
-                let row_count = data.len() as i64;
-                Ok(QueryResult {
-                    data,
-                    row_count,
-                    error: None,
-                    time_taken_ms: Some(start_time.elapsed().as_millis()),
-                })
-            }
-            Err(e) => {
-                let error_str = e.to_string();
-                let should_reset = error_str.contains("Connection reset by peer")
-                    || error_str.contains("broken pipe")
-                    || error_str.contains("connection closed")
-                    || error_str.contains("server closed the connection");
-
-                if should_reset {
-                    println!(
-                        "[Postgres] Connection error detected, resetting pool: {}",
-                        error_str
-                    );
-                    let _ = self.reset_pool().await;
+        if query_returns_rows(query) {
+            match sqlx::query(query).fetch_all(&pool).await {
+                Ok(rows) => {
+                    let data: Vec<Value> = rows.iter().map(Self::row_to_json).collect();
+                    let row_count = data.len() as i64;
+                    Ok(QueryResult {
+                        data,
+                        row_count,
+                        rows_affected: None,
+                        error: None,
+                        time_taken_ms: Some(start_time.elapsed().as_millis()),
+                    })
                 }
-
-                Ok(QueryResult {
-                    data: vec![],
-                    row_count: 0,
-                    error: Some(error_str),
-                    time_taken_ms: Some(start_time.elapsed().as_millis()),
-                })
+                Err(e) => self.query_error_result(e, start_time).await,
+            }
+        } else {
+            match sqlx::query(query).execute(&pool).await {
+                Ok(result) => {
+                    let rows_affected = result.rows_affected();
+                    Ok(QueryResult {
+                        data: vec![],
+                        row_count: rows_affected as i64,
+                        rows_affected: Some(rows_affected),
+                        error: None,
+                        time_taken_ms: Some(start_time.elapsed().as_millis()),
+                    })
+                }
+                Err(e) => self.query_error_result(e, start_time).await,
             }
         }
     }

--- a/src-tauri/src/database/redis.rs
+++ b/src-tauri/src/database/redis.rs
@@ -412,6 +412,7 @@ impl DatabaseDriver for RedisDriver {
                     return Ok(QueryResult {
                         data: vec![json!({"info": info})],
                         row_count: 1,
+                        rows_affected: None,
                         error: None,
                         time_taken_ms: Some(start_time.elapsed().as_millis()),
                     });
@@ -421,6 +422,7 @@ impl DatabaseDriver for RedisDriver {
                     return Ok(QueryResult {
                         data: vec![],
                         row_count: 0,
+                        rows_affected: None,
                         error: Some(error_msg),
                         time_taken_ms: Some(start_time.elapsed().as_millis()),
                     });
@@ -434,6 +436,7 @@ impl DatabaseDriver for RedisDriver {
             return Ok(QueryResult {
                 data: vec![],
                 row_count: 0,
+                rows_affected: None,
                 error: Some("Empty query".to_string()),
                 time_taken_ms: Some(start_time.elapsed().as_millis()),
             });
@@ -450,6 +453,7 @@ impl DatabaseDriver for RedisDriver {
                 Ok(QueryResult {
                     data: vec![json_value],
                     row_count: 1,
+                    rows_affected: None,
                     error: None,
                     time_taken_ms: Some(start_time.elapsed().as_millis()),
                 })
@@ -459,6 +463,7 @@ impl DatabaseDriver for RedisDriver {
                 Ok(QueryResult {
                     data: vec![],
                     row_count: 0,
+                    rows_affected: None,
                     error: Some(error_msg),
                     time_taken_ms: Some(start_time.elapsed().as_millis()),
                 })

--- a/src-tauri/src/database/sqlite.rs
+++ b/src-tauri/src/database/sqlite.rs
@@ -3,7 +3,7 @@ use serde_json::{json, Value};
 use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::{Column, Row, TypeInfo};
 
-use super::{DatabaseDriver, SqliteConfig};
+use super::{query_returns_rows, DatabaseDriver, SqliteConfig};
 use crate::database::queries::sqlite::{
     COLUMNS_QUERY, FOREIGN_KEYS_QUERY, INDEXES_QUERY, TABLES_QUERY,
 };
@@ -33,6 +33,21 @@ impl SqliteDriver {
             .connect(&conn_str)
             .await
             .map_err(|e| e.to_string())
+    }
+
+    async fn get_primary_key_columns(
+        pool: &sqlx::SqlitePool,
+        table: &str,
+    ) -> Result<Vec<String>, String> {
+        let rows = sqlx::query_as::<_, (String,)>(
+            "SELECT name FROM pragma_table_info(?) WHERE pk > 0 ORDER BY pk",
+        )
+        .bind(table)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| e.to_string())?;
+
+        Ok(rows.into_iter().map(|(column,)| column).collect())
     }
 
     fn row_to_json(row: &sqlx::sqlite::SqliteRow) -> Value {
@@ -185,24 +200,33 @@ impl DatabaseDriver for SqliteDriver {
             })
             .unwrap_or_default();
 
-        let order_clause = sort_column
-            .as_ref()
-            .map(|col| {
-                // Validate sort_direction to prevent SQL injection
-                let dir = match sort_direction
-                    .as_deref()
-                    .map(|s| s.to_lowercase())
-                    .as_deref()
-                {
-                    Some("asc") => "ASC",
-                    Some("desc") => "DESC",
-                    _ => "ASC", // Default to ASC for invalid/missing values
-                };
-                // Escape double quotes in column name to prevent SQL injection
-                let escaped_col = col.replace('"', "\"\"");
-                format!(" ORDER BY \"{}\" {}", escaped_col, dir)
-            })
-            .unwrap_or_default();
+        let order_clause = if let Some(col) = sort_column.as_ref() {
+            // Validate sort_direction to prevent SQL injection
+            let dir = match sort_direction
+                .as_deref()
+                .map(|s| s.to_lowercase())
+                .as_deref()
+            {
+                Some("asc") => "ASC",
+                Some("desc") => "DESC",
+                _ => "ASC", // Default to ASC for invalid/missing values
+            };
+            // Escape double quotes in column name to prevent SQL injection
+            let escaped_col = col.replace('"', "\"\"");
+            format!(" ORDER BY \"{}\" {}", escaped_col, dir)
+        } else {
+            let primary_key_columns = Self::get_primary_key_columns(&pool, table).await?;
+            if primary_key_columns.is_empty() {
+                String::new()
+            } else {
+                let order_columns = primary_key_columns
+                    .iter()
+                    .map(|col| format!("\"{}\" ASC", col.replace('"', "\"\"")))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(" ORDER BY {}", order_columns)
+            }
+        };
 
         let count_query = format!(
             "SELECT COUNT(*) as count FROM \"{}\"{}",
@@ -342,26 +366,54 @@ impl DatabaseDriver for SqliteDriver {
         let start_time = std::time::Instant::now();
         let pool = self.get_pool().await?;
 
-        match sqlx::query(query).fetch_all(&pool).await {
-            Ok(rows) => {
-                pool.close().await;
-                let data: Vec<Value> = rows.iter().map(Self::row_to_json).collect();
-                let row_count = data.len() as i64;
-                Ok(QueryResult {
-                    data,
-                    row_count,
-                    error: None,
-                    time_taken_ms: Some(start_time.elapsed().as_millis()),
-                })
+        if query_returns_rows(query) {
+            match sqlx::query(query).fetch_all(&pool).await {
+                Ok(rows) => {
+                    pool.close().await;
+                    let data: Vec<Value> = rows.iter().map(Self::row_to_json).collect();
+                    let row_count = data.len() as i64;
+                    Ok(QueryResult {
+                        data,
+                        row_count,
+                        rows_affected: None,
+                        error: None,
+                        time_taken_ms: Some(start_time.elapsed().as_millis()),
+                    })
+                }
+                Err(e) => {
+                    pool.close().await;
+                    Ok(QueryResult {
+                        data: vec![],
+                        row_count: 0,
+                        rows_affected: None,
+                        error: Some(e.to_string()),
+                        time_taken_ms: Some(start_time.elapsed().as_millis()),
+                    })
+                }
             }
-            Err(e) => {
-                pool.close().await;
-                Ok(QueryResult {
-                    data: vec![],
-                    row_count: 0,
-                    error: Some(e.to_string()),
-                    time_taken_ms: Some(start_time.elapsed().as_millis()),
-                })
+        } else {
+            match sqlx::query(query).execute(&pool).await {
+                Ok(result) => {
+                    pool.close().await;
+                    let rows_affected = result.rows_affected();
+                    Ok(QueryResult {
+                        data: vec![],
+                        row_count: rows_affected as i64,
+                        rows_affected: Some(rows_affected),
+                        error: None,
+                        time_taken_ms: Some(start_time.elapsed().as_millis()),
+                    })
+                }
+                Err(e) => {
+                    pool.close().await;
+                    Ok(QueryResult {
+                        data: vec![],
+                        row_count: 0,
+                        rows_affected: None,
+                        error: Some(e.to_string()),
+                        time_taken_ms: Some(start_time.elapsed().as_millis()),
+                    })
+                }
             }
         }
     }

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -137,6 +137,8 @@ pub struct QueryResult {
     pub data: Vec<serde_json::Value>,
     pub row_count: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub rows_affected: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_taken_ms: Option<u128>,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-tauri/tests/postgres_integration_tests.rs
+++ b/src-tauri/tests/postgres_integration_tests.rs
@@ -245,6 +245,65 @@ async fn test_get_table_data_with_rows() {
 }
 
 #[tokio::test]
+async fn test_get_table_data_defaults_to_primary_key_order() {
+    let driver = create_test_driver();
+    let table_name = test_table_name("pk_order");
+
+    driver
+        .execute_query(&format!(
+            "CREATE TABLE \"{}\" (code TEXT PRIMARY KEY, name TEXT)",
+            table_name
+        ))
+        .await
+        .unwrap();
+
+    driver
+        .execute_query(&format!(
+            "INSERT INTO \"{}\" (code, name) VALUES ('c', 'Charlie'), ('a', 'Alice'), ('b', 'Bob')",
+            table_name
+        ))
+        .await
+        .unwrap();
+
+    let data = driver
+        .get_table_data("public", &table_name, 1, 10, None, None, None)
+        .await
+        .unwrap();
+
+    let codes: Vec<String> = data
+        .data
+        .iter()
+        .map(|row| row.get("code").unwrap().as_str().unwrap().to_string())
+        .collect();
+
+    assert_eq!(codes, vec!["a", "b", "c"]);
+
+    let sorted_data = driver
+        .get_table_data(
+            "public",
+            &table_name,
+            1,
+            10,
+            None,
+            Some("name".to_string()),
+            Some("desc".to_string()),
+        )
+        .await
+        .unwrap();
+
+    let names: Vec<String> = sorted_data
+        .data
+        .iter()
+        .map(|row| row.get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+
+    assert_eq!(names, vec!["Charlie", "Bob", "Alice"]);
+
+    // Cleanup
+    drop_table(&driver, &table_name).await;
+}
+
+#[tokio::test]
 async fn test_get_table_data_pagination() {
     let driver = create_test_driver();
     let table_name = test_table_name("page");
@@ -598,6 +657,44 @@ async fn test_execute_query_update() {
         .unwrap();
     let age = select_result.data[0].get("age").unwrap().as_i64().unwrap();
     assert_eq!(age, 30);
+
+    // Cleanup
+    drop_table(&driver, &table_name).await;
+}
+
+#[tokio::test]
+async fn test_execute_query_update_reports_rows_affected() {
+    let driver = create_test_driver();
+    let table_name = test_table_name("affected");
+
+    driver
+        .execute_query(&format!(
+            "CREATE TABLE \"{}\" (id SERIAL PRIMARY KEY, name TEXT, age INTEGER)",
+            table_name
+        ))
+        .await
+        .unwrap();
+
+    driver
+        .execute_query(&format!(
+            "INSERT INTO \"{}\" (name, age) VALUES ('Test', 25)",
+            table_name
+        ))
+        .await
+        .unwrap();
+
+    let result = driver
+        .execute_query(&format!(
+            "UPDATE \"{}\" SET age = 30 WHERE name = 'Test'",
+            table_name
+        ))
+        .await;
+    assert!(result.is_ok());
+
+    let query_result = result.unwrap();
+    assert!(query_result.error.is_none(), "UPDATE should succeed");
+    assert_eq!(query_result.row_count, 1);
+    assert_eq!(query_result.rows_affected, Some(1));
 
     // Cleanup
     drop_table(&driver, &table_name).await;

--- a/src-tauri/tests/sqlite_integration_tests.rs
+++ b/src-tauri/tests/sqlite_integration_tests.rs
@@ -232,6 +232,58 @@ async fn test_get_table_data_with_rows() {
 }
 
 #[tokio::test]
+async fn test_get_table_data_defaults_to_primary_key_order() {
+    let temp_dir = tempdir().expect("Failed to create temp directory");
+    let (driver, _) = create_test_driver(&temp_dir);
+
+    driver
+        .execute_query("CREATE TABLE keyed_users (code TEXT PRIMARY KEY, name TEXT)")
+        .await
+        .unwrap();
+
+    driver
+        .execute_query(
+            "INSERT INTO keyed_users (code, name) VALUES ('c', 'Charlie'), ('a', 'Alice'), ('b', 'Bob')",
+        )
+        .await
+        .unwrap();
+
+    let data = driver
+        .get_table_data("main", "keyed_users", 1, 10, None, None, None)
+        .await
+        .unwrap();
+
+    let codes: Vec<String> = data
+        .data
+        .iter()
+        .map(|row| row.get("code").unwrap().as_str().unwrap().to_string())
+        .collect();
+
+    assert_eq!(codes, vec!["a", "b", "c"]);
+
+    let sorted_data = driver
+        .get_table_data(
+            "main",
+            "keyed_users",
+            1,
+            10,
+            None,
+            Some("name".to_string()),
+            Some("desc".to_string()),
+        )
+        .await
+        .unwrap();
+
+    let names: Vec<String> = sorted_data
+        .data
+        .iter()
+        .map(|row| row.get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+
+    assert_eq!(names, vec!["Charlie", "Bob", "Alice"]);
+}
+
+#[tokio::test]
 async fn test_get_table_data_pagination() {
     let temp_dir = tempdir().expect("Failed to create temp directory");
     let driver = create_driver_with_table(&temp_dir).await;
@@ -467,6 +519,8 @@ async fn test_execute_query_insert() {
 
     let query_result = result.unwrap();
     assert!(query_result.error.is_none());
+    assert_eq!(query_result.row_count, 1);
+    assert_eq!(query_result.rows_affected, Some(1));
 }
 
 #[tokio::test]
@@ -484,7 +538,10 @@ async fn test_execute_query_update() {
         .execute_query("UPDATE users SET age = 30 WHERE name = 'Test'")
         .await;
     assert!(result.is_ok());
-    assert!(result.unwrap().error.is_none());
+    let query_result = result.unwrap();
+    assert!(query_result.error.is_none());
+    assert_eq!(query_result.row_count, 1);
+    assert_eq!(query_result.rows_affected, Some(1));
 
     // Verify update
     let select_result = driver
@@ -510,7 +567,10 @@ async fn test_execute_query_delete() {
         .execute_query("DELETE FROM users WHERE name = 'Test'")
         .await;
     assert!(result.is_ok());
-    assert!(result.unwrap().error.is_none());
+    let query_result = result.unwrap();
+    assert!(query_result.error.is_none());
+    assert_eq!(query_result.row_count, 1);
+    assert_eq!(query_result.rows_affected, Some(1));
 
     // Verify delete
     let select_result = driver.execute_query("SELECT * FROM users").await.unwrap();

--- a/src-tauri/tests/unified_commands_tests.rs
+++ b/src-tauri/tests/unified_commands_tests.rs
@@ -532,6 +532,8 @@ async fn test_update_table_row_sqlite() {
     assert!(result.is_ok());
     let query_result = result.unwrap();
     assert!(query_result.error.is_none(), "Update should succeed");
+    assert_eq!(query_result.row_count, 1);
+    assert_eq!(query_result.rows_affected, Some(1));
 
     // Verify the update
     let select = unified_execute_query(

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -27,6 +27,7 @@ interface DataTableProps<TData> {
 	sortable?: boolean;
 	sort?: SortState | null;
 	onSortChange?: (sort: SortState | null) => void;
+	isRowHighlighted?: (row: TData) => boolean;
 }
 
 const COLUMN_WIDTH = 150;
@@ -46,6 +47,7 @@ export function DataTable<TData>({
 	sortable = false,
 	sort = null,
 	onSortChange,
+	isRowHighlighted,
 }: DataTableProps<TData>) {
 	const containerRef = useRef<HTMLDivElement>(null);
 
@@ -198,13 +200,15 @@ export function DataTable<TData>({
 				)}
 				{virtualRows.map((virtualRow) => {
 					const row = rows[virtualRow.index];
+					const highlighted = isRowHighlighted?.(row.original) ?? false;
 					return (
 						<tr
 							key={row.id}
 							data-index={virtualRow.index}
 							ref={measureRowElement}
 							data-state={row.getIsSelected() && "selected"}
-							className={`hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors ${
+							data-highlighted={highlighted ? "true" : undefined}
+							className={`hover:bg-muted/50 data-[state=selected]:bg-muted data-[highlighted=true]:bg-primary/5 border-b transition-colors ${
 								onRowClick ? "cursor-pointer" : ""
 							}`}
 							onClick={() => onRowClick?.(row.original)}

--- a/src/components/InlineEditableCell.tsx
+++ b/src/components/InlineEditableCell.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { PencilSimple } from "@phosphor-icons/react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import type { TableColumn } from "@/types/tabTypes";
+
+interface InlineEditableCellProps {
+	value: unknown;
+	column: TableColumn;
+	disabled?: boolean;
+	children: ReactNode;
+	onSave: (value: unknown) => Promise<void>;
+}
+
+function stringifyCellValue(value: unknown): string {
+	if (value === null || value === undefined) return "NULL";
+	if (typeof value === "object") return JSON.stringify(value);
+	return String(value);
+}
+
+function isNumericType(columnType: string): boolean {
+	return (
+		columnType.includes("int") ||
+		columnType.includes("numeric") ||
+		columnType.includes("decimal") ||
+		columnType.includes("real") ||
+		columnType.includes("double") ||
+		columnType.includes("float") ||
+		columnType === "serial" ||
+		columnType === "bigserial"
+	);
+}
+
+function parseCellValue(text: string, column: TableColumn): unknown {
+	const trimmed = text.trim();
+	const columnType = column.type.toLowerCase();
+
+	if (trimmed.toLowerCase() === "null") {
+		return null;
+	}
+
+	if (columnType === "boolean" || columnType === "bool") {
+		if (["true", "1", "yes"].includes(trimmed.toLowerCase())) return true;
+		if (["false", "0", "no"].includes(trimmed.toLowerCase())) return false;
+		throw new Error("Boolean values must be true or false");
+	}
+
+	if (isNumericType(columnType)) {
+		if (trimmed === "") return null;
+		const numericValue = Number(trimmed);
+		if (Number.isNaN(numericValue)) {
+			throw new Error("Numeric values must be valid numbers");
+		}
+		return numericValue;
+	}
+
+	if (columnType.includes("json")) {
+		if (trimmed === "") return null;
+		try {
+			return JSON.parse(trimmed);
+		} catch {
+			throw new Error("JSON values must be valid JSON");
+		}
+	}
+
+	return text;
+}
+
+export function InlineEditableCell({
+	value,
+	column,
+	disabled = false,
+	children,
+	onSave,
+}: InlineEditableCellProps) {
+	const [editing, setEditing] = useState(false);
+	const [draftValue, setDraftValue] = useState(stringifyCellValue(value));
+	const [saving, setSaving] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (!editing) {
+			setDraftValue(stringifyCellValue(value));
+		}
+	}, [value, editing]);
+
+	useEffect(() => {
+		if (editing) {
+			inputRef.current?.focus();
+			inputRef.current?.select();
+		}
+	}, [editing]);
+
+	const commit = async () => {
+		if (saving) return;
+
+		let parsedValue: unknown;
+		try {
+			parsedValue = parseCellValue(draftValue, column);
+		} catch (error) {
+			toast.error("Invalid cell value", {
+				description: error instanceof Error ? error.message : String(error),
+			});
+			return;
+		}
+
+		if (JSON.stringify(parsedValue) === JSON.stringify(value)) {
+			setEditing(false);
+			return;
+		}
+
+		setSaving(true);
+		try {
+			await onSave(parsedValue);
+			setEditing(false);
+		} finally {
+			setSaving(false);
+		}
+	};
+
+	if (editing) {
+		return (
+			<div
+				className="relative"
+				onClick={(event) => event.stopPropagation()}
+				onDoubleClick={(event) => event.stopPropagation()}
+			>
+				<Input
+					ref={inputRef}
+					value={draftValue}
+					onChange={(event) => setDraftValue(event.target.value)}
+					onBlur={() => void commit()}
+					onKeyDown={(event) => {
+						if (event.key === "Enter") {
+							event.preventDefault();
+							void commit();
+						}
+						if (event.key === "Escape") {
+							event.preventDefault();
+							setDraftValue(stringifyCellValue(value));
+							setEditing(false);
+						}
+					}}
+					disabled={saving}
+					className="h-7 pr-8"
+				/>
+				{saving && (
+					<Spinner className="absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2" />
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<div className="group/cell flex min-w-0 items-center">
+			<div className="min-w-0 flex-1 truncate">{children}</div>
+			{!disabled && (
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-xs"
+					className="ml-1 opacity-0 group-hover/cell:opacity-100 focus-visible:opacity-100"
+					title={`Edit ${column.name}`}
+					onClick={(event) => {
+						event.stopPropagation();
+						setEditing(true);
+					}}
+				>
+					<PencilSimple className="h-3 w-3" />
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -117,6 +117,7 @@ export interface TableDataResponse {
 export interface QueryResult {
 	data: Record<string, unknown>[];
 	row_count: number;
+	rows_affected?: number;
 	error?: string;
 	time_taken_ms?: number;
 }

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -121,6 +121,7 @@ import { TabBar } from "@/components/TabBar";
 import { useAIGeneration } from "@/hooks/useAIGeneration";
 import { RowEditSheet } from "@/components/RowEditSheet";
 import { RowInsertSheet } from "@/components/RowInsertSheet";
+import { InlineEditableCell } from "@/components/InlineEditableCell";
 import { RedisKeySheet } from "@/components/RedisKeySheet";
 import { ExpandableText } from "@/components/ExpandableText";
 import { ConnectionStatus } from "@/components/ConnectionStatus";
@@ -200,6 +201,24 @@ function buildWrappedQuery(
 ${normalizedBaseQuery}
 )
 SELECT * FROM user_query${whereClause}${orderClause};`;
+}
+
+function getPrimaryKeyRowKey(
+	row: Record<string, unknown>,
+	columns: TableColumn[],
+): string | null {
+	const primaryKeyColumns = columns.filter((column) => column.primary_key);
+	if (primaryKeyColumns.length === 0) return null;
+
+	return JSON.stringify(
+		primaryKeyColumns.map((column) => [column.name, row[column.name]]),
+	);
+}
+
+function formatQuerySuccessDetail(affectedRows: number | null): string {
+	if (affectedRows === null) return "No rows returned";
+
+	return `${affectedRows} row${affectedRows !== 1 ? "s" : ""} affected`;
 }
 
 // Header component that uses useSidebar for conditional padding
@@ -457,6 +476,10 @@ export function ConnectionDetails() {
 	);
 	const [savingRow, setSavingRow] = useState(false);
 	const [deletingRow, setDeletingRow] = useState(false);
+	const [highlightedTableRow, setHighlightedTableRow] = useState<{
+		tableName: string;
+		rowKey: string;
+	} | null>(null);
 
 	// Row insert state
 	const [rowInsertSheetOpen, setRowInsertSheetOpen] = useState(false);
@@ -1051,6 +1074,7 @@ export function ConnectionDetails() {
 					updateTab<QueryTab>(tab.id, {
 						error: result.error,
 						executionTime,
+						affectedRows: null,
 						executing: false,
 					});
 					return;
@@ -1061,6 +1085,7 @@ export function ConnectionDetails() {
 					success: true,
 					error: null,
 					executionTime,
+					affectedRows: null,
 					executing: false,
 					filter: nextFilter,
 					sort: nextSort,
@@ -1072,6 +1097,7 @@ export function ConnectionDetails() {
 							? error.message
 							: "Failed to apply query filter/sort",
 					executionTime: null,
+					affectedRows: null,
 					executing: false,
 				});
 			}
@@ -1207,6 +1233,7 @@ export function ConnectionDetails() {
 			results: null,
 			success: false,
 			executionTime: null,
+			affectedRows: null,
 			filterInput: "",
 			filter: "",
 			sort: null,
@@ -1223,6 +1250,7 @@ export function ConnectionDetails() {
 				updateTab<QueryTab>(tab.id, {
 					error: result.error,
 					executionTime,
+					affectedRows: null,
 					executing: false,
 				});
 				return;
@@ -1232,6 +1260,7 @@ export function ConnectionDetails() {
 				results: result.data as Record<string, unknown>[],
 				success: true,
 				executionTime,
+				affectedRows: result.rows_affected ?? null,
 				executing: false,
 				filterInput: "",
 				filter: "",
@@ -1245,6 +1274,7 @@ export function ConnectionDetails() {
 				error:
 					error instanceof Error ? error.message : "Failed to execute query",
 				executionTime: null,
+				affectedRows: null,
 				executing: false,
 			});
 		}
@@ -1265,6 +1295,7 @@ export function ConnectionDetails() {
 			results: null,
 			success: false,
 			executionTime: null,
+			affectedRows: null,
 			filterInput: "",
 			filter: "",
 			sort: null,
@@ -1275,6 +1306,7 @@ export function ConnectionDetails() {
 		let lastResult: Record<string, unknown>[] = [];
 		let lastError: string | null = null;
 		let lastBaseQuery: string | null = null;
+		let lastAffectedRows: number | null = null;
 
 		try {
 			for (const statement of statements) {
@@ -1290,6 +1322,7 @@ export function ConnectionDetails() {
 				}
 
 				lastResult = result.data as Record<string, unknown>[];
+				lastAffectedRows = result.rows_affected ?? null;
 				lastBaseQuery = isWrappableQuery(queryToRun)
 					? stripTrailingSemicolon(queryToRun)
 					: null;
@@ -1299,6 +1332,7 @@ export function ConnectionDetails() {
 				updateTab<QueryTab>(tab.id, {
 					error: lastError,
 					executionTime: totalTime,
+					affectedRows: null,
 					executing: false,
 				});
 			} else {
@@ -1306,6 +1340,7 @@ export function ConnectionDetails() {
 					results: lastResult,
 					success: true,
 					executionTime: totalTime,
+					affectedRows: lastAffectedRows,
 					executing: false,
 					filterInput: "",
 					filter: "",
@@ -1318,6 +1353,7 @@ export function ConnectionDetails() {
 				error:
 					error instanceof Error ? error.message : "Failed to execute queries",
 				executionTime: null,
+				affectedRows: null,
 				executing: false,
 			});
 		}
@@ -1476,10 +1512,13 @@ export function ConnectionDetails() {
 				if (result.error) {
 					toast.error("Failed to update row", { description: result.error });
 				} else {
+					const rowKey = getPrimaryKeyRowKey(editingRow, tab.columns);
+					if (rowKey) {
+						setHighlightedTableRow({ tableName: tab.tableName, rowKey });
+					}
 					toast.success("Row updated successfully");
 					setRowEditSheetOpen(false);
 					setEditingRow(null);
-					// Refresh table data
 					fetchTableData(tab);
 				}
 			} catch (error) {
@@ -1492,6 +1531,62 @@ export function ConnectionDetails() {
 			}
 		},
 		[connection, activeTab, editingRow, fetchTableData],
+	);
+
+	const handleInlineCellSave = useCallback(
+		async (
+			row: Record<string, unknown>,
+			columnName: string,
+			value: unknown,
+		) => {
+			if (!connection || !activeTab || activeTab.type !== "table-data") return;
+
+			const tab = activeTab as TableDataTab;
+			const column = tab.columns.find((col) => col.name === columnName);
+			if (!column || column.primary_key) {
+				throw new Error("This column cannot be edited inline");
+			}
+
+			const primaryKeyColumns = tab.columns
+				.filter((col) => col.primary_key)
+				.map((col) => col.name);
+			const primaryKeyValues = primaryKeyColumns.map((col) => row[col]);
+
+			if (primaryKeyColumns.length === 0) {
+				throw new Error("Cannot update row without primary key");
+			}
+
+			const [schema, tableName] = tab.tableName.split(".");
+
+			try {
+				const result = await api.pool.updateTableRow(
+					connection.uuid,
+					schema,
+					tableName,
+					primaryKeyColumns,
+					primaryKeyValues,
+					[{ column: columnName, value, isRawSql: false }],
+				);
+
+				if (result.error) {
+					throw new Error(result.error);
+				}
+
+				const rowKey = getPrimaryKeyRowKey(row, tab.columns);
+				if (rowKey) {
+					setHighlightedTableRow({ tableName: tab.tableName, rowKey });
+				}
+				toast.success("Cell updated successfully");
+				await fetchTableData(tab);
+			} catch (error) {
+				console.error("Failed to update cell:", error);
+				toast.error("Failed to update cell", {
+					description: error instanceof Error ? error.message : String(error),
+				});
+				throw error;
+			}
+		},
+		[connection, activeTab, fetchTableData],
 	);
 
 	const handleDeleteRow = useCallback(async () => {
@@ -1872,6 +1967,8 @@ export function ConnectionDetails() {
 
 		const schema = tab.tableName.split(".")[0];
 		const firstRow = tab.data.data[0];
+		const dbType = connection?.db_type || connection?.type;
+		const hasPrimaryKey = tab.columns.some((col) => col.primary_key);
 		return Object.keys(firstRow).map((key) => {
 			const fkInfo = tab.foreignKeys.find((fk) => fk.column === key);
 			const columnInfo = tab.columns.find((col) => col.name === key);
@@ -1896,31 +1993,38 @@ export function ConnectionDetails() {
 						)}
 					</span>
 				),
-				cell: ({ getValue }) => {
+				cell: ({ getValue, row }) => {
 					const value = getValue();
-					if (value === null)
-						return <span className="text-muted-foreground italic">null</span>;
+					const cellContent =
+						value === null ? (
+							<span className="text-muted-foreground italic">null</span>
+						) : null;
 
 					const rawValue =
 						typeof value === "object" ? JSON.stringify(value) : String(value);
 					const displayValue =
 						rawValue.length > 200 ? `${rawValue.slice(0, 200)}…` : rawValue;
+					const canEditInline =
+						!!columnInfo &&
+						!columnInfo.primary_key &&
+						hasPrimaryKey &&
+						dbType !== "clickhouse";
 
-					if (fkInfo && value !== null) {
-						const refTable = `${schema}.${fkInfo.references_table}`;
-						return (
+					const content =
+						cellContent ??
+						(fkInfo && value !== null ? (
 							<span
-								className="group/fk flex items-center gap-1"
+								className="group/fk flex items-center"
 								title={rawValue}
 							>
-								<span>{displayValue}</span>
+								<span className="truncate">{displayValue}</span>
 								<button
 									type="button"
 									className="opacity-0 group-hover/fk:opacity-100 p-0.5 rounded hover:bg-muted transition-opacity cursor-pointer"
 									onClick={(e) => {
 										e.stopPropagation();
 										handleOpenTableDataWithFilter(
-											refTable,
+											`${schema}.${fkInfo.references_table}`,
 											fkInfo.references_column,
 											value,
 										);
@@ -1930,14 +2034,28 @@ export function ConnectionDetails() {
 									<ArrowRight className="w-3.5 h-3.5 text-primary" />
 								</button>
 							</span>
-						);
-					}
+						) : (
+							<span title={rawValue}>{displayValue}</span>
+						));
 
-					return <span title={rawValue}>{displayValue}</span>;
+					return columnInfo ? (
+						<InlineEditableCell
+							value={value}
+							column={columnInfo}
+							disabled={!canEditInline}
+							onSave={(nextValue) =>
+								handleInlineCellSave(row.original, key, nextValue)
+							}
+						>
+							{content}
+						</InlineEditableCell>
+					) : (
+						content
+					);
 				},
 			};
 		});
-	}, [activeTab, handleOpenTableDataWithFilter]);
+	}, [activeTab, connection, handleOpenTableDataWithFilter, handleInlineCellSave]);
 
 	const tableDataPageCount = useMemo(() => {
 		if (!activeTab || activeTab.type !== "table-data") return 0;
@@ -2188,6 +2306,11 @@ export function ConnectionDetails() {
 							sortable
 							sort={tab.sort}
 							onSortChange={handleSortChange}
+							isRowHighlighted={(row) =>
+								highlightedTableRow?.tableName === tab.tableName &&
+								getPrimaryKeyRowKey(row, tab.columns) ===
+									highlightedTableRow.rowKey
+							}
 						/>
 					</div>
 				) : (
@@ -2670,7 +2793,11 @@ export function ConnectionDetails() {
 								{tab.results !== null &&
 									tab.results.length === 0 &&
 									tab.success &&
-									"Query executed successfully - no rows returned"}
+									(tab.affectedRows !== null
+										? `Query executed successfully - ${formatQuerySuccessDetail(
+												tab.affectedRows,
+											)}`
+										: "Query executed successfully - no rows returned")}
 							</CardDescription>
 						</div>
 						{tab.results && tab.results.length > 0 && (
@@ -2827,20 +2954,24 @@ export function ConnectionDetails() {
 											tab.resultBaseQuery ? handleQuerySortChange : undefined
 										}
 										onRowClick={(row) => {
-											const index = tab.results.findIndex((r) => r === row);
+											const index =
+												tab.results?.findIndex((r) => r === row) ?? -1;
 											setSelectedQueryRow({ row, index });
 											setQueryResultSheetOpen(true);
 										}}
 									/>
 								</div>
 							) : tab.success ? (
-								<div className="text-center py-8">
-									<div className="rounded-md bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800 p-4 max-w-md mx-auto">
-										<p className="text-sm text-green-800 dark:text-green-200 font-medium">
-											✓ Query executed successfully
+								<div className="flex items-start gap-2 rounded-md border bg-muted/20 px-3 py-2 text-sm">
+									<span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-[3px] border border-green-500 bg-green-50 text-green-600 dark:border-green-500/80 dark:bg-green-950/30 dark:text-green-400">
+										<Check weight="bold" className="h-3 w-3" />
+									</span>
+									<div className="min-w-0">
+										<p className="font-medium text-foreground">
+											Query executed successfully
 										</p>
-										<p className="text-sm text-green-600 dark:text-green-300 mt-1">
-											No rows returned
+										<p className="mt-0.5 text-muted-foreground">
+											{formatQuerySuccessDetail(tab.affectedRows)}
 										</p>
 									</div>
 								</div>

--- a/src/types/tabTypes.ts
+++ b/src/types/tabTypes.ts
@@ -71,6 +71,7 @@ export interface QueryTab extends BaseTab {
 	error: string | null;
 	success: boolean;
 	executionTime: number | null;
+	affectedRows: number | null;
 	executing: boolean;
 	filterInput: string;
 	filter: string;
@@ -164,6 +165,7 @@ export function createQueryTab(
 		error: null,
 		success: false,
 		executionTime: null,
+		affectedRows: null,
 		executing: false,
 		filterInput: "",
 		filter: "",


### PR DESCRIPTION
## Summary
- report affected row counts for non-returning update/insert/delete queries
- add inline table-cell editing for primary-keyed rows
- keep table rows stable after updates by defaulting unsorted table views to primary-key order
- refresh the query success state with the Option A-style left-aligned status and green checkbox
- bump the Tauri app version to `0.0.53` for release

## Release notes
Merging this PR into `main` with the `release` label will let the existing workflow create tag `v0.0.53` and build the draft release.

## Validation
- `cargo check`
- `cargo test --test sqlite_integration_tests -- --nocapture`
- `cargo test --test unified_commands_tests test_update_table_row_sqlite -- --nocapture`
- targeted Postgres integration coverage for affected rows and default primary-key ordering
- `bunx eslint components/DataTable.tsx components/InlineEditableCell.tsx pages/ConnectionDetails.tsx --quiet`
- `bun run --bun build`

## Notes
- `bun run build` under the local Node runtime still hits the existing Rollup native optional package code-signature issue for `@rollup/rollup-darwin-arm64`; the Bun-runtime production build completed successfully.