### PR TITLE
Improve table inline edit actions

### DIFF
--- a/src/components/InlineEditableCell.tsx
+++ b/src/components/InlineEditableCell.tsx
@@ -1,5 +1,9 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
-import { PencilSimple } from "@phosphor-icons/react";
+import {
+	ArrowCounterClockwise,
+	Check,
+	PencilSimple,
+} from "@phosphor-icons/react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -79,6 +83,7 @@ export function InlineEditableCell({
 	const [draftValue, setDraftValue] = useState(stringifyCellValue(value));
 	const [saving, setSaving] = useState(false);
 	const inputRef = useRef<HTMLInputElement>(null);
+	const editorRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		if (!editing) {
@@ -120,18 +125,26 @@ export function InlineEditableCell({
 		}
 	};
 
+	const reset = () => {
+		setDraftValue(stringifyCellValue(value));
+		setEditing(false);
+	};
+
+	const handleEditorBlur = () => {
+		window.requestAnimationFrame(() => {
+			if (!editorRef.current?.contains(document.activeElement)) {
+				reset();
+			}
+		});
+	};
+
 	if (editing) {
 		return (
-			<div
-				className="relative"
-				onClick={(event) => event.stopPropagation()}
-				onDoubleClick={(event) => event.stopPropagation()}
-			>
+			<div ref={editorRef} className="flex min-w-48 items-center">
 				<Input
 					ref={inputRef}
 					value={draftValue}
 					onChange={(event) => setDraftValue(event.target.value)}
-					onBlur={() => void commit()}
 					onKeyDown={(event) => {
 						if (event.key === "Enter") {
 							event.preventDefault();
@@ -144,11 +157,43 @@ export function InlineEditableCell({
 						}
 					}}
 					disabled={saving}
-					className="h-7 pr-8"
+					className="h-7 min-w-0"
+					onBlur={handleEditorBlur}
+					onClick={(event) => event.stopPropagation()}
+					onDoubleClick={(event) => event.stopPropagation()}
 				/>
-				{saving && (
-					<Spinner className="absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2" />
-				)}
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-xs"
+					title={`Save ${column.name}`}
+					disabled={saving}
+					onBlur={handleEditorBlur}
+					onClick={(event) => {
+						event.stopPropagation();
+						void commit();
+					}}
+				>
+					{saving ? (
+						<Spinner className="h-3 w-3" />
+					) : (
+						<Check className="h-3 w-3" />
+					)}
+				</Button>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-xs"
+					title={`Reset ${column.name}`}
+					disabled={saving}
+					onBlur={handleEditorBlur}
+					onClick={(event) => {
+						event.stopPropagation();
+						reset();
+					}}
+				>
+					<ArrowCounterClockwise className="h-3 w-3" />
+				</Button>
 			</div>
 		);
 	}

--- a/src/components/RowEditSheet.tsx
+++ b/src/components/RowEditSheet.tsx
@@ -1,12 +1,12 @@
-import { useState, useEffect, useMemo } from "react";
 import {
-	Sheet,
-	SheetContent,
-	SheetDescription,
-	SheetHeader,
-	SheetTitle,
-	SheetFooter,
-} from "@/components/ui/sheet";
+	ArrowCounterClockwise,
+	FloppyDisk,
+	Key,
+	Trash,
+	Warning,
+} from "@phosphor-icons/react";
+import { useEffect, useMemo, useState } from "react";
+import { type DbType, FieldInput } from "@/components/field-inputs";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -17,13 +17,19 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetFooter,
+	SheetHeader,
+	SheetTitle,
+} from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
-import { Trash, FloppyDisk, Warning, Key } from "@phosphor-icons/react";
 import type { TableColumn } from "@/types/tabTypes";
-import { FieldInput, type DbType } from "@/components/field-inputs";
 
 interface RowEditSheetProps {
 	open: boolean;
@@ -43,6 +49,16 @@ interface RowEditSheetProps {
 interface FieldValue {
 	value: unknown;
 	isRawSql: boolean;
+}
+
+function getRowFieldValues(
+	row: Record<string, unknown>,
+): Record<string, FieldValue> {
+	const initialValues: Record<string, FieldValue> = {};
+	Object.entries(row).forEach(([key, value]) => {
+		initialValues[key] = { value, isRawSql: false };
+	});
+	return initialValues;
 }
 
 export function RowEditSheet({
@@ -76,11 +92,7 @@ export function RowEditSheet({
 	// Reset edited values when row changes
 	useEffect(() => {
 		if (row) {
-			const initialValues: Record<string, FieldValue> = {};
-			Object.entries(row).forEach(([key, value]) => {
-				initialValues[key] = { value, isRawSql: false };
-			});
-			setEditedValues(initialValues);
+			setEditedValues(getRowFieldValues(row));
 		} else {
 			setEditedValues({});
 		}
@@ -142,6 +154,11 @@ export function RowEditSheet({
 		await onSave(updates);
 	};
 
+	const handleReset = () => {
+		if (!row) return;
+		setEditedValues(getRowFieldValues(row));
+	};
+
 	const handleDelete = async () => {
 		setShowDeleteDialog(false);
 		await onDelete();
@@ -154,9 +171,9 @@ export function RowEditSheet({
 			<Sheet open={open} onOpenChange={onOpenChange}>
 				<SheetContent
 					side="right"
-					className="w-full sm:max-w-lg overflow-y-auto"
+					className="w-full sm:max-w-lg overflow-hidden"
 				>
-					<SheetHeader>
+					<SheetHeader className="shrink-0">
 						<SheetTitle className="flex items-center gap-2">
 							{isClickHouse ? "View Row" : "Edit Row"}
 							<Badge variant="secondary" className="font-mono">
@@ -183,7 +200,7 @@ export function RowEditSheet({
 						</SheetDescription>
 					</SheetHeader>
 
-					<div className="py-6 px-4 space-y-4">
+					<div className="min-h-0 flex-1 overflow-y-auto px-4 py-6 space-y-4">
 						{columns.map((column) => {
 							const fieldValue = editedValues[column.name] || {
 								value: row?.[column.name] ?? null,
@@ -223,7 +240,7 @@ export function RowEditSheet({
 					</div>
 
 					{!isClickHouse && (
-						<SheetFooter className="flex-row gap-2 justify-between sm:justify-between px-4">
+						<SheetFooter className="sticky bottom-0 z-10 shrink-0 flex-row gap-2 justify-between border-t bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:justify-between">
 							<Button
 								variant="destructive"
 								onClick={() => setShowDeleteDialog(true)}
@@ -232,13 +249,23 @@ export function RowEditSheet({
 								{deleting ? <Spinner /> : <Trash className="w-4 h-4" />}
 								Delete
 							</Button>
-							<Button
-								onClick={handleSave}
-								disabled={!hasPrimaryKey || !hasChanges || saving || deleting}
-							>
-								{saving ? <Spinner /> : <FloppyDisk className="w-4 h-4" />}
-								Save Changes
-							</Button>
+							<div className="flex items-center gap-2">
+								<Button
+									variant="outline"
+									onClick={handleReset}
+									disabled={!hasPrimaryKey || !hasChanges || saving || deleting}
+								>
+									<ArrowCounterClockwise className="w-4 h-4" />
+									Reset
+								</Button>
+								<Button
+									onClick={handleSave}
+									disabled={!hasPrimaryKey || !hasChanges || saving || deleting}
+								>
+									{saving ? <Spinner /> : <FloppyDisk className="w-4 h-4" />}
+									Save Changes
+								</Button>
+							</div>
 						</SheetFooter>
 					)}
 				</SheetContent>

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,13 +1,16 @@
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
-  return (
-    <div
-      data-slot="skeleton"
-      className={cn("bg-muted rounded-none animate-pulse", className)}
-      {...props}
-    />
-  )
+	return (
+		<div
+			data-slot="skeleton"
+			className={cn(
+				"bg-muted rounded-none animate-pulse dark:bg-foreground/15",
+				className,
+			)}
+			{...props}
+		/>
+	);
 }
 
-export { Skeleton }
+export { Skeleton };

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,12 +1,17 @@
-import { cn } from "@/lib/utils";
 import { CircleNotch } from "@phosphor-icons/react";
+import { cn } from "@/lib/utils";
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+function Spinner({
+	className,
+	weight = "bold",
+	...props
+}: React.ComponentProps<typeof CircleNotch>) {
 	return (
 		<CircleNotch
 			role="status"
 			aria-label="Loading"
-			className={cn("size-4 animate-spin bg-none", className)}
+			weight={weight}
+			className={cn("size-4 animate-spin bg-none text-current", className)}
 			{...props}
 		/>
 	);

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -215,6 +215,16 @@ function getPrimaryKeyRowKey(
 	);
 }
 
+function areCellValuesEqual(left: unknown, right: unknown): boolean {
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+interface PendingInlineCellEdit {
+	row: Record<string, unknown>;
+	columnName: string;
+	value: unknown;
+}
+
 function formatQuerySuccessDetail(affectedRows: number | null): string {
 	if (affectedRows === null) return "No rows returned";
 
@@ -480,6 +490,10 @@ export function ConnectionDetails() {
 		tableName: string;
 		rowKey: string;
 	} | null>(null);
+	const [pendingInlineEditsByTab, setPendingInlineEditsByTab] = useState<
+		Record<string, Record<string, PendingInlineCellEdit>>
+	>({});
+	const [savingInlineEdits, setSavingInlineEdits] = useState(false);
 
 	// Row insert state
 	const [rowInsertSheetOpen, setRowInsertSheetOpen] = useState(false);
@@ -1539,7 +1553,7 @@ export function ConnectionDetails() {
 			columnName: string,
 			value: unknown,
 		) => {
-			if (!connection || !activeTab || activeTab.type !== "table-data") return;
+			if (!activeTab || activeTab.type !== "table-data") return;
 
 			const tab = activeTab as TableDataTab;
 			const column = tab.columns.find((col) => col.name === columnName);
@@ -1547,47 +1561,137 @@ export function ConnectionDetails() {
 				throw new Error("This column cannot be edited inline");
 			}
 
-			const primaryKeyColumns = tab.columns
-				.filter((col) => col.primary_key)
-				.map((col) => col.name);
-			const primaryKeyValues = primaryKeyColumns.map((col) => row[col]);
-
-			if (primaryKeyColumns.length === 0) {
+			const rowKey = getPrimaryKeyRowKey(row, tab.columns);
+			if (!rowKey) {
 				throw new Error("Cannot update row without primary key");
 			}
 
-			const [schema, tableName] = tab.tableName.split(".");
+			const editKey = `${rowKey}:${columnName}`;
 
-			try {
+			setPendingInlineEditsByTab((prev) => {
+				const tabEdits = { ...(prev[tab.id] ?? {}) };
+				if (areCellValuesEqual(row[columnName], value)) {
+					delete tabEdits[editKey];
+				} else {
+					tabEdits[editKey] = { row, columnName, value };
+				}
+
+				if (Object.keys(tabEdits).length === 0) {
+					const next = { ...prev };
+					delete next[tab.id];
+					return next;
+				}
+
+				return { ...prev, [tab.id]: tabEdits };
+			});
+			toast.success("Change staged");
+		},
+		[activeTab],
+	);
+
+	const handleSaveInlineChanges = useCallback(async () => {
+		if (!connection || !activeTab || activeTab.type !== "table-data") return;
+
+		const tab = activeTab as TableDataTab;
+		const pendingEdits = Object.entries(pendingInlineEditsByTab[tab.id] ?? {});
+		if (pendingEdits.length === 0) return;
+
+		const primaryKeyColumns = tab.columns
+			.filter((col) => col.primary_key)
+			.map((col) => col.name);
+
+		if (primaryKeyColumns.length === 0) {
+			toast.error("Cannot update rows without primary key");
+			return;
+		}
+
+		const [schema, tableName] = tab.tableName.split(".");
+		const editsByRow = new Map<
+			string,
+			{
+				row: Record<string, unknown>;
+				updates: Array<{ column: string; value: unknown; isRawSql: boolean }>;
+			}
+		>();
+
+		for (const [, edit] of pendingEdits) {
+			const rowKey = getPrimaryKeyRowKey(edit.row, tab.columns);
+			if (!rowKey) continue;
+
+			const groupedEdit = editsByRow.get(rowKey) ?? {
+				row: edit.row,
+				updates: [],
+			};
+			groupedEdit.updates.push({
+				column: edit.columnName,
+				value: edit.value,
+				isRawSql: false,
+			});
+			editsByRow.set(rowKey, groupedEdit);
+		}
+
+		if (editsByRow.size === 0) return;
+
+		setSavingInlineEdits(true);
+		try {
+			for (const [rowKey, editGroup] of editsByRow) {
+				const primaryKeyValues = primaryKeyColumns.map(
+					(col) => editGroup.row[col],
+				);
 				const result = await api.pool.updateTableRow(
 					connection.uuid,
 					schema,
 					tableName,
 					primaryKeyColumns,
 					primaryKeyValues,
-					[{ column: columnName, value, isRawSql: false }],
+					editGroup.updates,
 				);
 
 				if (result.error) {
 					throw new Error(result.error);
 				}
 
-				const rowKey = getPrimaryKeyRowKey(row, tab.columns);
-				if (rowKey) {
-					setHighlightedTableRow({ tableName: tab.tableName, rowKey });
-				}
-				toast.success("Cell updated successfully");
-				await fetchTableData(tab);
-			} catch (error) {
-				console.error("Failed to update cell:", error);
-				toast.error("Failed to update cell", {
-					description: error instanceof Error ? error.message : String(error),
-				});
-				throw error;
+				setHighlightedTableRow({ tableName: tab.tableName, rowKey });
 			}
-		},
-		[connection, activeTab, fetchTableData],
-	);
+
+			setPendingInlineEditsByTab((prev) => {
+				const next = { ...prev };
+				delete next[tab.id];
+				return next;
+			});
+			toast.success(
+				`Committed ${pendingEdits.length} inline change${pendingEdits.length === 1 ? "" : "s"}`,
+			);
+			await fetchTableData(tab);
+		} catch (error) {
+			console.error("Failed to save inline changes:", error);
+			toast.error("Failed to save inline changes", {
+				description: error instanceof Error ? error.message : String(error),
+			});
+		} finally {
+			setSavingInlineEdits(false);
+		}
+	}, [
+		connection,
+		activeTab,
+		pendingInlineEditsByTab,
+		fetchTableData,
+	]);
+
+	const handleDiscardInlineChanges = useCallback(() => {
+		if (!activeTab || activeTab.type !== "table-data") return;
+
+		const tab = activeTab as TableDataTab;
+		const pendingEdits = pendingInlineEditsByTab[tab.id];
+		if (!pendingEdits || Object.keys(pendingEdits).length === 0) return;
+
+		setPendingInlineEditsByTab((prev) => {
+			const next = { ...prev };
+			delete next[tab.id];
+			return next;
+		});
+		toast.info("Inline changes discarded");
+	}, [activeTab, pendingInlineEditsByTab]);
 
 	const handleDeleteRow = useCallback(async () => {
 		if (
@@ -1994,7 +2098,12 @@ export function ConnectionDetails() {
 					</span>
 				),
 				cell: ({ getValue, row }) => {
-					const value = getValue();
+					const originalValue = getValue();
+					const rowKey = getPrimaryKeyRowKey(row.original, tab.columns);
+					const pendingEdit = rowKey
+						? pendingInlineEditsByTab[tab.id]?.[`${rowKey}:${key}`]
+						: undefined;
+					const value = pendingEdit ? pendingEdit.value : originalValue;
 					const cellContent =
 						value === null ? (
 							<span className="text-muted-foreground italic">null</span>
@@ -2047,7 +2156,11 @@ export function ConnectionDetails() {
 								handleInlineCellSave(row.original, key, nextValue)
 							}
 						>
-							{content}
+							{pendingEdit ? (
+								<span className="text-primary font-medium">{content}</span>
+							) : (
+								content
+							)}
 						</InlineEditableCell>
 					) : (
 						content
@@ -2055,7 +2168,13 @@ export function ConnectionDetails() {
 				},
 			};
 		});
-	}, [activeTab, connection, handleOpenTableDataWithFilter, handleInlineCellSave]);
+	}, [
+		activeTab,
+		connection,
+		pendingInlineEditsByTab,
+		handleOpenTableDataWithFilter,
+		handleInlineCellSave,
+	]);
 
 	const tableDataPageCount = useMemo(() => {
 		if (!activeTab || activeTab.type !== "table-data") return 0;
@@ -2196,8 +2315,14 @@ export function ConnectionDetails() {
 		);
 	}
 
-	const renderTableDataContent = (tab: TableDataTab) => (
-		<Card>
+	const renderTableDataContent = (tab: TableDataTab) => {
+		const pendingInlineChangeCount = Object.keys(
+			pendingInlineEditsByTab[tab.id] ?? {},
+		).length;
+		const hasPendingInlineChanges = pendingInlineChangeCount > 0;
+
+		return (
+			<Card>
 			<CardHeader>
 				<div className="flex items-center justify-between">
 					<div>
@@ -2237,6 +2362,36 @@ export function ConnectionDetails() {
 					</div>
 				</div>
 			</CardHeader>
+			{hasPendingInlineChanges && (
+				<div className="mx-6 flex items-center justify-between rounded-lg border border-primary/30 bg-primary/5 px-3 py-2">
+					<span className="text-xs font-medium text-foreground">
+						Unsaved changes
+					</span>
+					<div className="flex items-center gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={handleDiscardInlineChanges}
+							disabled={savingInlineEdits || tab.loading}
+						>
+							<X className="w-4 h-4" />
+							Discard
+						</Button>
+						<Button
+							size="sm"
+							onClick={() => void handleSaveInlineChanges()}
+							disabled={savingInlineEdits || tab.loading}
+						>
+							{savingInlineEdits ? (
+								<Spinner />
+							) : (
+								<FloppyDisk className="w-4 h-4" />
+							)}
+							Commit
+						</Button>
+					</div>
+				</div>
+			)}
 			<div className="px-6 pb-4">
 				<div className="flex items-center gap-2">
 					<Input
@@ -2252,13 +2407,6 @@ export function ConnectionDetails() {
 						}}
 						className="flex-1 font-mono text-xs"
 					/>
-					<Button
-						size="sm"
-						onClick={handleApplyFilter}
-						disabled={tab.loading || !tab.filterInput.trim()}
-					>
-						Apply
-					</Button>
 					{tab.filter && (
 						<Button
 							size="sm"
@@ -2320,7 +2468,8 @@ export function ConnectionDetails() {
 				)}
 			</CardContent>
 		</Card>
-	);
+		);
+	};
 
 	const renderTableStructureContent = (tab: TableStructureTab) => (
 		<Card>
@@ -2909,13 +3058,6 @@ export function ConnectionDetails() {
 										}}
 										className="flex-1 font-mono text-xs"
 									/>
-									<Button
-										size="sm"
-										onClick={handleApplyQueryFilter}
-										disabled={tab.executing || !tab.filterInput.trim()}
-									>
-										Apply
-									</Button>
 									{tab.filter && (
 										<Button
 											size="sm"


### PR DESCRIPTION
## Summary
- stage inline table cell edits instead of applying them immediately
- add a table-level unsaved changes bar with Commit and Discard actions
- improve dark-mode loading visibility and keep row-detail sheet actions pinned while scrolling

## Testing
- bunx biome check src/components/InlineEditableCell.tsx src/components/RowEditSheet.tsx src/components/ui/skeleton.tsx src/components/ui/spinner.tsx
- bun run --bun build