### PR TITLE
Prepare v0.0.54 release

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- bump Tauri app version from 0.0.53 to 0.0.54

## Testing
- jq .version src-tauri/tauri.conf.json
- bun --bun run build
- cargo check (from src-tauri/)