### PR TITLE
feat: rolling SQL query history (last 10 per connection)

### DIFF
--- a/src-tauri/migrations/005_query_history.sql
+++ b/src-tauri/migrations/005_query_history.sql
@@ -1,0 +1,16 @@
+-- Create query_history table (rolling last-10 runs per connection)
+CREATE TABLE IF NOT EXISTS query_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    connection_uuid TEXT NOT NULL,
+    query TEXT NOT NULL,
+    status TEXT NOT NULL,              -- 'success' | 'error'
+    time_taken_ms INTEGER,
+    row_count INTEGER,
+    rows_affected INTEGER,
+    error TEXT,
+    executed_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (connection_uuid) REFERENCES connections(uuid) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_query_history_conn
+    ON query_history(connection_uuid, executed_at DESC);

--- a/src-tauri/src/commands/queries.rs
+++ b/src-tauri/src/commands/queries.rs
@@ -1,4 +1,4 @@
-use crate::db::models::{SavedQuery, SavedQueryFormData};
+use crate::db::models::{QueryHistory, SavedQuery, SavedQueryFormData};
 use sqlx::SqlitePool;
 use tauri::State;
 
@@ -63,6 +63,86 @@ pub async fn update_saved_query(
 pub async fn delete_saved_query(pool: State<'_, SqlitePool>, id: i64) -> Result<bool, String> {
     sqlx::query("DELETE FROM saved_queries WHERE id = ?")
         .bind(id)
+        .execute(pool.inner())
+        .await
+        .map(|_| true)
+        .map_err(|e| e.to_string())
+}
+
+/// Record a query run in history and prune to the newest 10 per connection.
+/// Fire-and-forget from the UI: failures must not block query results.
+#[tauri::command]
+pub async fn record_query_history(
+    pool: State<'_, SqlitePool>,
+    connection_uuid: String,
+    query: String,
+    status: String,
+    time_taken_ms: Option<i64>,
+    row_count: Option<i64>,
+    rows_affected: Option<i64>,
+    error: Option<String>,
+) -> Result<(), String> {
+    sqlx::query(
+        r#"
+        INSERT INTO query_history
+            (connection_uuid, query, status, time_taken_ms, row_count, rows_affected, error)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind(&connection_uuid)
+    .bind(&query)
+    .bind(&status)
+    .bind(time_taken_ms)
+    .bind(row_count)
+    .bind(rows_affected)
+    .bind(&error)
+    .execute(pool.inner())
+    .await
+    .map_err(|e| e.to_string())?;
+
+    // Keep only the newest 10 runs for this connection.
+    sqlx::query(
+        r#"
+        DELETE FROM query_history
+        WHERE connection_uuid = ?
+          AND id NOT IN (
+            SELECT id FROM query_history
+            WHERE connection_uuid = ?
+            ORDER BY executed_at DESC, id DESC
+            LIMIT 10
+          )
+        "#,
+    )
+    .bind(&connection_uuid)
+    .bind(&connection_uuid)
+    .execute(pool.inner())
+    .await
+    .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn get_query_history(
+    pool: State<'_, SqlitePool>,
+    connection_uuid: String,
+) -> Result<Vec<QueryHistory>, String> {
+    sqlx::query_as::<_, QueryHistory>(
+        "SELECT * FROM query_history WHERE connection_uuid = ? ORDER BY executed_at DESC, id DESC LIMIT 10",
+    )
+    .bind(&connection_uuid)
+    .fetch_all(pool.inner())
+    .await
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn clear_query_history(
+    pool: State<'_, SqlitePool>,
+    connection_uuid: String,
+) -> Result<bool, String> {
+    sqlx::query("DELETE FROM query_history WHERE connection_uuid = ?")
+        .bind(&connection_uuid)
         .execute(pool.inner())
         .await
         .map(|_| true)

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -83,6 +83,19 @@ pub struct SavedQueryFormData {
     pub query: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct QueryHistory {
+    pub id: i64,
+    pub connection_uuid: String,
+    pub query: String,
+    pub status: String,
+    pub time_taken_ms: Option<i64>,
+    pub row_count: Option<i64>,
+    pub rows_affected: Option<i64>,
+    pub error: Option<String>,
+    pub executed_at: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TableInfo {
     pub schema: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,7 +25,8 @@ use commands::postgres::{
     execute_query, get_table_data, get_table_structure, list_tables, test_connection,
 };
 use commands::queries::{
-    create_saved_query, delete_saved_query, get_saved_queries, update_saved_query,
+    clear_query_history, create_saved_query, delete_saved_query, get_query_history,
+    get_saved_queries, record_query_history, update_saved_query,
 };
 use commands::settings::{get_all_settings, get_setting, set_setting};
 use database::pool_manager::PoolManager;
@@ -186,6 +187,9 @@ pub fn run() {
             create_saved_query,
             update_saved_query,
             delete_saved_query,
+            record_query_history,
+            get_query_history,
+            clear_query_history,
             get_setting,
             set_setting,
             get_all_settings,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -141,6 +141,18 @@ export interface SavedQueryFormData {
 	query: string;
 }
 
+export interface QueryHistory {
+	id: number;
+	connection_uuid: string;
+	query: string;
+	status: "success" | "error";
+	time_taken_ms: number | null;
+	row_count: number | null;
+	rows_affected: number | null;
+	error: string | null;
+	executed_at: string;
+}
+
 // Redis types
 export interface RedisKeyInfo {
 	key: string;
@@ -622,6 +634,22 @@ export const api = {
 			invoke<SavedQuery>("update_saved_query", { id, data }),
 
 		delete: (id: number) => invoke<boolean>("delete_saved_query", { id }),
+
+		history: (connectionUuid: string) =>
+			invoke<QueryHistory[]>("get_query_history", { connectionUuid }),
+
+		recordHistory: (args: {
+			connectionUuid: string;
+			query: string;
+			status: "success" | "error";
+			timeTakenMs?: number | null;
+			rowCount?: number | null;
+			rowsAffected?: number | null;
+			error?: string | null;
+		}) => invoke<void>("record_query_history", args),
+
+		clearHistory: (connectionUuid: string) =>
+			invoke<boolean>("clear_query_history", { connectionUuid }),
 	},
 
 	settings: {

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -4047,15 +4047,15 @@ export function ConnectionDetails() {
 													>
 														<div className="flex items-center gap-2 w-full">
 															{item.status === "error" ? (
-																<WarningCircle className="w-4 h-4 text-destructive shrink-0" />
+																<WarningCircle className="w-4 h-4 shrink-0 text-destructive group-hover/menu-button:text-sidebar-accent-foreground" />
 															) : (
-																<Check className="w-4 h-4 text-green-600 shrink-0" />
+																<Check className="w-4 h-4 shrink-0 text-green-600 dark:text-green-500 group-hover/menu-button:text-sidebar-accent-foreground" />
 															)}
 															<span className="truncate flex-1 font-mono text-xs">
 																{item.query}
 															</span>
 														</div>
-														<div className="flex items-center gap-2 text-[10px] text-muted-foreground pl-6">
+														<div className="flex items-center gap-2 text-[10px] text-muted-foreground pl-6 group-hover/menu-button:text-sidebar-accent-foreground">
 															<span>{formatHistoryTime(item.executed_at)}</span>
 															{item.status === "success" &&
 															item.time_taken_ms != null ? (

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -27,6 +27,7 @@ import type { SavedQuery } from "@/types/savedQuery";
 import {
 	api,
 	type Connection,
+	type QueryHistory,
 	type RedisKeyDetails,
 	type RedisKeyInfo,
 } from "@/lib/tauri";
@@ -111,6 +112,9 @@ import {
 	Plus,
 	PaintBrush,
 	Gear,
+	ClockCounterClockwise,
+	WarningCircle,
+	Trash,
 } from "@phosphor-icons/react";
 import { DataTable } from "@/components/DataTable";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -345,6 +349,17 @@ function RedisContentHeader({
 	);
 }
 
+// query_history.executed_at is a UTC string from SQLite's datetime('now')
+// with no timezone marker; append "Z" so it parses as UTC, then show local.
+function formatHistoryTime(executedAt: string): string {
+	const iso = executedAt.includes("T")
+		? executedAt
+		: `${executedAt.replace(" ", "T")}Z`;
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) return executedAt;
+	return date.toLocaleString();
+}
+
 export function ConnectionDetails() {
 	const { uuid } = useParams<{ uuid: string }>();
 	const navigate = useNavigate();
@@ -354,11 +369,13 @@ export function ConnectionDetails() {
 	const [loadingPhase, setLoadingPhase] =
 		useState<LoadingPhase>("fetching-config");
 	const [refreshingTables, setRefreshingTables] = useState(false);
-	const [sidebarTab, setSidebarTab] = useState<"objects" | "queries">(
-		"objects",
-	);
+	const [sidebarTab, setSidebarTab] = useState<
+		"objects" | "queries" | "history"
+	>("objects");
 	const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
 	const [loadingQueries, setLoadingQueries] = useState(false);
+	const [queryHistory, setQueryHistory] = useState<QueryHistory[]>([]);
+	const [loadingHistory, setLoadingHistory] = useState(false);
 	const [expandedTables, setExpandedTables] = useState<Set<string>>(new Set());
 	const [tableColumns, setTableColumns] = useState<
 		Record<string, TableColumn[]>
@@ -674,6 +691,51 @@ export function ConnectionDetails() {
 
 		fetchSavedQueries();
 	}, [uuid, sidebarTab]);
+
+	const fetchQueryHistory = useCallback(async () => {
+		if (!uuid) return;
+		try {
+			const data = await api.queries.history(uuid);
+			setQueryHistory(data);
+		} catch (error) {
+			console.error("Failed to fetch query history:", error);
+		}
+	}, [uuid]);
+
+	// Recording lives here, not in the backend pool_execute_query command, on
+	// purpose: that command also serves internal filter/sort/pagination
+	// re-queries (runQueryResultViewQuery), which must NOT pollute history.
+	// Only this layer knows which executeQuery calls are user-initiated runs.
+	// Fire-and-forget; a history failure must never affect the query UX.
+	const recordHistory = useCallback(
+		(
+			query: string,
+			opts: {
+				status: "success" | "error";
+				timeTakenMs?: number | null;
+				rowCount?: number | null;
+				rowsAffected?: number | null;
+				error?: string | null;
+			},
+		) => {
+			if (!uuid) return;
+			api.queries
+				.recordHistory({ connectionUuid: uuid, query, ...opts })
+				// Only live-refresh the panel if it's actually open; otherwise the
+				// tab-switch effect refetches on demand.
+				.then(() => {
+					if (sidebarTab === "history") fetchQueryHistory();
+				})
+				.catch((e) => console.error("Failed to record query history:", e));
+		},
+		[uuid, sidebarTab, fetchQueryHistory],
+	);
+
+	useEffect(() => {
+		if (!uuid || sidebarTab !== "history") return;
+		setLoadingHistory(true);
+		fetchQueryHistory().finally(() => setLoadingHistory(false));
+	}, [uuid, sidebarTab, fetchQueryHistory]);
 
 	const updateTab = useCallback(
 		<T extends Tab>(tabId: string, updates: Partial<T>) => {
@@ -1268,6 +1330,11 @@ export function ConnectionDetails() {
 					affectedRows: null,
 					executing: false,
 				});
+				recordHistory(queryToRun, {
+					status: "error",
+					timeTakenMs: result.time_taken_ms ?? null,
+					error: result.error,
+				});
 				return;
 			}
 
@@ -1284,16 +1351,24 @@ export function ConnectionDetails() {
 					? stripTrailingSemicolon(queryToRun)
 					: null,
 			});
+			recordHistory(queryToRun, {
+				status: "success",
+				timeTakenMs: result.time_taken_ms ?? null,
+				rowCount: result.row_count ?? null,
+				rowsAffected: result.rows_affected ?? null,
+			});
 		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : "Failed to execute query";
 			updateTab<QueryTab>(tab.id, {
-				error:
-					error instanceof Error ? error.message : "Failed to execute query",
+				error: message,
 				executionTime: null,
 				affectedRows: null,
 				executing: false,
 			});
+			recordHistory(queryToRun, { status: "error", error: message });
 		}
-	}, [activeTab, uuid, updateTab, cursorLine, cursorChar]);
+	}, [activeTab, uuid, updateTab, cursorLine, cursorChar, recordHistory]);
 
 	const handleRunAllQueries = useCallback(async () => {
 		if (!activeTab || activeTab.type !== "query" || !uuid) return;
@@ -1333,6 +1408,11 @@ export function ConnectionDetails() {
 
 				if (result.error) {
 					lastError = result.error;
+					recordHistory(queryToRun, {
+						status: "error",
+						timeTakenMs: result.time_taken_ms ?? null,
+						error: result.error,
+					});
 					break;
 				}
 
@@ -1341,6 +1421,12 @@ export function ConnectionDetails() {
 				lastBaseQuery = isWrappableQuery(queryToRun)
 					? stripTrailingSemicolon(queryToRun)
 					: null;
+				recordHistory(queryToRun, {
+					status: "success",
+					timeTakenMs: result.time_taken_ms ?? null,
+					rowCount: result.row_count ?? null,
+					rowsAffected: result.rows_affected ?? null,
+				});
 			}
 
 			if (lastError) {
@@ -1372,7 +1458,7 @@ export function ConnectionDetails() {
 				executing: false,
 			});
 		}
-	}, [activeTab, uuid, updateTab]);
+	}, [activeTab, uuid, updateTab, recordHistory]);
 
 	const handleQueryChange = useCallback(
 		(query: string) => {
@@ -3815,10 +3901,12 @@ export function ConnectionDetails() {
 				<SidebarContent className="overflow-hidden p-2">
 					<Tabs
 						value={sidebarTab}
-						onValueChange={(v) => setSidebarTab(v as "objects" | "queries")}
+						onValueChange={(v) =>
+							setSidebarTab(v as "objects" | "queries" | "history")
+						}
 						className="h-full min-h-0"
 					>
-						<TabsList className="w-full grid grid-cols-2">
+						<TabsList className="w-full grid grid-cols-3">
 							<TabsTrigger value="objects" className="flex items-center gap-2">
 								<Table className="w-4 h-4" />
 								Objects
@@ -3826,6 +3914,10 @@ export function ConnectionDetails() {
 							<TabsTrigger value="queries" className="flex items-center gap-2">
 								<Code className="w-4 h-4" />
 								Queries
+							</TabsTrigger>
+							<TabsTrigger value="history" className="flex items-center gap-2">
+								<ClockCounterClockwise className="w-4 h-4" />
+								History
 							</TabsTrigger>
 						</TabsList>
 						<TabsContent value="objects" className="mt-2 min-h-0 flex-1">
@@ -3906,6 +3998,72 @@ export function ConnectionDetails() {
 														</ContextMenuItem>
 													</ContextMenuContent>
 												</ContextMenu>
+											))}
+										</SidebarMenu>
+									)}
+								</SidebarGroupContent>
+							</SidebarGroup>
+						</TabsContent>
+						<TabsContent value="history" className="mt-2 min-h-0 flex-1 overflow-auto">
+							<SidebarGroup>
+								<div className="flex items-center justify-between pr-2">
+									<SidebarGroupLabel>Recent Queries</SidebarGroupLabel>
+									{queryHistory.length > 0 ? (
+										<button
+											type="button"
+											className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+											onClick={async () => {
+												if (!uuid) return;
+												try {
+													await api.queries.clearHistory(uuid);
+													setQueryHistory([]);
+												} catch (e) {
+													console.error("Failed to clear query history:", e);
+												}
+											}}
+										>
+											<Trash className="w-3 h-3" />
+											Clear
+										</button>
+									) : null}
+								</div>
+								<SidebarGroupContent>
+									{loadingHistory ? (
+										<div className="flex items-center justify-center py-4">
+											<Spinner />
+										</div>
+									) : queryHistory.length === 0 ? (
+										<p className="text-xs text-muted-foreground px-2 py-4 text-center">
+											No query history yet
+										</p>
+									) : (
+										<SidebarMenu>
+											{queryHistory.map((item) => (
+												<SidebarMenuItem key={item.id}>
+													<SidebarMenuButton
+														onClick={() => handleOpenQuery(item.query)}
+														className="h-auto flex-col items-start gap-1 py-2"
+														title={item.error ?? item.query}
+													>
+														<div className="flex items-center gap-2 w-full">
+															{item.status === "error" ? (
+																<WarningCircle className="w-4 h-4 text-destructive shrink-0" />
+															) : (
+																<Check className="w-4 h-4 text-green-600 shrink-0" />
+															)}
+															<span className="truncate flex-1 font-mono text-xs">
+																{item.query}
+															</span>
+														</div>
+														<div className="flex items-center gap-2 text-[10px] text-muted-foreground pl-6">
+															<span>{formatHistoryTime(item.executed_at)}</span>
+															{item.status === "success" &&
+															item.time_taken_ms != null ? (
+																<span>· {item.time_taken_ms} ms</span>
+															) : null}
+														</div>
+													</SidebarMenuButton>
+												</SidebarMenuItem>
 											))}
 										</SidebarMenu>
 									)}


### PR DESCRIPTION
## What

Adds automatic, rolling SQL query history — keeps the **last 10 runs per connection** and surfaces them in a new **History** sidebar tab.

## Why

Running a query returned a result but persisted nothing — once a tab closed, the SQL was gone. This gives a lightweight rolling history scoped per connection (mirrors the existing `saved_queries` pattern).

## How

- **Migration** `005_query_history.sql`: new `query_history` table, FK to `connections` (cascade delete), index on `(connection_uuid, executed_at)`.
- **Backend** (`commands/queries.rs`): `record_query_history` (insert + prune to newest 10 per connection), `get_query_history`, `clear_query_history`.
- **Frontend** (`tauri.ts`, `ConnectionDetails.tsx`): API wrappers + `QueryHistory` type, record on both run paths (single run + run-all), History sidebar tab with click-to-open and Clear.

Stores query text + metadata (status, timing, row counts, error) — **not** result rows.

### Design note
Recording is triggered from the frontend run paths, **not** from `pool_execute_query`, on purpose: that command also serves internal filter/sort/pagination re-queries, which must not pollute history. Only the frontend knows which `executeQuery` calls are user-initiated runs.

## Verify
1. Run several queries (valid + error) against a connection.
2. Open **History** tab → newest-first, status icon + timing.
3. Run >10 queries → only latest 10 remain (rolling prune).
4. Click an item → opens in a tab. Switch connections → lists differ.

## Follow-up (not in this PR)
`ConnectionDetails.tsx` is 4200+ lines; the History panel should be extracted into `components/connection-details/` (matching the recent `ConnectionWelcome` split). Deferred to a separate decomposition PR.