### PR TITLE
Prepare v0.0.55 release

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bump version `0.0.54` → `0.0.55`.

## Changes since v0.0.54
- feat: rolling SQL query history — last 10 runs per connection, with a History sidebar tab (#95)