### PR TITLE
v0.0.56 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@
 - Do not add any gap between icon and text in button, as the component already has it
 - Run shadcn commands inside the src/ directory. Use shadcn cli to install components.
 - Make sure components files don't get too big, split into multiple files if needed.
+- Release PRs should have the `release` tag/label.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bump version `0.0.55` → `0.0.56` in `src-tauri/tauri.conf.json`.