### PR TITLE
fix: Cmd+W closes the active tab (#66); query editor usable on Linux (#83)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,9 +31,11 @@ use commands::queries::{
 use commands::settings::{get_all_settings, get_setting, set_setting};
 use database::pool_manager::PoolManager;
 use tauri::menu::{AboutMetadata, Menu, MenuItem, PredefinedMenuItem, Submenu};
-use tauri::{Manager, WebviewUrl};
+use tauri::{Emitter, Manager, WebviewUrl};
 
 const NEW_WINDOW_MENU_ID: &str = "new_window";
+const CLOSE_TAB_MENU_ID: &str = "close_tab";
+const CLOSE_WINDOW_MENU_ID: &str = "close_window";
 
 fn create_new_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
     let label = format!("window-{}", uuid::Uuid::new_v4());
@@ -46,6 +48,20 @@ fn create_new_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) -> tauri::Res
     }
 
     Ok(())
+}
+
+/// Resolve the window a menu accelerator should act on. Prefers the focused
+/// window (the one the user is interacting with) and falls back to the first
+/// window so single-window setups always have a target.
+fn menu_target_window<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Option<tauri::WebviewWindow<R>> {
+    let windows = app.webview_windows();
+    windows
+        .values()
+        .find(|window| window.is_focused().unwrap_or(false))
+        .or_else(|| windows.values().next())
+        .cloned()
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -115,6 +131,26 @@ pub fn run() {
                 Some("CmdOrCtrl+Shift+N"),
             )?;
 
+            // Cmd/Ctrl+W closes the active in-app tab (not the window). The
+            // predefined close_window item hard-codes Cmd/Ctrl+W and the native
+            // menu intercepts that accelerator before the webview ever sees it,
+            // so closing a tab ended up closing the whole window (issue #66).
+            let close_tab_menu_item = MenuItem::with_id(
+                app_handle,
+                CLOSE_TAB_MENU_ID,
+                "Close Tab",
+                true,
+                Some("CmdOrCtrl+W"),
+            )?;
+
+            let close_window_menu_item = MenuItem::with_id(
+                app_handle,
+                CLOSE_WINDOW_MENU_ID,
+                "Close Window",
+                true,
+                Some("CmdOrCtrl+Shift+W"),
+            )?;
+
             let file_submenu = Submenu::with_items(
                 app_handle,
                 "File",
@@ -122,16 +158,32 @@ pub fn run() {
                 &[
                     &new_window_menu_item,
                     &PredefinedMenuItem::separator(app_handle)?,
-                    &PredefinedMenuItem::close_window(app_handle, Some("Close Window"))?,
+                    &close_tab_menu_item,
+                    &close_window_menu_item,
                 ],
             )?;
 
             Menu::with_items(app_handle, &[&app_submenu, &file_submenu, &edit_submenu])
         })
         .on_menu_event(|app, event| {
-            if event.id() == NEW_WINDOW_MENU_ID {
+            let id = event.id();
+            if id == NEW_WINDOW_MENU_ID {
                 if let Err(error) = create_new_window(app) {
                     eprintln!("Failed to open new window: {error}");
+                }
+            } else if id == CLOSE_TAB_MENU_ID {
+                // Let the frontend close the active tab; it falls back to
+                // closing the window when no tab is open.
+                if let Some(window) = menu_target_window(app) {
+                    if let Err(error) = window.emit("menu:close-tab", ()) {
+                        eprintln!("Failed to emit close-tab event: {error}");
+                    }
+                }
+            } else if id == CLOSE_WINDOW_MENU_ID {
+                if let Some(window) = menu_target_window(app) {
+                    if let Err(error) = window.close() {
+                        eprintln!("Failed to close window: {error}");
+                    }
                 }
             }
         })

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
         "minWidth": 1024,
         "minHeight": 768,
         "titleBarStyle": "Overlay",
-        "dragDropEnabled": true,
+        "dragDropEnabled": false,
         "trafficLightPosition": {
           "x": 19,
           "y": 25

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -32,6 +32,7 @@ import {
 	type RedisKeyInfo,
 } from "@/lib/tauri";
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { toast } from "sonner";
 import { PostgresqlIcon } from "@/components/icons/postgres";
 import { SqliteIcon } from "@/components/icons/sqlite";
@@ -1075,6 +1076,39 @@ export function ConnectionDetails() {
 		setActiveTabId(tabId);
 	}, []);
 
+	// Cmd/Ctrl+W is wired to a native "Close Tab" menu item that emits
+	// "menu:close-tab". Closing the active tab here (instead of letting the
+	// native menu close the window) fixes the whole app closing on tab close
+	// (issue #66). When no tab is open, fall back to closing the window.
+	const closeActiveTabRef = useRef<() => void>(() => {});
+	closeActiveTabRef.current = () => {
+		if (activeTabId) {
+			handleCloseTab(activeTabId);
+		} else {
+			getCurrentWindow().close();
+		}
+	};
+
+	useEffect(() => {
+		let isMounted = true;
+		let unlisten: (() => void) | undefined;
+
+		listen("menu:close-tab", () => {
+			closeActiveTabRef.current();
+		}).then((fn) => {
+			if (isMounted) {
+				unlisten = fn;
+			} else {
+				fn();
+			}
+		});
+
+		return () => {
+			isMounted = false;
+			unlisten?.();
+		};
+	}, []);
+
 	const handleRefreshTables = async () => {
 		if (!uuid || refreshingTables) return;
 
@@ -2008,12 +2042,10 @@ export function ConnectionDetails() {
 				return;
 			}
 
-			// Cmd+W - Close Tab
-			if (e.key === "w" && (e.metaKey || e.ctrlKey) && activeTabId) {
-				e.preventDefault();
-				handleCloseTab(activeTabId);
-				return;
-			}
+			// Cmd+W (Close Tab) is owned by the native menu accelerator, which
+			// emits "menu:close-tab" to the frontend (see the listener below).
+			// Handling it here too would double-close tabs on platforms where
+			// the webview also receives the key event.
 
 			// Cmd+] - Next Tab
 			if (e.key === "]" && (e.metaKey || e.ctrlKey) && tabs.length > 1) {
@@ -2135,11 +2167,9 @@ export function ConnectionDetails() {
 		return () => document.removeEventListener("keydown", handleKeyDown);
 	}, [
 		activeTab,
-		activeTabId,
 		tabs,
 		connection,
 		handleNewQuery,
-		handleCloseTab,
 		handleNextTab,
 		handlePreviousTab,
 		handleToggleSidebar,


### PR DESCRIPTION
## #66 — Closing a query tab closes the whole app

The File menu used `PredefinedMenuItem::close_window`, which hard-binds `Cmd/Ctrl+W`. The native menu intercepts that accelerator before the webview receives it, so the in-app close-tab handler at `ConnectionDetails.tsx` never ran and closing a query tab closed the whole window.

- Custom **Close Tab** item on `Cmd/Ctrl+W` → emits `menu:close-tab` to the focused window; the frontend closes the active tab (falls back to closing the window when no tab is open).
- **Close Window** moved to `Cmd/Ctrl+Shift+W`.
- Removed the now-redundant JS `Cmd+W` keydown branch (would double-close on platforms where the webview also receives the key) and its stale effect deps.
- Emits to the focused window, so it stays correct with multiple windows open.

## #83 — Unable to use the query editor

`dragDropEnabled` was `true` but the app never uses native file drop. On Linux/WebKitGTK the native drag-drop handler swallows pointer events over the webview, which makes the CodeMirror query editor unusable.

- Set `dragDropEnabled: false`. Window dragging via `startDragging()` is unaffected.

> Note: I couldn't view the reporter's screen recording, so the #83 root cause is a strong inference (same reporter as #66, likely on Linux; the flag is unused so the change is low-risk). Left as `Refs` rather than `Closes` so it can be confirmed on Linux before the issue is closed.

### Verification
- `cargo check` passes.
- `tsc --noEmit` introduces no new errors (the one pre-existing Redis `setState` type error is unchanged).

Closes #66
Refs #83
