### PR TITLE
feat: show GitHub star count in landing page header

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -11,6 +11,24 @@ import SEO from "../components/SEO.astro";
 import { ThemeSwitcher } from "../components/ThemeSwitcher";
 
 const year = new Date().getFullYear();
+
+let stars: number | null = null;
+try {
+	const res = await fetch("https://api.github.com/repos/amalshaji/dbcooper", {
+		headers: { Accept: "application/vnd.github+json" },
+	});
+	if (res.ok) {
+		const data = await res.json();
+		stars = typeof data.stargazers_count === "number" ? data.stargazers_count : null;
+	}
+} catch {}
+
+const starLabel =
+	stars === null
+		? null
+		: stars >= 1000
+			? `${(stars / 1000).toFixed(1).replace(/\.0$/, "")}k`
+			: `${stars}`;
 ---
 
 <html lang="en" class="scroll-smooth">
@@ -65,13 +83,16 @@ const year = new Date().getFullYear();
 						href="https://github.com/amalshaji/dbcooper"
 						target="_blank"
 						aria-label="GitHub"
-						class="text-faint hover:text-copper transition-colors"
+						class="flex items-center gap-1.5 text-faint hover:text-copper transition-colors"
 					>
 						<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"
 							><path
 								d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
 							></path></svg
 						>
+						{starLabel && (
+							<span class="font-mono text-xs tabular-nums">{starLabel}</span>
+						)}
 					</a>
 					<ThemeSwitcher client:load />
 				</div>


### PR DESCRIPTION
Adds live GitHub star count next to the GitHub icon in the landing page header.

## What
- Build-time fetch of `stargazers_count` from the GitHub API in `index.astro` frontmatter.
- Renders count next to the existing GitHub icon (mono, tabular-nums). `1000+` formats as `1.2k`.
- Wrapped in try/catch — if the fetch fails, the count is omitted and the build still succeeds.

## Note
Count is baked at build time, so it refreshes on each deploy rather than per page load.