### PR TITLE
ci: auto-push homebrew cask bump on release publish

### DIFF
--- a/.github/workflows/update-brew-cask.yml
+++ b/.github/workflows/update-brew-cask.yml
@@ -1,0 +1,39 @@
+name: update-brew-cask
+
+# Bump the DBcooper cask in amalshaji/homebrew-taps whenever a release is
+# published. Uses Homebrew's canonical `brew bump-cask-pr --write-only` to
+# recompute the version + sha256 (downloading the new DMG), then pushes the
+# resulting commit straight to the tap — no intermediate PR to merge.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  cask:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bump cask and push to tap
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          brew tap amalshaji/taps
+          tap_dir="$(brew --repository amalshaji/taps)"
+
+          git -C "$tap_dir" config user.name "github-actions[bot]"
+          git -C "$tap_dir" config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Edit only version + sha256 in the tap cask and commit it locally.
+          brew bump-cask-pr \
+            --version="${TAG#v}" \
+            --write-only --commit --no-audit \
+            amalshaji/taps/dbcooper
+
+          # Push the commit straight to the tap's default branch.
+          git -C "$tap_dir" remote set-url origin \
+            "https://x-access-token:${TAP_TOKEN}@github.com/amalshaji/homebrew-taps.git"
+          git -C "$tap_dir" push origin HEAD:main


### PR DESCRIPTION
## What
When a release is **published**, auto-update the DBcooper cask in `amalshaji/homebrew-taps`. Users get new versions via `brew upgrade --cask dbcooper`.

## How
`brew bump-cask-pr --write-only --commit` recomputes `version` + `sha256` (downloads the new DMG), editing only those two lines and preserving the rest of the cask. The commit is then pushed **straight to the tap** — no intermediate PR to merge.

Fires on `release: published`, so your manual "publish the draft release" step remains the only human gate. After you publish, the tap update is automatic.

## Required setup
Repo secret **`HOMEBREW_TAP_TOKEN`** — PAT with **Contents: read/write** on `amalshaji/homebrew-taps`. (PR scope not needed with direct push.)

## Note
v0.0.56 cask already on the tap, so `brew install --cask amalshaji/taps/dbcooper` works today. First live exercise of this workflow = v0.0.57.