### PR TITLE
v0.0.57 release

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bump version 0.0.56 → 0.0.57.

Merging this (with the `release` label) triggers `tag-on-merge` → tags `v0.0.57` → `publish.yml` builds the macOS DMG and creates a **draft** release.

After you publish the draft, the new `update-brew-cask` workflow auto-pushes the cask bump to `amalshaji/homebrew-taps`. **First live test of the brew automation.**