### PR TITLE
ci: run update-brew-cask on macos-latest

### DIFF
--- a/.github/workflows/update-brew-cask.yml
+++ b/.github/workflows/update-brew-cask.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   cask:
     if: ${{ !github.event.release.prerelease }}
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Bump cask and push to tap
         env:


### PR DESCRIPTION
## Why
The `update-brew-cask` job failed on the v0.0.57 release with `brew: command not found` (exit 127) — `ubuntu-latest` runners have no Homebrew on PATH.

## Fix
Switch the job to `macos-latest`, which ships Homebrew preinstalled. The cask tooling (`brew bump-cask-pr`) is macOS-native anyway.

## Note
The v0.0.57 cask was bumped manually on the tap, so `brew install/upgrade --cask amalshaji/taps/dbcooper` already serves 0.0.57. This fix makes the **next** release auto-bump cleanly.