### PR TITLE
v0.0.58 release

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bump version 0.0.57 → 0.0.58.

Merging this (with the `release` label) triggers `tag-on-merge` → tags `v0.0.58` → `publish.yml` builds the macOS DMG and creates a **draft** release.

After you publish the draft, `update-brew-cask` (now on `macos-latest`) auto-pushes the cask bump to `amalshaji/homebrew-taps`. **First clean end-to-end run of the brew automation.**