### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ A database client for PostgreSQL, SQLite, Redis, and ClickHouse, built with Taur
 
 ## Installation
 
+### Homebrew (recommended)
+
+```bash
+brew install --cask --force amalshaji/taps/dbcooper
+```
+
+Homebrew clears the Gatekeeper quarantine automatically, so the app opens right away.
+
+### Direct download
+
 Download the latest `.dmg` from [Releases](https://github.com/amalshaji/dbcooper/releases).
 
 **macOS users:** After installing (**before opening the app the first time**), bypass Gatekeeper since the app isn't notarized:

--- a/docs/src/components/DownloadButton.tsx
+++ b/docs/src/components/DownloadButton.tsx
@@ -17,6 +17,16 @@ export function DownloadButton() {
 
 	return (
 		<div className="flex flex-col items-start gap-4">
+			{/* Homebrew — recommended install */}
+			<div className="w-full max-w-md rounded-lg border border-line bg-surface/60 p-3 font-mono text-[11px] leading-relaxed text-soft">
+				<span className="text-faint"># install with Homebrew (recommended)</span>
+				<br />
+				<span className="select-all">
+					<span className="text-copper">$</span> brew install --cask --force
+					amalshaji/taps/dbcooper
+				</span>
+			</div>
+
 			<div className="flex flex-wrap items-center gap-3">
 				<a
 					href="https://github.com/amalshaji/dbcooper/releases/latest"
@@ -50,7 +60,7 @@ export function DownloadButton() {
 			{/* macOS gatekeeper note, styled as a terminal comment */}
 			<div className="w-full max-w-md rounded-lg border border-line bg-surface/60 p-3 font-mono text-[11px] leading-relaxed text-soft">
 				<span className="text-faint">
-					# unsigned build — clear quarantine before first launch
+					# direct .dmg download — clear quarantine before first launch
 				</span>
 				<br />
 				<span className="select-all">


### PR DESCRIPTION
## What
Surface Homebrew as the recommended install method.

```
brew install --cask --force amalshaji/taps/dbcooper
```

- **README** — new "Homebrew (recommended)" section above the direct `.dmg` download.
- **Landing page** (`DownloadButton.tsx`) — copyable Homebrew command block as the primary install, above the download buttons.

## Note
Homebrew strips the Gatekeeper quarantine via the cask `postflight`, so brew users skip the manual `xattr` step. The Gatekeeper note is reworded to apply only to the direct `.dmg` path.