### PR TITLE
fix: connection status handling and pool lifecycle

### DIFF
--- a/src-tauri/src/commands/pool.rs
+++ b/src-tauri/src/commands/pool.rs
@@ -63,6 +63,11 @@ pub async fn pool_connect(
         },
     };
 
+    // Serialize with data-op (re)connects for this UUID so a UI-initiated
+    // connect can't race a concurrent ensure_connection/reconnect.
+    let lock = pool_manager.get_connect_lock(&uuid).await;
+    let _guard = lock.lock().await;
+
     match pool_manager.connect(&uuid, config).await {
         Ok(_) => Ok(ConnectionStatusResponse {
             status: ConnectionStatus::Connected,

--- a/src-tauri/src/database/pool_manager.rs
+++ b/src-tauri/src/database/pool_manager.rs
@@ -6,7 +6,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
 use tokio::sync::{Mutex, RwLock};
 
 use super::clickhouse::ClickhouseDriver;
@@ -56,7 +55,6 @@ struct PoolEntry {
     driver: Arc<Box<dyn DatabaseDriver>>,
     config: ConnectionConfig,
     status: ConnectionStatus,
-    last_used: Instant,
     last_error: Option<String>,
     #[allow(dead_code)]
     ssh_tunnel: Option<SshTunnel>,
@@ -204,26 +202,6 @@ impl PoolManager {
         }
     }
 
-    /// Get or create a connection for the given UUID
-    pub async fn get_connection(
-        &self,
-        uuid: &str,
-        config: ConnectionConfig,
-    ) -> Result<Arc<Box<dyn DatabaseDriver>>, String> {
-        // Check if we have an existing connected pool
-        {
-            let pools = self.pools.read().await;
-            if let Some(entry) = pools.get(uuid) {
-                if entry.status == ConnectionStatus::Connected {
-                    return Ok(entry.driver.clone());
-                }
-            }
-        }
-
-        // Need to create or reconnect
-        self.connect(uuid, config).await
-    }
-
     /// Explicitly connect (or reconnect) a connection
     pub async fn connect(
         &self,
@@ -255,7 +233,6 @@ impl PoolManager {
             driver: driver.clone(),
             config,
             status: status.clone(),
-            last_used: Instant::now(),
             last_error: if test_result.success {
                 None
             } else {
@@ -296,23 +273,6 @@ impl PoolManager {
     pub async fn get_last_error(&self, uuid: &str) -> Option<String> {
         let pools = self.pools.read().await;
         pools.get(uuid).and_then(|e| e.last_error.clone())
-    }
-
-    /// Update last used time for a connection
-    pub async fn touch(&self, uuid: &str) {
-        let mut pools = self.pools.write().await;
-        if let Some(entry) = pools.get_mut(uuid) {
-            entry.last_used = Instant::now();
-        }
-    }
-
-    /// Mark a connection as disconnected (e.g., after an error)
-    pub async fn mark_disconnected(&self, uuid: &str, error: Option<String>) {
-        let mut pools = self.pools.write().await;
-        if let Some(entry) = pools.get_mut(uuid) {
-            entry.status = ConnectionStatus::Disconnected;
-            entry.last_error = error;
-        }
     }
 
     /// Perform a health check on a connection

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -13,29 +13,25 @@ type Status = "connected" | "disconnected" | "reconnecting";
 
 interface ConnectionStatusProps {
 	connectionUuid: string;
-	initialStatus?: "connected" | "disconnected";
+	status: "connected" | "disconnected";
 	onReconnect?: () => Promise<void>;
 	onStatusChange?: (status: "connected" | "disconnected") => void;
 }
 
 export function ConnectionStatus({
 	connectionUuid,
-	initialStatus = "connected",
+	status: controlledStatus,
 	onReconnect,
 	onStatusChange,
 }: ConnectionStatusProps) {
 	const [isReconnecting, setIsReconnecting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const [currentStatus, setCurrentStatus] = useState<"connected" | "disconnected">(initialStatus);
 	const isMounted = useRef(true);
 	const isCheckingHealth = useRef(false);
 
-	const status: Status = isReconnecting ? "reconnecting" : currentStatus;
-
-	// Sync with initialStatus prop changes
-	useEffect(() => {
-		setCurrentStatus(initialStatus);
-	}, [initialStatus]);
+	// Parent owns the connected/disconnected truth; this component only layers
+	// the transient "reconnecting" state on top and reports changes upward.
+	const status: Status = isReconnecting ? "reconnecting" : controlledStatus;
 
 	const reconnect = useCallback(async () => {
 		if (!isMounted.current) return;
@@ -49,7 +45,6 @@ export function ConnectionStatus({
 				await api.pool.connect(connectionUuid);
 			}
 			if (isMounted.current) {
-				setCurrentStatus("connected");
 				setError(null);
 				onStatusChange?.("connected");
 			}
@@ -72,7 +67,7 @@ export function ConnectionStatus({
 	}, []);
 
 	useEffect(() => {
-		if (currentStatus !== "connected") return;
+		if (controlledStatus !== "connected") return;
 
 		const performHealthCheck = async () => {
 			if (!isMounted.current || isCheckingHealth.current) return;
@@ -82,14 +77,12 @@ export function ConnectionStatus({
 				const result = await api.pool.healthCheck(connectionUuid);
 				if (isMounted.current) {
 					if (!result.success) {
-						setCurrentStatus("disconnected");
 						setError(result.message || "Connection lost");
 						onStatusChange?.("disconnected");
 					}
 				}
 			} catch (err) {
 				if (isMounted.current) {
-					setCurrentStatus("disconnected");
 					setError(err instanceof Error ? err.message : "Health check failed");
 					onStatusChange?.("disconnected");
 				}
@@ -101,7 +94,7 @@ export function ConnectionStatus({
 		const interval = setInterval(performHealthCheck, 15000);
 
 		return () => clearInterval(interval);
-	}, [connectionUuid, currentStatus, onStatusChange]);
+	}, [connectionUuid, controlledStatus, onStatusChange]);
 
 	const statusColors = {
 		connected: "bg-green-500",

--- a/src/components/connection-details/DisconnectedScreen.tsx
+++ b/src/components/connection-details/DisconnectedScreen.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { ArrowsClockwise, X } from "@phosphor-icons/react";
+import { handleDragStart } from "@/lib/windowDrag";
+
+interface DisconnectedScreenProps {
+	connectionName: string;
+	databaseIcon: ReactNode;
+	error: string | null;
+	onReconnect: () => Promise<void>;
+	onClose: () => void;
+}
+
+/**
+ * Full-screen takeover shown when the initial connect fails, instead of the
+ * empty workspace shell. Owns its own retry-in-flight state.
+ */
+export function DisconnectedScreen({
+	connectionName,
+	databaseIcon,
+	error,
+	onReconnect,
+	onClose,
+}: DisconnectedScreenProps) {
+	const [isReconnecting, setIsReconnecting] = useState(false);
+
+	const handleRetry = async () => {
+		setIsReconnecting(true);
+		try {
+			await onReconnect();
+		} catch {
+			// failure already surfaced upstream via toast + the error prop
+		} finally {
+			setIsReconnecting(false);
+		}
+	};
+
+	return (
+		<div className="flex flex-col h-screen">
+			<header
+				onMouseDown={handleDragStart}
+				className="flex h-12 shrink-0 items-center gap-2 border-b pl-20 pr-4 bg-background sticky top-0 z-20 select-none"
+			>
+				<div className="flex items-center gap-2 flex-1 ml-4">
+					<Button variant="ghost" size="sm" onClick={onClose} className="gap-2">
+						<X className="w-4 h-4" />
+						Close Connection
+					</Button>
+					<span className="font-semibold">{connectionName}</span>
+				</div>
+			</header>
+			<div className="flex-1 flex items-center justify-center bg-background">
+				<div className="flex flex-col items-center gap-5 max-w-md px-6 text-center">
+					<div className="shrink-0 opacity-50">{databaseIcon}</div>
+					<div className="flex flex-col gap-2">
+						<h2 className="text-lg font-semibold">Connection failed</h2>
+						<p className="text-sm text-muted-foreground">
+							Couldn't connect to {connectionName}.
+						</p>
+						{error && (
+							<p className="text-sm text-red-500 break-words">{error}</p>
+						)}
+					</div>
+					<div className="flex items-center gap-2">
+						<Button
+							onClick={handleRetry}
+							disabled={isReconnecting}
+							className="gap-2"
+						>
+							{isReconnecting ? (
+								<Spinner className="w-4 h-4" />
+							) : (
+								<ArrowsClockwise className="w-4 h-4" />
+							)}
+							Retry connection
+						</Button>
+						<Button variant="ghost" onClick={onClose}>
+							Close
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -132,6 +132,7 @@ import { ConnectionStatus } from "@/components/ConnectionStatus";
 import { FunctionDefinitionView } from "@/components/connection-details/FunctionDefinitionView";
 import { ObjectExplorer } from "@/components/connection-details/ObjectExplorer";
 import { ConnectionWelcome } from "@/components/connection-details/ConnectionWelcome";
+import { DisconnectedScreen } from "@/components/connection-details/DisconnectedScreen";
 import { handleDragStart } from "@/lib/windowDrag";
 import { SchemaVisualizer } from "@/components/SchemaVisualizer";
 import { CommandPalette } from "@/components/CommandPalette";
@@ -278,7 +279,7 @@ function ContentHeader({
 			<div className="flex items-center gap-3">
 				<ConnectionStatus
 					connectionUuid={connection.uuid}
-					initialStatus={connectionStatus}
+					status={connectionStatus}
 					onReconnect={onReconnect}
 					onStatusChange={onStatusChange}
 				/>
@@ -335,7 +336,7 @@ function RedisContentHeader({
 			<div className="flex items-center gap-3">
 				<ConnectionStatus
 					connectionUuid={connection.uuid}
-					initialStatus={connectionStatus}
+					status={connectionStatus}
 					onReconnect={onReconnect}
 					onStatusChange={onStatusChange}
 				/>
@@ -389,6 +390,23 @@ export function ConnectionDetails() {
 	const [connectionStatus, setConnectionStatus] = useState<
 		"connected" | "disconnected"
 	>("connected");
+	const [connectionError, setConnectionError] = useState<string | null>(null);
+	// True once we've connected at least once. Distinguishes an initial
+	// connect failure (show takeover screen) from a mid-session drop after
+	// data already loaded (keep the workspace, reconnect via the badge).
+	const [hasEverConnected, setHasEverConnected] = useState(false);
+
+	// Connection state always moves as a unit; funnel every transition through
+	// these two so callers can't set status without its matching error/flag.
+	const markConnected = useCallback(() => {
+		setConnectionStatus("connected");
+		setConnectionError(null);
+		setHasEverConnected(true);
+	}, []);
+	const markDisconnected = useCallback((error: string) => {
+		setConnectionStatus("disconnected");
+		setConnectionError(error);
+	}, []);
 
 	// Tab state
 	const [tabs, setTabs] = useState<Tab[]>([]);
@@ -574,6 +592,15 @@ export function ConnectionDetails() {
 		}
 	}, [uuid, navigate]);
 
+	// Tear down the pooled driver (and any SSH tunnel) when leaving this
+	// connection so connections/tunnels don't leak for the app's lifetime.
+	useEffect(() => {
+		if (!uuid) return;
+		return () => {
+			api.pool.disconnect(uuid).catch(() => {});
+		};
+	}, [uuid]);
+
 	const fetchSchemaOverviewData = useCallback(async () => {
 		if (!uuid) return;
 
@@ -589,7 +616,7 @@ export function ConnectionDetails() {
 				type: (table.type === "view" ? "view" : "table") as "table" | "view",
 			}));
 			setTables(tablesList);
-			setConnectionStatus("connected");
+			markConnected();
 
 			const tableDataMap: Record<string, TableColumn[]> = {};
 			data.tables.forEach((table) => {
@@ -615,16 +642,16 @@ export function ConnectionDetails() {
 			console.error("Failed to fetch schema overview:", error);
 			setSchemaOverview(null);
 			setTables([]);
-			setConnectionStatus("disconnected");
 			const errorMessage =
 				error instanceof Error ? error.message : String(error);
+			markDisconnected(errorMessage);
 			toast.error("Connection failed", {
 				description: errorMessage,
 			});
 		} finally {
 			setLoadingSchemaOverview(false);
 		}
-	}, [uuid]);
+	}, [uuid, markConnected, markDisconnected]);
 
 	// Reset loading flag when connection changes
 	useEffect(() => {
@@ -646,21 +673,23 @@ export function ConnectionDetails() {
 				const connectResult = await api.pool.connect(uuid!);
 
 				if (connectResult.status === "connected") {
-					setConnectionStatus("connected");
+					markConnected();
 					if (connection.type !== "redis") {
 						setLoadingPhase("loading-schema");
 						await fetchSchemaOverviewData();
 					}
 				} else {
-					setConnectionStatus("disconnected");
+					const message = connectResult.error || "Connection failed";
+					markDisconnected(message);
 					toast.error("Connection failed", {
-						description: connectResult.error || "Connection failed",
+						description: message,
 					});
 				}
 			} catch (error) {
-				setConnectionStatus("disconnected");
+				const message = error instanceof Error ? error.message : String(error);
+				markDisconnected(message);
 				toast.error("Connection failed", {
-					description: error instanceof Error ? error.message : String(error),
+					description: message,
 				});
 			} finally {
 				setLoadingPhase("complete");
@@ -669,7 +698,7 @@ export function ConnectionDetails() {
 
 		loadData().catch((error) => {
 			console.error("Failed to load connection data:", error);
-			setConnectionStatus("disconnected");
+			markDisconnected(error instanceof Error ? error.message : String(error));
 			setLoadingPhase("complete");
 		});
 		// Only depend on connection and loadingPhase, not the callbacks
@@ -1038,18 +1067,20 @@ export function ConnectionDetails() {
 		if (!uuid) return;
 		const connectResult = await api.pool.connect(uuid);
 		if (connectResult.status === "connected") {
-			setConnectionStatus("connected");
+			markConnected();
 			toast.success("Reconnected successfully");
 			if (connection?.type !== "redis") {
 				await fetchSchemaOverviewData();
 			}
 		} else {
+			const message = connectResult.error || "Connection failed";
+			markDisconnected(message);
 			toast.error("Reconnection failed", {
-				description: connectResult.error || "Connection failed",
+				description: message,
 			});
-			throw new Error(connectResult.error || "Connection failed");
+			throw new Error(message);
 		}
-	}, [uuid, connection?.type, fetchSchemaOverviewData]);
+	}, [uuid, connection?.type, fetchSchemaOverviewData, markConnected, markDisconnected]);
 
 	const handleCloseTab = useCallback(
 		(tabId: string) => {
@@ -3836,6 +3867,24 @@ export function ConnectionDetails() {
 				return renderEmptyState();
 		}
 	};
+
+	// Initial connect failed: show a dedicated error screen instead of the
+	// empty workspace shell. A mid-session drop (after connecting at least
+	// once) keeps the workspace and reconnects via the header status badge.
+	const showDisconnectedScreen =
+		connectionStatus === "disconnected" && !hasEverConnected;
+
+	if (showDisconnectedScreen) {
+		return (
+			<DisconnectedScreen
+				connectionName={connection.name}
+				databaseIcon={getDatabaseIcon()}
+				error={connectionError}
+				onReconnect={handleReconnect}
+				onClose={() => navigate("/")}
+			/>
+		);
+	}
 
 	// Redis-specific layout without sidebar or tabs
 	if (connection.type === "redis") {


### PR DESCRIPTION
## Problem

A failed database connection still rendered the full "Welcome" workspace (empty sidebar, `0 objects`) with only a small "Disconnected" badge — see below. The render gate keyed off `loadingPhase` alone, and `loadData`'s `finally` forced `loadingPhase = "complete"` even on failure, so a failed connect fell straight through to the workspace shell. The nicely-designed "Connection failed" loader state was effectively unreachable.

While in here, fixed the surrounding status/retry/pooling issues that made the area fragile.

## Changes

**UI / connection status**
- Dedicated **error screen** on initial connect failure: shows the real error message and a Retry button instead of the empty workspace. Extracted as `DisconnectedScreen`. A mid-session drop (after connecting at least once) still keeps the workspace and reconnects via the header badge.
- `ConnectionStatus` is now a **controlled component**. Status has a single owner (the page); the badge only layers the transient "reconnecting" state and reports changes up. Removes the prop↔state two-way sync that could flicker/desync on reconnect.
- Every connection-state transition goes through `markConnected` / `markDisconnected`, so status, error, and the has-ever-connected flag always move as a unit.

**Pooling / lifecycle**
- **Disconnect on unmount**: tear down the pooled driver (and any SSH tunnel) when leaving a connection. `pool_disconnect` existed but had zero callers, so drivers and SSH tunnels leaked for the app's lifetime.
- `pool_connect` now takes the per-uuid connect lock like the data-op paths, so a UI-initiated connect can't race a concurrent reconnect.
- Removed dead `pool_manager` code (`touch`, `last_used`, `get_connection`, `mark_disconnected`).

## Testing

- `cargo check`: clean (0 warnings/errors).
- `tsc --noEmit`: no new type errors in changed files.
- Not run live; happy to verify the error screen + retry in-app on request.

## Follow-ups (not in this PR)

- `ConnectionDetails.tsx` is a ~4.3k-line god-component (pre-existing). Decomposing the Redis view + tab renderers would roughly halve it.
- Connection state could become a discriminated union (`idle|connected|failed|lost`), deleting the has-ever-connected flag and making illegal states unrepresentable — deferred to avoid churning the loader's status reads on a critical path.
