### PR TITLE
v0.0.59 release

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

- bump the Tauri app version from 0.0.58 to 0.0.59
- prepare the next release containing the changes merged since v0.0.58

Merging this PR with the release label triggers tag-on-merge, creates v0.0.59, and starts the draft macOS release build.

## Validation

- bun run build
- cargo test --no-run
- cargo test --lib -- --test-threads=1 (4 passed)
- cargo test --test sqlite_integration_tests --test app_data_tests -- --test-threads=1 (47 passed)
- version JSON assertion and git diff --check

## Existing main-branch issues

- bun run lint cannot start because the root project has no ESLint 9 flat config
- bunx tsc --noEmit -p tsconfig.json reports existing source type errors unrelated to this version-only change