### PR TITLE
v0.0.61 release

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

- bump the Tauri app version from `0.0.60` to `0.0.61`
- release the structured table filters, bounded and virtualized result grids, and contextual AI query drafts merged since `v0.0.60`
- include the merged `serde_with` dependency update

Merging this PR with the `release` label triggers `tag-on-merge`, creates `v0.0.61`, and starts the draft macOS release build.

## Validation

- `bun run build`
- 22 frontend AI, SQL-safety, and result-filter tests passed
- `cargo test --lib --test sqlite_integration_tests --test app_data_tests -- --test-threads=1` — 60 passed, 1 intentionally ignored
- million-row SQLite window benchmark — 100 rows loaded in 7.49 ms
- version JSON assertion and `git diff --check`

## Existing main-branch issues

- `cargo fmt --check` reports pre-existing formatting differences in `src-tauri/src/database/queries/mod.rs` and `src-tauri/tests/unified_commands_tests.rs`; this version-only PR leaves them untouched
- GitHub currently reports 9 dependency alerts on the default branch (2 high, 4 moderate, 3 low)