### PR TITLE
v0.0.62 release

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- bump the Tauri app version from `0.0.61` to `0.0.62`
- release the roadmap and refreshed application UI merged in #120

## Validation
- `bun run build`
- `bun test` (22 tests)
- `cargo test --lib` (11 tests)
- `cd docs && bun run build`
- `git diff --check`

## Release
Merging this PR with the `release` label triggers `tag-on-merge.yml`, which creates `v0.0.62` and runs the macOS draft-release workflow. The previous `v0.0.61` tag remains the rollback point.