### PR TITLE
Improve table filter UX and type handling

### DIFF
--- a/src-tauri/src/commands/postgres.rs
+++ b/src-tauri/src/commands/postgres.rs
@@ -1,3 +1,4 @@
+use crate::database::filter::{classify_column_type, FilterDialect};
 use crate::database::{query_returns_rows, MAX_QUERY_RESULT_ROWS};
 use crate::db::models::{
     ColumnInfo, ForeignKeyInfo, IndexInfo, QueryResult, TableDataResponse, TableInfo,
@@ -428,6 +429,7 @@ pub async fn get_table_structure(
             .map(
                 |(name, data_type, nullable, default, primary_key)| ColumnInfo {
                     name,
+                    filter_kind: classify_column_type(&data_type, FilterDialect::Postgres),
                     data_type,
                     nullable,
                     default,

--- a/src-tauri/src/database/clickhouse.rs
+++ b/src-tauri/src/database/clickhouse.rs
@@ -136,6 +136,7 @@ impl ClickhouseDriver {
                     FilterValue::Integer(value) => value.to_string(),
                     FilterValue::Float(value) => value.to_string(),
                     FilterValue::Boolean(value) => u8::from(*value).to_string(),
+                    FilterValue::ExactNumber { value, .. } => value.clone(),
                 };
                 (format!("param_f{index}"), value)
             })
@@ -272,10 +273,7 @@ impl DatabaseDriver for ClickhouseDriver {
             let columns = self
                 .get_table_structure(&self.config.database, table)
                 .await?
-                .columns
-                .into_iter()
-                .map(|column| column.name)
-                .collect::<Vec<_>>();
+                .columns;
             Some(compile_filter(
                 expression,
                 &columns,

--- a/src-tauri/src/database/clickhouse.rs
+++ b/src-tauri/src/database/clickhouse.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use super::filter::{
-    build_where_clause, compile_filter, structured_expression, FilterDialect, FilterValue,
+    build_where_clause, classify_column_type, compile_filter, structured_expression, FilterDialect,
+    FilterValue,
 };
 use super::{DatabaseDriver, MAX_QUERY_RESULT_ROWS};
 use crate::database::queries::clickhouse::{
@@ -360,6 +361,7 @@ impl DatabaseDriver for ClickhouseDriver {
                 let nullable = data_type.starts_with("Nullable");
                 ColumnInfo {
                     name: col["name"].as_str().unwrap_or("").to_string(),
+                    filter_kind: classify_column_type(&data_type, FilterDialect::Clickhouse),
                     data_type,
                     nullable,
                     default: {
@@ -482,6 +484,7 @@ impl DatabaseDriver for ClickhouseDriver {
 
                         columns.push(ColumnInfo {
                             name: col_name,
+                            filter_kind: classify_column_type(&col_type, FilterDialect::Clickhouse),
                             data_type: col_type,
                             nullable,
                             default,

--- a/src-tauri/src/database/filter.rs
+++ b/src-tauri/src/database/filter.rs
@@ -1,14 +1,111 @@
-use crate::db::models::{FilterConjunction, FilterExpression, FilterOperator, TableFilter};
+use crate::db::models::{
+    FilterColumnKind, FilterConjunction, FilterExpression, FilterOperator, TableFilter,
+};
 use serde_json::Value;
 
 const MAX_CONDITIONS: usize = 20;
 const MAX_IN_VALUES: usize = 100;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FilterDialect {
     Postgres,
     Sqlite,
     Clickhouse,
+}
+
+fn normalize_clickhouse_type(data_type: &str) -> String {
+    let mut normalized = data_type.trim().to_string();
+
+    loop {
+        let lower = normalized.to_ascii_lowercase();
+        let wrapper = ["nullable", "lowcardinality"]
+            .into_iter()
+            .find(|wrapper| lower.starts_with(&format!("{wrapper}(")));
+        let Some(wrapper) = wrapper else {
+            break;
+        };
+        let prefix_len = wrapper.len() + 1;
+        if !normalized.ends_with(')') {
+            break;
+        }
+        normalized = normalized[prefix_len..normalized.len() - 1]
+            .trim()
+            .to_string();
+    }
+
+    normalized
+}
+
+pub fn classify_column_type(data_type: &str, dialect: FilterDialect) -> FilterColumnKind {
+    let normalized = data_type.trim().to_ascii_lowercase();
+
+    match dialect {
+        FilterDialect::Postgres => match normalized.as_str() {
+            "smallint" | "integer" | "bigint" | "smallserial" | "serial" | "bigserial" => {
+                FilterColumnKind::Integer
+            }
+            "numeric" | "decimal" | "real" | "double precision" | "money" => {
+                FilterColumnKind::Decimal
+            }
+            "boolean" => FilterColumnKind::Boolean,
+            "date"
+            | "time"
+            | "time without time zone"
+            | "time with time zone"
+            | "timestamp"
+            | "timestamp without time zone"
+            | "timestamp with time zone"
+            | "interval" => FilterColumnKind::Temporal,
+            "uuid" => FilterColumnKind::Uuid,
+            "text" | "character" | "character varying" | "citext" | "name" => {
+                FilterColumnKind::Text
+            }
+            _ => FilterColumnKind::Other,
+        },
+        FilterDialect::Sqlite => {
+            if normalized == "boolean" || normalized == "bool" {
+                return FilterColumnKind::Boolean;
+            }
+            if normalized.contains("date") || normalized.contains("time") {
+                return FilterColumnKind::Temporal;
+            }
+
+            let declared_type = normalized.to_ascii_uppercase();
+            if declared_type.contains("INT") {
+                FilterColumnKind::Integer
+            } else if ["CHAR", "CLOB", "TEXT"]
+                .iter()
+                .any(|token| declared_type.contains(token))
+            {
+                FilterColumnKind::Text
+            } else if declared_type.is_empty() || declared_type.contains("BLOB") {
+                FilterColumnKind::Other
+            } else {
+                FilterColumnKind::Decimal
+            }
+        }
+        FilterDialect::Clickhouse => {
+            let base_type = normalize_clickhouse_type(data_type).to_ascii_lowercase();
+            if base_type == "string" || base_type.starts_with("fixedstring(") {
+                FilterColumnKind::Text
+            } else if base_type == "bool" || base_type == "boolean" {
+                FilterColumnKind::Boolean
+            } else if base_type == "uuid" {
+                FilterColumnKind::Uuid
+            } else if ["date", "date32", "time", "time64", "datetime", "datetime64"]
+                .iter()
+                .any(|name| base_type == *name || base_type.starts_with(&format!("{name}(")))
+            {
+                FilterColumnKind::Temporal
+            } else if base_type.starts_with("int") || base_type.starts_with("uint") {
+                FilterColumnKind::Integer
+            } else if base_type.starts_with("float") || base_type.starts_with("decimal") {
+                FilterColumnKind::Decimal
+            } else {
+                FilterColumnKind::Other
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -215,7 +312,9 @@ fn placeholder(index: usize, value: &FilterValue, dialect: FilterDialect) -> Str
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::models::{FilterCondition, FilterConjunction, FilterExpression, FilterOperator};
+    use crate::db::models::{
+        FilterColumnKind, FilterCondition, FilterConjunction, FilterExpression, FilterOperator,
+    };
     use serde_json::json;
 
     fn expression(condition: FilterCondition) -> FilterExpression {
@@ -223,6 +322,34 @@ mod tests {
             conjunction: FilterConjunction::And,
             conditions: vec![condition],
         }
+    }
+
+    #[test]
+    fn classifies_column_types_by_database_dialect() {
+        assert_eq!(
+            classify_column_type("STRING", FilterDialect::Sqlite),
+            FilterColumnKind::Decimal
+        );
+        assert_eq!(
+            classify_column_type("FLOATING POINT", FilterDialect::Sqlite),
+            FilterColumnKind::Integer
+        );
+        assert_eq!(
+            classify_column_type("String", FilterDialect::Clickhouse),
+            FilterColumnKind::Text
+        );
+        assert_eq!(
+            classify_column_type("Nullable(UInt128)", FilterDialect::Clickhouse),
+            FilterColumnKind::Integer
+        );
+        assert_eq!(
+            classify_column_type("Decimal(38, 18)", FilterDialect::Clickhouse),
+            FilterColumnKind::Decimal
+        );
+        assert_eq!(
+            classify_column_type("timestamp with time zone", FilterDialect::Postgres),
+            FilterColumnKind::Temporal
+        );
     }
 
     #[test]

--- a/src-tauri/src/database/filter.rs
+++ b/src-tauri/src/database/filter.rs
@@ -1,5 +1,5 @@
 use crate::db::models::{
-    FilterColumnKind, FilterConjunction, FilterExpression, FilterOperator, TableFilter,
+    ColumnInfo, FilterColumnKind, FilterConjunction, FilterExpression, FilterOperator, TableFilter,
 };
 use serde_json::Value;
 
@@ -114,6 +114,7 @@ pub enum FilterValue {
     Integer(i64),
     Float(f64),
     Boolean(bool),
+    ExactNumber { value: String, data_type: String },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -156,7 +157,7 @@ fn normalize_advanced_filter(filter: &str) -> String {
 
 pub fn compile_filter(
     expression: &FilterExpression,
-    allowed_columns: &[String],
+    columns: &[ColumnInfo],
     dialect: FilterDialect,
 ) -> Result<CompiledFilter, String> {
     if expression.conditions.len() > MAX_CONDITIONS {
@@ -169,9 +170,10 @@ pub fn compile_filter(
     let mut clauses = Vec::with_capacity(expression.conditions.len());
 
     for condition in &expression.conditions {
-        if !allowed_columns.contains(&condition.column) {
-            return Err(format!("Unknown filter column: {}", condition.column));
-        }
+        let column_info = columns
+            .iter()
+            .find(|column| column.name == condition.column)
+            .ok_or_else(|| format!("Unknown filter column: {}", condition.column))?;
 
         let column = quote_identifier(&condition.column, dialect);
         let clause = match condition.operator {
@@ -192,7 +194,7 @@ pub fn compile_filter(
 
                 let mut placeholders = Vec::with_capacity(array.len());
                 for item in array {
-                    let value = parse_value(item)?;
+                    let value = parse_value(item, column_info, dialect)?;
                     placeholders.push(placeholder(values.len(), &value, dialect));
                     values.push(value);
                 }
@@ -203,7 +205,7 @@ pub fn compile_filter(
                     .value
                     .as_ref()
                     .ok_or_else(|| "This filter requires a value".to_string())?;
-                let mut value = parse_value(raw_value)?;
+                let mut value = parse_value(raw_value, column_info, dialect)?;
                 let operator = match condition.operator {
                     FilterOperator::Equals => "=",
                     FilterOperator::NotEquals => "<>",
@@ -256,17 +258,79 @@ fn quote_identifier(identifier: &str, dialect: FilterDialect) -> String {
     }
 }
 
-fn parse_value(value: &Value) -> Result<FilterValue, String> {
-    match value {
-        Value::Object(value) if value.get("kind").and_then(Value::as_str) == Some("integer") => {
-            value
-                .get("value")
-                .and_then(Value::as_str)
-                .ok_or_else(|| "Integer filter value must be a string".to_string())?
-                .parse::<i64>()
-                .map(FilterValue::Integer)
-                .map_err(|_| "Integer filter value is out of range".to_string())
+fn tagged_number(
+    value: &Value,
+    column: &ColumnInfo,
+    dialect: FilterDialect,
+) -> Result<Option<FilterValue>, String> {
+    let Value::Object(object) = value else {
+        return Ok(None);
+    };
+    let Some(kind) = object.get("kind").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+    if kind != "integer" && kind != "decimal" {
+        return Ok(None);
+    }
+
+    let value = object
+        .get("value")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "Numeric filter value must be a non-empty string".to_string())?;
+    let expected_kind = if kind == "integer" {
+        FilterColumnKind::Integer
+    } else {
+        FilterColumnKind::Decimal
+    };
+    if column.filter_kind != expected_kind {
+        return Err(format!(
+            "Numeric filter value does not match column type: {}",
+            column.name
+        ));
+    }
+
+    let parsed = match (dialect, expected_kind) {
+        (FilterDialect::Postgres | FilterDialect::Sqlite, FilterColumnKind::Integer) => value
+            .parse::<i64>()
+            .map(FilterValue::Integer)
+            .map_err(|_| "Integer filter value is out of range".to_string())?,
+        (FilterDialect::Postgres | FilterDialect::Sqlite, FilterColumnKind::Decimal) => {
+            FilterValue::ExactNumber {
+                value: value.to_string(),
+                data_type: "numeric".to_string(),
+            }
         }
+        (FilterDialect::Clickhouse, _) => {
+            let data_type = normalize_clickhouse_type(&column.data_type);
+            if !data_type.chars().all(|character| {
+                character.is_ascii_alphanumeric()
+                    || matches!(character, '(' | ')' | ',' | ' ' | '_')
+            }) {
+                return Err("Unsupported ClickHouse numeric column type".to_string());
+            }
+            FilterValue::ExactNumber {
+                value: value.to_string(),
+                data_type,
+            }
+        }
+        _ => unreachable!(),
+    };
+
+    Ok(Some(parsed))
+}
+
+fn parse_value(
+    value: &Value,
+    column: &ColumnInfo,
+    dialect: FilterDialect,
+) -> Result<FilterValue, String> {
+    if let Some(value) = tagged_number(value, column, dialect)? {
+        return Ok(value);
+    }
+
+    match value {
         Value::String(value) => Ok(FilterValue::Text(value.clone())),
         Value::Number(value) if value.is_i64() => Ok(FilterValue::Integer(value.as_i64().unwrap())),
         Value::Number(value) if value.is_u64() => value
@@ -295,7 +359,12 @@ fn with_text_pattern(
 
 fn placeholder(index: usize, value: &FilterValue, dialect: FilterDialect) -> String {
     match dialect {
-        FilterDialect::Postgres => format!("${}", index + 1),
+        FilterDialect::Postgres => match value {
+            FilterValue::ExactNumber { data_type, .. } => {
+                format!("${}::text::{data_type}", index + 1)
+            }
+            _ => format!("${}", index + 1),
+        },
         FilterDialect::Sqlite => "?".to_string(),
         FilterDialect::Clickhouse => {
             let value_type = match value {
@@ -303,6 +372,7 @@ fn placeholder(index: usize, value: &FilterValue, dialect: FilterDialect) -> Str
                 FilterValue::Integer(_) => "Int64",
                 FilterValue::Float(_) => "Float64",
                 FilterValue::Boolean(_) => "UInt8",
+                FilterValue::ExactNumber { data_type, .. } => data_type,
             };
             format!("{{f{index}:{value_type}}}")
         }
@@ -313,7 +383,8 @@ fn placeholder(index: usize, value: &FilterValue, dialect: FilterDialect) -> Str
 mod tests {
     use super::*;
     use crate::db::models::{
-        FilterColumnKind, FilterCondition, FilterConjunction, FilterExpression, FilterOperator,
+        ColumnInfo, FilterColumnKind, FilterCondition, FilterConjunction, FilterExpression,
+        FilterOperator,
     };
     use serde_json::json;
 
@@ -321,6 +392,17 @@ mod tests {
         FilterExpression {
             conjunction: FilterConjunction::And,
             conditions: vec![condition],
+        }
+    }
+
+    fn column(name: &str, data_type: &str, dialect: FilterDialect) -> ColumnInfo {
+        ColumnInfo {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            filter_kind: classify_column_type(data_type, dialect),
+            nullable: false,
+            default: None,
+            primary_key: false,
         }
     }
 
@@ -360,7 +442,7 @@ mod tests {
                 operator: FilterOperator::Equals,
                 value: Some(json!("active")),
             }),
-            &["status".to_string()],
+            &[column("status", "text", FilterDialect::Postgres)],
             FilterDialect::Postgres,
         )
         .unwrap();
@@ -380,7 +462,7 @@ mod tests {
                 operator: FilterOperator::Contains,
                 value: Some(json!("cooper")),
             }),
-            &["name".to_string()],
+            &[column("name", "TEXT", FilterDialect::Sqlite)],
             FilterDialect::Sqlite,
         )
         .unwrap();
@@ -400,7 +482,11 @@ mod tests {
                 operator: FilterOperator::IsNull,
                 value: None,
             }),
-            &["deleted_at".to_string()],
+            &[column(
+                "deleted_at",
+                "timestamp with time zone",
+                FilterDialect::Postgres,
+            )],
             FilterDialect::Postgres,
         )
         .unwrap();
@@ -417,7 +503,7 @@ mod tests {
                 operator: FilterOperator::Equals,
                 value: Some(json!("secret")),
             }),
-            &["email".to_string()],
+            &[column("email", "text", FilterDialect::Postgres)],
             FilterDialect::Postgres,
         )
         .unwrap_err();
@@ -436,7 +522,7 @@ mod tests {
                     "value": "9007199254740993"
                 })),
             }),
-            &["external_id".to_string()],
+            &[column("external_id", "bigint", FilterDialect::Postgres)],
             FilterDialect::Postgres,
         )
         .unwrap();
@@ -444,6 +530,91 @@ mod tests {
         assert_eq!(
             compiled.values,
             vec![FilterValue::Integer(9_007_199_254_740_993)]
+        );
+    }
+
+    #[test]
+    fn preserves_wide_clickhouse_integer_values() {
+        let value = "340282366920938463463374607431768211455";
+        let compiled = compile_filter(
+            &expression(FilterCondition {
+                column: "visits".to_string(),
+                operator: FilterOperator::Equals,
+                value: Some(json!({
+                    "kind": "integer",
+                    "value": value
+                })),
+            }),
+            &[column("visits", "UInt128", FilterDialect::Clickhouse)],
+            FilterDialect::Clickhouse,
+        )
+        .unwrap();
+
+        assert_eq!(compiled.sql, "`visits` = {f0:UInt128}");
+        assert_eq!(
+            compiled.values,
+            vec![FilterValue::ExactNumber {
+                value: value.to_string(),
+                data_type: "UInt128".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn preserves_high_precision_decimal_values() {
+        let value = "12345678901234567890.123456789012345678";
+        let compiled = compile_filter(
+            &expression(FilterCondition {
+                column: "amount".to_string(),
+                operator: FilterOperator::GreaterThan,
+                value: Some(json!({
+                    "kind": "decimal",
+                    "value": value
+                })),
+            }),
+            &[column(
+                "amount",
+                "Decimal(38, 18)",
+                FilterDialect::Clickhouse,
+            )],
+            FilterDialect::Clickhouse,
+        )
+        .unwrap();
+
+        assert_eq!(compiled.sql, "`amount` > {f0:Decimal(38, 18)}");
+        assert_eq!(
+            compiled.values,
+            vec![FilterValue::ExactNumber {
+                value: value.to_string(),
+                data_type: "Decimal(38, 18)".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn preserves_postgres_decimal_values() {
+        let value = "12345678901234567890.123456789012345678";
+        let compiled = compile_filter(
+            &expression(FilterCondition {
+                column: "amount".to_string(),
+                operator: FilterOperator::GreaterThan,
+                value: Some(json!({
+                    "kind": "decimal",
+                    "value": value
+                })),
+            }),
+            &[column("amount", "numeric", FilterDialect::Postgres)],
+            FilterDialect::Postgres,
+        )
+        .unwrap();
+
+        assert_eq!(compiled.sql, "\"amount\" > $1::text::numeric");
+        assert_eq!(
+            compiled.values,
+            vec![FilterValue::ExactNumber {
+                value: value.to_string(),
+                data_type: "numeric".to_string(),
+            }]
         );
     }
 

--- a/src-tauri/src/database/postgres.rs
+++ b/src-tauri/src/database/postgres.rs
@@ -60,6 +60,7 @@ impl PostgresDriver {
                 FilterValue::Integer(value) => query.bind(value),
                 FilterValue::Float(value) => query.bind(value),
                 FilterValue::Boolean(value) => query.bind(value),
+                FilterValue::ExactNumber { value, .. } => query.bind(value),
             };
         }
         query
@@ -332,13 +333,7 @@ impl DatabaseDriver for PostgresDriver {
         let offset = (page - 1) * limit;
         let full_table_name = format!("\"{}\".\"{}\"", schema, table);
         let compiled_filter = if let Some(expression) = structured_expression(filter.as_ref()) {
-            let columns = self
-                .get_table_structure(schema, table)
-                .await?
-                .columns
-                .into_iter()
-                .map(|column| column.name)
-                .collect::<Vec<_>>();
+            let columns = self.get_table_structure(schema, table).await?.columns;
             Some(compile_filter(
                 expression,
                 &columns,

--- a/src-tauri/src/database/postgres.rs
+++ b/src-tauri/src/database/postgres.rs
@@ -649,8 +649,12 @@ impl DatabaseDriver for PostgresDriver {
             let table_type: String = row.try_get("type").map_err(|e| e.to_string())?;
 
             let columns_json: Value = row.try_get("columns").map_err(|e| e.to_string())?;
-            let columns: Vec<ColumnInfo> = serde_json::from_value(columns_json)
+            let mut columns: Vec<ColumnInfo> = serde_json::from_value(columns_json)
                 .map_err(|e| format!("Failed to parse columns: {}", e))?;
+            for column in &mut columns {
+                column.filter_kind =
+                    classify_column_type(&column.data_type, FilterDialect::Postgres);
+            }
 
             let foreign_keys_json: Value =
                 row.try_get("foreign_keys").map_err(|e| e.to_string())?;

--- a/src-tauri/src/database/postgres.rs
+++ b/src-tauri/src/database/postgres.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use super::filter::{
-    build_where_clause, compile_filter, structured_expression, CompiledFilter, FilterDialect,
-    FilterValue,
+    build_where_clause, classify_column_type, compile_filter, structured_expression,
+    CompiledFilter, FilterDialect, FilterValue,
 };
 use super::{query_returns_rows, DatabaseDriver, PostgresConfig};
 use crate::database::queries::postgres::{
@@ -547,6 +547,7 @@ impl DatabaseDriver for PostgresDriver {
                 .map(
                     |(name, data_type, nullable, default, primary_key)| ColumnInfo {
                         name,
+                        filter_kind: classify_column_type(&data_type, FilterDialect::Postgres),
                         data_type,
                         nullable,
                         default,

--- a/src-tauri/src/database/sqlite.rs
+++ b/src-tauri/src/database/sqlite.rs
@@ -41,6 +41,7 @@ impl SqliteDriver {
                 FilterValue::Integer(value) => query.bind(value),
                 FilterValue::Float(value) => query.bind(value),
                 FilterValue::Boolean(value) => query.bind(value),
+                FilterValue::ExactNumber { value, .. } => query.bind(value),
             };
         }
         query
@@ -206,13 +207,7 @@ impl DatabaseDriver for SqliteDriver {
 
         let offset = (page - 1) * limit;
         let compiled_filter = if let Some(expression) = structured_expression(filter.as_ref()) {
-            let columns = self
-                .get_table_structure("main", table)
-                .await?
-                .columns
-                .into_iter()
-                .map(|column| column.name)
-                .collect::<Vec<_>>();
+            let columns = self.get_table_structure("main", table).await?.columns;
             Some(compile_filter(expression, &columns, FilterDialect::Sqlite)?)
         } else {
             None

--- a/src-tauri/src/database/sqlite.rs
+++ b/src-tauri/src/database/sqlite.rs
@@ -5,8 +5,8 @@ use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::{Column, Row, TypeInfo};
 
 use super::filter::{
-    build_where_clause, compile_filter, structured_expression, CompiledFilter, FilterDialect,
-    FilterValue,
+    build_where_clause, classify_column_type, compile_filter, structured_expression,
+    CompiledFilter, FilterDialect, FilterValue,
 };
 use super::{query_returns_rows, DatabaseDriver, SqliteConfig};
 use crate::database::queries::sqlite::{
@@ -316,6 +316,7 @@ impl DatabaseDriver for SqliteDriver {
 
                 ColumnInfo {
                     name,
+                    filter_kind: classify_column_type(&data_type, FilterDialect::Sqlite),
                     data_type,
                     nullable: notnull == 0,
                     default,
@@ -506,6 +507,7 @@ impl DatabaseDriver for SqliteDriver {
             if let Some(table) = tables_map.get_mut(&table_name) {
                 table.columns.push(ColumnInfo {
                     name: column_name,
+                    filter_kind: classify_column_type(&data_type, FilterDialect::Sqlite),
                     data_type,
                     nullable: not_null == 0,
                     default: default_value,

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -109,6 +109,7 @@ pub struct ColumnInfo {
     pub name: String,
     #[serde(rename = "type")]
     pub data_type: String,
+    #[serde(default)]
     pub filter_kind: FilterColumnKind,
     pub nullable: bool,
     pub default: Option<String>,
@@ -125,6 +126,32 @@ pub enum FilterColumnKind {
     Temporal,
     Uuid,
     Other,
+}
+
+impl Default for FilterColumnKind {
+    fn default() -> Self {
+        Self::Other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn column_info_accepts_internal_schema_json_without_filter_kind() {
+        let column: ColumnInfo = serde_json::from_value(json!({
+            "name": "id",
+            "type": "bigint",
+            "nullable": false,
+            "default": null,
+            "primary_key": true
+        }))
+        .unwrap();
+
+        assert_eq!(column.filter_kind, FilterColumnKind::Other);
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -109,9 +109,22 @@ pub struct ColumnInfo {
     pub name: String,
     #[serde(rename = "type")]
     pub data_type: String,
+    pub filter_kind: FilterColumnKind,
     pub nullable: bool,
     pub default: Option<String>,
     pub primary_key: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FilterColumnKind {
+    Text,
+    Integer,
+    Decimal,
+    Boolean,
+    Temporal,
+    Uuid,
+    Other,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -93,11 +93,11 @@ export function CommandPalette({
 		"results" in activeTab &&
 		activeTab.results &&
 		activeTab.results.length > 0;
-	const hasFilter =
-		(isTableDataTab || isQueryTab) &&
-		activeTab &&
-		"filter" in activeTab &&
-		!!activeTab.filter;
+	const hasFilter = isTableDataTab
+		? activeTab.filterState.applied !== null
+		: isQueryTab
+			? Boolean(activeTab.filter)
+			: false;
 
 	useEffect(() => {
 		const down = (e: KeyboardEvent) => {

--- a/src/components/SettingsForm.tsx
+++ b/src/components/SettingsForm.tsx
@@ -18,8 +18,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
-import { type Theme, useTheme } from "@/contexts/ThemeContext";
+import { useTheme } from "@/contexts/ThemeContext";
 import { type AiHarnessStatus, type AiProvider, api } from "@/lib/tauri";
+import { ThemeSelector } from "./ThemeSelector";
 
 interface SettingsFormProps {
 	onSaveSuccess?: () => void;
@@ -125,19 +126,11 @@ export function SettingsForm({ onSaveSuccess, compact }: SettingsFormProps) {
 						</p>
 					)}
 				</div>
-				<div className="flex rounded-md border bg-muted/50 p-0.5">
-					{(["light", "dark", "system"] as Theme[]).map((t) => (
-						<Button
-							key={t}
-							variant={theme === t ? "secondary" : "ghost"}
-							onClick={() => setTheme(t)}
-							className="flex-1 capitalize"
-							size={compact ? "sm" : "default"}
-						>
-							{t}
-						</Button>
-					))}
-				</div>
+				<ThemeSelector
+					theme={theme}
+					compact={compact}
+					onThemeChange={setTheme}
+				/>
 			</div>
 
 			<div className={sectionClass}>

--- a/src/components/ThemeSelector.test.tsx
+++ b/src/components/ThemeSelector.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ComponentProps } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("@/components/ui/button", () => ({
+	Button: ({
+		children,
+		variant: _variant,
+		size: _size,
+		...props
+	}: ComponentProps<"button"> & { variant?: string; size?: string }) => (
+		<button {...props}>{children}</button>
+	),
+}));
+
+const { ThemeSelector } = await import("./ThemeSelector");
+
+describe("ThemeSelector", () => {
+	test("renders a distinct and accessible selected theme", () => {
+		const markup = renderToStaticMarkup(
+			<ThemeSelector theme="dark" onThemeChange={() => {}} />,
+		);
+
+		expect(markup).toContain("<legend");
+		expect(markup).toContain("Theme</legend>");
+		expect(markup).toMatch(
+			/<button[^>]*class="[^"]*bg-background[^"]*shadow-sm[^"]*"[^>]*aria-pressed="true"[^>]*>dark<\/button>/,
+		);
+		expect(markup).toMatch(
+			/<button[^>]*class="[^"]*text-muted-foreground[^"]*"[^>]*aria-pressed="false"[^>]*>light<\/button>/,
+		);
+	});
+});

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@/components/ui/button";
+import type { Theme } from "@/contexts/ThemeContext";
+
+interface ThemeSelectorProps {
+	theme: Theme;
+	compact?: boolean;
+	onThemeChange: (theme: Theme) => void;
+}
+
+const themes: Theme[] = ["light", "dark", "system"];
+
+export function ThemeSelector({
+	theme,
+	compact,
+	onThemeChange,
+}: ThemeSelectorProps) {
+	return (
+		<fieldset className="flex rounded-md border bg-muted/50 p-0.5">
+			<legend className="sr-only">Theme</legend>
+			{themes.map((option) => {
+				const selected = theme === option;
+
+				return (
+					<Button
+						key={option}
+						type="button"
+						variant="ghost"
+						size={compact ? "sm" : "default"}
+						className={
+							selected
+								? "flex-1 border-border bg-background text-foreground shadow-sm hover:bg-background capitalize"
+								: "flex-1 capitalize text-muted-foreground"
+						}
+						aria-pressed={selected}
+						onClick={() => onThemeChange(option)}
+					>
+						{option}
+					</Button>
+				);
+			})}
+		</fieldset>
+	);
+}

--- a/src/components/connection-details/FilterConditionRow.tsx
+++ b/src/components/connection-details/FilterConditionRow.tsx
@@ -42,16 +42,22 @@ export function FilterConditionRow({
 	onRemove,
 	onApply,
 }: FilterConditionRowProps) {
-	const selectedColumn =
-		columns.find((column) => column.name === condition.column) ?? columns[0];
-	const filterOperators = getFilterOperatorsForColumn(
-		selectedColumn?.type ?? "unknown",
+	const selectedColumn = columns.find(
+		(column) => column.name === condition.column,
 	);
+	const filterOperators = selectedColumn
+		? getFilterOperatorsForColumn(selectedColumn.filter_kind)
+		: [];
 
 	return (
 		<div className="flex items-center gap-2">
 			{showConjunction && (
-				<Select value={conjunction} onValueChange={onConjunctionChange}>
+				<Select
+					value={conjunction}
+					onValueChange={(value) => {
+						if (value) onConjunctionChange(value);
+					}}
+				>
 					<SelectTrigger size="sm" className="w-16">
 						<SelectValue />
 					</SelectTrigger>
@@ -64,18 +70,19 @@ export function FilterConditionRow({
 			<Select
 				value={condition.column}
 				onValueChange={(columnName) => {
+					if (!columnName) return;
 					const column = columns.find((item) => item.name === columnName);
 					onChange(
 						changeFilterConditionColumn(
 							condition,
 							columnName,
-							column?.type ?? "unknown",
+							column?.filter_kind ?? "other",
 						),
 					);
 				}}
 			>
 				<SelectTrigger size="sm" className="w-40" aria-label="Filter column">
-					<SelectValue placeholder="Column" />
+					<SelectValue />
 				</SelectTrigger>
 				<SelectContent>
 					{columns.map((column) => (
@@ -87,6 +94,7 @@ export function FilterConditionRow({
 			</Select>
 			<Select
 				value={condition.operator}
+				disabled={!selectedColumn}
 				onValueChange={(operator) =>
 					onChange(
 						changeFilterConditionOperator(

--- a/src/components/connection-details/FilterConditionRow.tsx
+++ b/src/components/connection-details/FilterConditionRow.tsx
@@ -1,6 +1,5 @@
 import { X } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
 	Select,
 	SelectContent,
@@ -9,14 +8,16 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import {
-	FILTER_OPERATORS,
+	changeFilterConditionColumn,
+	changeFilterConditionOperator,
 	FILTER_OPERATOR_LABELS,
-	operatorNeedsValue,
 	type FilterCondition,
 	type FilterExpression,
 	type FilterOperator,
+	getFilterOperatorsForColumn,
 } from "@/lib/resultFilters";
 import type { TableColumn } from "@/types/tabTypes";
+import { FilterValueInput } from "./FilterValueInput";
 
 interface FilterConditionRowProps {
 	condition: FilterCondition;
@@ -41,15 +42,11 @@ export function FilterConditionRow({
 	onRemove,
 	onApply,
 }: FilterConditionRowProps) {
-	const inputValue = Array.isArray(condition.value)
-		? condition.value
-				.map((value) =>
-					typeof value === "object" && value !== null ? value.value : String(value),
-				)
-				.join(", ")
-		: typeof condition.value === "object" && condition.value !== null
-			? condition.value.value
-			: String(condition.value ?? "");
+	const selectedColumn =
+		columns.find((column) => column.name === condition.column) ?? columns[0];
+	const filterOperators = getFilterOperatorsForColumn(
+		selectedColumn?.type ?? "unknown",
+	);
 
 	return (
 		<div className="flex items-center gap-2">
@@ -66,9 +63,18 @@ export function FilterConditionRow({
 			)}
 			<Select
 				value={condition.column}
-				onValueChange={(column) => onChange({ column })}
+				onValueChange={(columnName) => {
+					const column = columns.find((item) => item.name === columnName);
+					onChange(
+						changeFilterConditionColumn(
+							condition,
+							columnName,
+							column?.type ?? "unknown",
+						),
+					);
+				}}
 			>
-				<SelectTrigger size="sm" className="w-40">
+				<SelectTrigger size="sm" className="w-40" aria-label="Filter column">
 					<SelectValue placeholder="Column" />
 				</SelectTrigger>
 				<SelectContent>
@@ -82,34 +88,32 @@ export function FilterConditionRow({
 			<Select
 				value={condition.operator}
 				onValueChange={(operator) =>
-					onChange({
-						operator: operator as FilterOperator,
-						value: operatorNeedsValue(operator as FilterOperator)
-							? (condition.value ?? "")
-							: undefined,
-					})
+					onChange(
+						changeFilterConditionOperator(
+							condition,
+							operator as FilterOperator,
+						),
+					)
 				}
 			>
-			<SelectTrigger size="sm" className="w-40">
+				<SelectTrigger size="sm" className="w-40" aria-label="Filter operator">
 					<SelectValue />
 				</SelectTrigger>
 				<SelectContent>
-					{FILTER_OPERATORS.map((operator) => (
+					{filterOperators.map((operator) => (
 						<SelectItem key={operator} value={operator}>
 							{FILTER_OPERATOR_LABELS[operator]}
 						</SelectItem>
 					))}
 				</SelectContent>
 			</Select>
-			{operatorNeedsValue(condition.operator) && (
-				<Input
-					value={inputValue}
-					onChange={(event) => onChange({ value: event.target.value })}
-					onKeyDown={(event) => {
-						if (event.key === "Enter" && canApply) onApply();
-					}}
-					placeholder={condition.operator === "in" ? "value, value" : "Value"}
-					className="h-7 flex-1 font-mono text-xs"
+			{selectedColumn && (
+				<FilterValueInput
+					condition={condition}
+					column={selectedColumn}
+					canApply={canApply}
+					onChange={(value) => onChange({ value })}
+					onApply={onApply}
 				/>
 			)}
 			<Button

--- a/src/components/connection-details/FilterValueInput.tsx
+++ b/src/components/connection-details/FilterValueInput.tsx
@@ -6,11 +6,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
-import {
-	type FilterCondition,
-	getFilterColumnKind,
-	operatorNeedsValue,
-} from "@/lib/resultFilters";
+import { type FilterCondition, operatorNeedsValue } from "@/lib/resultFilters";
 import type { TableColumn } from "@/types/tabTypes";
 
 interface FilterValueInputProps {
@@ -46,7 +42,7 @@ function getTemporalPlaceholder(dataType: string): string {
 }
 
 function getValuePlaceholder(column: TableColumn): string {
-	switch (getFilterColumnKind(column.type)) {
+	switch (column.filter_kind) {
 		case "integer":
 			return "0";
 		case "decimal":
@@ -61,7 +57,7 @@ function getValuePlaceholder(column: TableColumn): string {
 }
 
 function getListPlaceholder(column: TableColumn): string {
-	switch (getFilterColumnKind(column.type)) {
+	switch (column.filter_kind) {
 		case "integer":
 			return "1, 2";
 		case "decimal":
@@ -84,7 +80,7 @@ export function FilterValueInput({
 }: FilterValueInputProps) {
 	if (!operatorNeedsValue(condition.operator)) return null;
 
-	const columnKind = getFilterColumnKind(column.type);
+	const columnKind = column.filter_kind;
 	const inputValue = stringifyFilterValue(condition.value);
 	const ariaLabel = `Filter value for ${column.name}`;
 
@@ -95,7 +91,7 @@ export function FilterValueInput({
 		return (
 			<Select value={booleanValue} onValueChange={onChange}>
 				<SelectTrigger size="sm" className="flex-1" aria-label={ariaLabel}>
-					<SelectValue placeholder="Value" />
+					<SelectValue />
 				</SelectTrigger>
 				<SelectContent>
 					<SelectItem value="true">true</SelectItem>

--- a/src/components/connection-details/FilterValueInput.tsx
+++ b/src/components/connection-details/FilterValueInput.tsx
@@ -1,0 +1,133 @@
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	type FilterCondition,
+	getFilterColumnKind,
+	operatorNeedsValue,
+} from "@/lib/resultFilters";
+import type { TableColumn } from "@/types/tabTypes";
+
+interface FilterValueInputProps {
+	condition: FilterCondition;
+	column: TableColumn;
+	canApply: boolean;
+	onChange: (value: FilterCondition["value"]) => void;
+	onApply: () => void;
+}
+
+function stringifyFilterValue(value: FilterCondition["value"]): string {
+	if (Array.isArray(value)) {
+		return value
+			.map((item) =>
+				typeof item === "object" && item !== null ? item.value : String(item),
+			)
+			.join(", ");
+	}
+	if (typeof value === "object" && value !== null) return value.value;
+	return String(value ?? "");
+}
+
+function getTemporalPlaceholder(dataType: string): string {
+	const normalizedType = dataType.toLowerCase();
+	if (
+		normalizedType.includes("timestamp") ||
+		normalizedType.includes("datetime")
+	) {
+		return "YYYY-MM-DD HH:MM:SS";
+	}
+	if (normalizedType.includes("time")) return "HH:MM:SS";
+	return "YYYY-MM-DD";
+}
+
+function getValuePlaceholder(column: TableColumn): string {
+	switch (getFilterColumnKind(column.type)) {
+		case "integer":
+			return "0";
+		case "decimal":
+			return "0.0";
+		case "temporal":
+			return getTemporalPlaceholder(column.type);
+		case "uuid":
+			return "UUID";
+		default:
+			return "Value";
+	}
+}
+
+function getListPlaceholder(column: TableColumn): string {
+	switch (getFilterColumnKind(column.type)) {
+		case "integer":
+			return "1, 2";
+		case "decimal":
+			return "1.5, 2.5";
+		case "temporal":
+			return `${getTemporalPlaceholder(column.type)}, …`;
+		case "uuid":
+			return "uuid, uuid";
+		default:
+			return "value, value";
+	}
+}
+
+export function FilterValueInput({
+	condition,
+	column,
+	canApply,
+	onChange,
+	onApply,
+}: FilterValueInputProps) {
+	if (!operatorNeedsValue(condition.operator)) return null;
+
+	const columnKind = getFilterColumnKind(column.type);
+	const inputValue = stringifyFilterValue(condition.value);
+	const ariaLabel = `Filter value for ${column.name}`;
+
+	if (columnKind === "boolean") {
+		const booleanValue =
+			inputValue === "true" || inputValue === "false" ? inputValue : null;
+
+		return (
+			<Select value={booleanValue} onValueChange={onChange}>
+				<SelectTrigger size="sm" className="flex-1" aria-label={ariaLabel}>
+					<SelectValue placeholder="Value" />
+				</SelectTrigger>
+				<SelectContent>
+					<SelectItem value="true">true</SelectItem>
+					<SelectItem value="false">false</SelectItem>
+				</SelectContent>
+			</Select>
+		);
+	}
+
+	const isList = condition.operator === "in";
+	const isNumeric = columnKind === "integer" || columnKind === "decimal";
+
+	return (
+		<Input
+			type={!isList && isNumeric ? "number" : "text"}
+			step={
+				!isList && columnKind === "integer"
+					? "1"
+					: !isList && columnKind === "decimal"
+						? "any"
+						: undefined
+			}
+			value={inputValue}
+			onChange={(event) => onChange(event.target.value)}
+			onKeyDown={(event) => {
+				if (event.key === "Enter" && canApply) onApply();
+			}}
+			placeholder={
+				isList ? getListPlaceholder(column) : getValuePlaceholder(column)
+			}
+			aria-label={ariaLabel}
+			className="h-7 flex-1 font-mono text-xs"
+		/>
+	);
+}

--- a/src/components/connection-details/TableFilterBar.test.tsx
+++ b/src/components/connection-details/TableFilterBar.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ComponentProps, ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { TableFilterState } from "../../lib/resultFilters";
+import * as resultFilters from "../../lib/resultFilters";
+import type { TableColumn } from "../../types/tabTypes";
+
+mock.module("@/lib/resultFilters", () => resultFilters);
+mock.module("@/components/ui/button", () => ({
+	Button: ({
+		children,
+		variant: _variant,
+		size: _size,
+		...props
+	}: ComponentProps<"button"> & { variant?: string; size?: string }) => (
+		<button {...props}>{children}</button>
+	),
+}));
+mock.module("@/components/ui/input", () => ({
+	Input: (props: ComponentProps<"input">) => <input {...props} />,
+}));
+mock.module("@/components/ui/select", () => ({
+	Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	SelectContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	SelectItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	SelectTrigger: ({
+		children,
+		size: _size,
+		...props
+	}: ComponentProps<"button"> & { size?: string }) => (
+		<button {...props}>{children}</button>
+	),
+	SelectValue: () => null,
+}));
+
+const { TableFilterBar } = await import("./TableFilterBar");
+
+const columns: TableColumn[] = [
+	{
+		name: "name",
+		type: "text",
+		filter_kind: "text",
+		nullable: false,
+		default: null,
+		primary_key: false,
+	},
+];
+
+const noop = () => {};
+
+function renderFilterBar(state: TableFilterState): string {
+	return renderToStaticMarkup(
+		<TableFilterBar
+			state={state}
+			columns={columns}
+			loading={false}
+			onStateChange={noop}
+			onApply={noop}
+			onClear={noop}
+		/>,
+	);
+}
+
+describe("TableFilterBar", () => {
+	test("keeps the editor rendered when an active filter returns no rows", () => {
+		const filter = {
+			kind: "structured" as const,
+			value: {
+				conjunction: "and" as const,
+				conditions: [
+					{ column: "name", operator: "contains" as const, value: "missing" },
+				],
+			},
+		};
+
+		const markup = renderFilterBar({ draft: filter, applied: filter });
+
+		expect(markup).toContain("Builder");
+		expect(markup).toContain("Advanced");
+		expect(markup).toContain('aria-pressed="true"');
+		expect(markup).toContain("bg-background text-foreground shadow-sm");
+		expect(markup).toContain("Apply filter");
+		expect(markup).toContain("Active:");
+		expect(markup).toContain("name contains missing");
+	});
+
+	test("disables stale filter conditions instead of using another column type", () => {
+		const markup = renderFilterBar({
+			draft: {
+				kind: "structured",
+				value: {
+					conjunction: "and",
+					conditions: [
+						{ column: "removed", operator: "contains", value: "value" },
+					],
+				},
+			},
+			applied: null,
+		});
+
+		const applyButton = markup.match(
+			/<button[^>]*disabled=""[^>]*>Apply filter<\/button>/,
+		);
+		expect(applyButton).not.toBeNull();
+		expect(markup).not.toContain("Filter value for name");
+	});
+});

--- a/src/components/connection-details/TableFilterBar.tsx
+++ b/src/components/connection-details/TableFilterBar.tsx
@@ -6,7 +6,6 @@ import {
 	type FilterCondition,
 	type FilterExpression,
 	isConditionComplete,
-	shouldShowFilterEditor,
 	type TableFilterState,
 } from "@/lib/resultFilters";
 import type { TableColumn } from "@/types/tabTypes";
@@ -16,7 +15,6 @@ interface TableFilterBarProps {
 	state: TableFilterState;
 	columns: TableColumn[];
 	loading: boolean;
-	showInput: boolean;
 	onStateChange: (state: TableFilterState) => void;
 	onApply: () => void;
 	onClear: () => void;
@@ -34,7 +32,6 @@ export function TableFilterBar({
 	state,
 	columns,
 	loading,
-	showInput,
 	onStateChange,
 	onApply,
 	onClear,
@@ -46,8 +43,6 @@ export function TableFilterBar({
 			: { conjunction: "and" as const, conditions: [] };
 	const filterInput = state.draft.kind === "advanced" ? state.draft.value : "";
 	const hasActiveFilter = state.applied !== null;
-	const showEditor = shouldShowFilterEditor(showInput, state);
-	if (!showEditor) return null;
 
 	const setStructuredDraft = (value: FilterExpression) =>
 		onStateChange({ ...state, draft: { kind: "structured", value } });
@@ -78,129 +73,131 @@ export function TableFilterBar({
 		mode === "advanced"
 			? Boolean(filterInput.trim())
 			: structuredFilterInput.conditions.length > 0 &&
-				structuredFilterInput.conditions.every(isConditionComplete);
+				structuredFilterInput.conditions.every(
+					(condition) =>
+						columns.some((column) => column.name === condition.column) &&
+						isConditionComplete(condition),
+				);
 
 	return (
 		<div className="mx-6 mb-3 overflow-hidden rounded-xl border bg-muted/20 shadow-sm">
-			{showEditor && (
-				<div className="space-y-4 p-4">
-					<div className="flex flex-wrap items-center gap-2">
-						<fieldset className="flex rounded-lg bg-muted p-0.5">
-							<legend className="sr-only">Filter mode</legend>
-							<Button
-								variant="ghost"
-								size="sm"
-								className={
-									mode === "structured"
-										? "border-border bg-background text-foreground shadow-sm hover:bg-background"
-										: "text-muted-foreground"
-								}
-								aria-pressed={mode === "structured"}
-								onClick={() =>
-									onStateChange({
-										...state,
-										draft: {
-											kind: "structured",
-											value: { conjunction: "and", conditions: [] },
-										},
-									})
-								}
-							>
-								<Funnel /> Builder
-							</Button>
-							<Button
-								variant="ghost"
-								size="sm"
-								className={
-									mode === "advanced"
-										? "border-border bg-background text-foreground shadow-sm hover:bg-background"
-										: "text-muted-foreground"
-								}
-								aria-pressed={mode === "advanced"}
-								onClick={() =>
-									onStateChange({
-										...state,
-										draft: { kind: "advanced", value: "" },
-									})
-								}
-							>
-								<Code /> Advanced
-							</Button>
-						</fieldset>
-						{mode === "advanced" && (
-							<span className="text-[11px] text-muted-foreground">
-								SQL WHERE clause
-							</span>
-						)}
-						<Button
-							size="sm"
-							className="ml-auto"
-							onClick={onApply}
-							disabled={loading || !canApply}
-						>
-							Apply filter
-						</Button>
-					</div>
-
-					{mode === "structured" ? (
-						<div className="space-y-3">
-							{structuredFilterInput.conditions.map((condition, index) => (
-								<FilterConditionRow
-									key={`${index}-${condition.column}`}
-									condition={condition}
-									columns={columns}
-									conjunction={structuredFilterInput.conjunction}
-									showConjunction={index > 0}
-									canApply={canApply}
-									onConjunctionChange={(conjunction) =>
-										setStructuredDraft({
-											...structuredFilterInput,
-											conjunction,
-										})
-									}
-									onChange={(updates) => updateCondition(index, updates)}
-									onRemove={() => removeCondition(index)}
-									onApply={onApply}
-								/>
-							))}
-						</div>
-					) : (
-						<Input
-							placeholder="status = 'active' AND created_at > now() - interval '7 days'"
-							value={filterInput}
-							onChange={(event) =>
-								onStateChange({
-									...state,
-									draft: { kind: "advanced", value: event.target.value },
-								})
-							}
-							onKeyDown={(event) => {
-								if (event.key === "Enter" && canApply) onApply();
-							}}
-							className="font-mono text-xs"
-						/>
-					)}
-
-					{mode === "structured" && (
+			<div className="space-y-4 p-4">
+				<div className="flex flex-wrap items-center gap-2">
+					<fieldset className="flex rounded-lg bg-muted p-0.5">
+						<legend className="sr-only">Filter mode</legend>
 						<Button
 							variant="ghost"
 							size="sm"
+							className={
+								mode === "structured"
+									? "border-border bg-background text-foreground shadow-sm hover:bg-background"
+									: "text-muted-foreground"
+							}
+							aria-pressed={mode === "structured"}
 							onClick={() =>
-								setStructuredDraft({
-									...structuredFilterInput,
-									conditions: [
-										...structuredFilterInput.conditions,
-										emptyCondition(columns),
-									],
+								onStateChange({
+									...state,
+									draft: {
+										kind: "structured",
+										value: { conjunction: "and", conditions: [] },
+									},
 								})
 							}
-							disabled={!columns.length}
 						>
-							<Plus /> Add condition
+							<Funnel /> Builder
 						</Button>
+						<Button
+							variant="ghost"
+							size="sm"
+							className={
+								mode === "advanced"
+									? "border-border bg-background text-foreground shadow-sm hover:bg-background"
+									: "text-muted-foreground"
+							}
+							aria-pressed={mode === "advanced"}
+							onClick={() =>
+								onStateChange({
+									...state,
+									draft: { kind: "advanced", value: "" },
+								})
+							}
+						>
+							<Code /> Advanced
+						</Button>
+					</fieldset>
+					{mode === "advanced" && (
+						<span className="text-[11px] text-muted-foreground">
+							SQL WHERE clause
+						</span>
 					)}
+					<Button
+						size="sm"
+						className="ml-auto"
+						onClick={onApply}
+						disabled={loading || !canApply}
+					>
+						Apply filter
+					</Button>
 				</div>
-			)}
+
+				{mode === "structured" ? (
+					<div className="space-y-3">
+						{structuredFilterInput.conditions.map((condition, index) => (
+							<FilterConditionRow
+								key={`${index}-${condition.column}`}
+								condition={condition}
+								columns={columns}
+								conjunction={structuredFilterInput.conjunction}
+								showConjunction={index > 0}
+								canApply={canApply}
+								onConjunctionChange={(conjunction) =>
+									setStructuredDraft({
+										...structuredFilterInput,
+										conjunction,
+									})
+								}
+								onChange={(updates) => updateCondition(index, updates)}
+								onRemove={() => removeCondition(index)}
+								onApply={onApply}
+							/>
+						))}
+					</div>
+				) : (
+					<Input
+						placeholder="status = 'active' AND created_at > now() - interval '7 days'"
+						value={filterInput}
+						onChange={(event) =>
+							onStateChange({
+								...state,
+								draft: { kind: "advanced", value: event.target.value },
+							})
+						}
+						onKeyDown={(event) => {
+							if (event.key === "Enter" && canApply) onApply();
+						}}
+						className="font-mono text-xs"
+					/>
+				)}
+
+				{mode === "structured" && (
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() =>
+							setStructuredDraft({
+								...structuredFilterInput,
+								conditions: [
+									...structuredFilterInput.conditions,
+									emptyCondition(columns),
+								],
+							})
+						}
+						disabled={!columns.length}
+					>
+						<Plus /> Add condition
+					</Button>
+				)}
+			</div>
 
 			{hasActiveFilter && (
 				<div className="flex items-center justify-between border-t bg-background/60 px-3 py-2 text-xs">

--- a/src/components/connection-details/TableFilterBar.tsx
+++ b/src/components/connection-details/TableFilterBar.tsx
@@ -82,7 +82,7 @@ export function TableFilterBar({
 		<div className="mx-6 mb-3 overflow-hidden rounded-xl border bg-muted/20 shadow-sm">
 			{showInput && (
 				<div className="space-y-4 p-4">
-					<div className="flex items-center justify-between">
+					<div className="flex flex-wrap items-center gap-2">
 						<div
 							className="flex rounded-lg bg-muted p-0.5"
 							role="tablist"
@@ -121,6 +121,14 @@ export function TableFilterBar({
 								SQL WHERE clause
 							</span>
 						)}
+						<Button
+							size="sm"
+							className="ml-auto"
+							onClick={onApply}
+							disabled={loading || !canApply}
+						>
+							Apply filter
+						</Button>
 					</div>
 
 					{mode === "structured" ? (
@@ -162,34 +170,24 @@ export function TableFilterBar({
 						/>
 					)}
 
-					<div className="flex items-center justify-between">
-						{mode === "structured" && (
-							<Button
-								variant="ghost"
-								size="sm"
-								onClick={() =>
-									setStructuredDraft({
-										...structuredFilterInput,
-										conditions: [
-											...structuredFilterInput.conditions,
-											emptyCondition(columns),
-										],
-									})
-								}
-								disabled={!columns.length}
-							>
-								<Plus /> Add condition
-							</Button>
-						)}
+					{mode === "structured" && (
 						<Button
+							variant="ghost"
 							size="sm"
-							className="ml-auto"
-							onClick={onApply}
-							disabled={loading || !canApply}
+							onClick={() =>
+								setStructuredDraft({
+									...structuredFilterInput,
+									conditions: [
+										...structuredFilterInput.conditions,
+										emptyCondition(columns),
+									],
+								})
+							}
+							disabled={!columns.length}
 						>
-							Apply filter
+							<Plus /> Add condition
 						</Button>
-					</div>
+					)}
 				</div>
 			)}
 

--- a/src/components/connection-details/TableFilterBar.tsx
+++ b/src/components/connection-details/TableFilterBar.tsx
@@ -85,12 +85,18 @@ export function TableFilterBar({
 					<div className="flex flex-wrap items-center gap-2">
 						<div
 							className="flex rounded-lg bg-muted p-0.5"
-							role="tablist"
+							role="group"
 							aria-label="Filter mode"
 						>
 							<Button
-								variant={mode === "structured" ? "secondary" : "ghost"}
+								variant="ghost"
 								size="sm"
+								className={
+									mode === "structured"
+										? "border-border bg-background text-foreground shadow-sm hover:bg-background"
+										: "text-muted-foreground"
+								}
+								aria-pressed={mode === "structured"}
 								onClick={() =>
 									onStateChange({
 										...state,
@@ -104,8 +110,14 @@ export function TableFilterBar({
 								<Funnel /> Builder
 							</Button>
 							<Button
-								variant={mode === "advanced" ? "secondary" : "ghost"}
+								variant="ghost"
 								size="sm"
+								className={
+									mode === "advanced"
+										? "border-border bg-background text-foreground shadow-sm hover:bg-background"
+										: "text-muted-foreground"
+								}
+								aria-pressed={mode === "advanced"}
 								onClick={() =>
 									onStateChange({
 										...state,

--- a/src/components/connection-details/TableFilterBar.tsx
+++ b/src/components/connection-details/TableFilterBar.tsx
@@ -1,14 +1,15 @@
 import { Code, Funnel, Plus } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import type { TableColumn } from "@/types/tabTypes";
 import {
 	describeFilterExpression,
-	isConditionComplete,
 	type FilterCondition,
 	type FilterExpression,
+	isConditionComplete,
+	shouldShowFilterEditor,
 	type TableFilterState,
 } from "@/lib/resultFilters";
+import type { TableColumn } from "@/types/tabTypes";
 import { FilterConditionRow } from "./FilterConditionRow";
 
 interface TableFilterBarProps {
@@ -45,7 +46,8 @@ export function TableFilterBar({
 			: { conjunction: "and" as const, conditions: [] };
 	const filterInput = state.draft.kind === "advanced" ? state.draft.value : "";
 	const hasActiveFilter = state.applied !== null;
-	if (!showInput && !hasActiveFilter) return null;
+	const showEditor = shouldShowFilterEditor(showInput, state);
+	if (!showEditor) return null;
 
 	const setStructuredDraft = (value: FilterExpression) =>
 		onStateChange({ ...state, draft: { kind: "structured", value } });
@@ -80,14 +82,11 @@ export function TableFilterBar({
 
 	return (
 		<div className="mx-6 mb-3 overflow-hidden rounded-xl border bg-muted/20 shadow-sm">
-			{showInput && (
+			{showEditor && (
 				<div className="space-y-4 p-4">
 					<div className="flex flex-wrap items-center gap-2">
-						<div
-							className="flex rounded-lg bg-muted p-0.5"
-							role="group"
-							aria-label="Filter mode"
-						>
+						<fieldset className="flex rounded-lg bg-muted p-0.5">
+							<legend className="sr-only">Filter mode</legend>
 							<Button
 								variant="ghost"
 								size="sm"
@@ -127,7 +126,7 @@ export function TableFilterBar({
 							>
 								<Code /> Advanced
 							</Button>
-						</div>
+						</fieldset>
 						{mode === "advanced" && (
 							<span className="text-[11px] text-muted-foreground">
 								SQL WHERE clause

--- a/src/hooks/useTableDataFilters.ts
+++ b/src/hooks/useTableDataFilters.ts
@@ -37,7 +37,7 @@ export function useTableDataFilters({
 						value: coerceFilterExpression(
 							draft.value,
 							Object.fromEntries(
-								tab.columns.map((column) => [column.name, column.type]),
+								tab.columns.map((column) => [column.name, column.filter_kind]),
 							),
 						),
 					};

--- a/src/lib/resultFilters.test.ts
+++ b/src/lib/resultFilters.test.ts
@@ -11,6 +11,8 @@ import {
 	getFilterOperatorsForColumn,
 	getFilterRequest,
 	isConditionComplete,
+	shouldShowFilterEditor,
+	type TableFilterState,
 } from "./resultFilters";
 
 describe("result filters", () => {
@@ -327,5 +329,27 @@ describe("result filters", () => {
 				conditions: [{ column: "status", operator: "equals", value: "active" }],
 			},
 		});
+	});
+
+	test("keeps the filter editor visible when an active filter has no rows", () => {
+		const state: TableFilterState = {
+			draft: {
+				kind: "structured",
+				value: {
+					conjunction: "and",
+					conditions: [{ column: "name", operator: "contains", value: "orgs" }],
+				},
+			},
+			applied: {
+				kind: "structured",
+				value: {
+					conjunction: "and",
+					conditions: [{ column: "name", operator: "contains", value: "orgs" }],
+				},
+			},
+		};
+
+		expect(shouldShowFilterEditor(false, state)).toBe(true);
+		expect(shouldShowFilterEditor(false, createTableFilterState())).toBe(false);
 	});
 });

--- a/src/lib/resultFilters.test.ts
+++ b/src/lib/resultFilters.test.ts
@@ -4,6 +4,8 @@ import {
 	createTableFilterState,
 	createCellFilter,
 	describeFilterExpression,
+	getFilterColumnKind,
+	getFilterOperatorsForColumn,
 	getFilterRequest,
 	isConditionComplete,
 	type FilterExpression,
@@ -81,6 +83,109 @@ describe("result filters", () => {
 			{ kind: "integer", value: "18" },
 			true,
 			["admin", "editor"],
+		]);
+	});
+
+	test("classifies PostgreSQL, SQLite, and ClickHouse column types", () => {
+		expect(getFilterColumnKind("character varying")).toBe("text");
+		expect(getFilterColumnKind("VARCHAR(255)")).toBe("text");
+		expect(getFilterColumnKind("LowCardinality(String)")).toBe("text");
+		expect(getFilterColumnKind("bigint")).toBe("integer");
+		expect(getFilterColumnKind("INTEGER")).toBe("integer");
+		expect(getFilterColumnKind("Nullable(UInt64)")).toBe("integer");
+		expect(getFilterColumnKind("double precision")).toBe("decimal");
+		expect(getFilterColumnKind("REAL")).toBe("decimal");
+		expect(getFilterColumnKind("Decimal(12, 2)")).toBe("decimal");
+		expect(getFilterColumnKind("boolean")).toBe("boolean");
+		expect(getFilterColumnKind("Nullable(Bool)")).toBe("boolean");
+		expect(getFilterColumnKind("timestamp with time zone")).toBe("temporal");
+		expect(getFilterColumnKind("DATETIME")).toBe("temporal");
+		expect(getFilterColumnKind("DateTime64(3)")).toBe("temporal");
+		expect(getFilterColumnKind("uuid")).toBe("uuid");
+		expect(getFilterColumnKind("Array(String)")).toBe("other");
+		expect(getFilterColumnKind("BLOB")).toBe("other");
+		expect(getFilterColumnKind("USER-DEFINED")).toBe("other");
+	});
+
+	test("offers operators compatible with the selected column type", () => {
+		expect(getFilterOperatorsForColumn("text")).toEqual([
+			"equals",
+			"not_equals",
+			"contains",
+			"starts_with",
+			"ends_with",
+			"in",
+			"is_null",
+			"is_not_null",
+		]);
+		expect(getFilterOperatorsForColumn("Nullable(Int64)")).toEqual([
+			"equals",
+			"not_equals",
+			"greater_than",
+			"greater_than_or_equal",
+			"less_than",
+			"less_than_or_equal",
+			"in",
+			"is_null",
+			"is_not_null",
+		]);
+		expect(getFilterOperatorsForColumn("timestamp")).toEqual([
+			"equals",
+			"not_equals",
+			"greater_than",
+			"greater_than_or_equal",
+			"less_than",
+			"less_than_or_equal",
+			"in",
+			"is_null",
+			"is_not_null",
+		]);
+		expect(getFilterOperatorsForColumn("boolean")).toEqual([
+			"equals",
+			"not_equals",
+			"is_null",
+			"is_not_null",
+		]);
+		expect(getFilterOperatorsForColumn("uuid")).toEqual([
+			"equals",
+			"not_equals",
+			"in",
+			"is_null",
+			"is_not_null",
+		]);
+		expect(getFilterOperatorsForColumn("jsonb")).toEqual([
+			"equals",
+			"not_equals",
+			"in",
+			"is_null",
+			"is_not_null",
+		]);
+	});
+
+	test("coerces wrapped ClickHouse scalar and list values", () => {
+		const expression = coerceFilterExpression(
+			{
+				conjunction: "and",
+				conditions: [
+					{ column: "visits", operator: "in", value: "1, 2" },
+					{ column: "score", operator: "greater_than", value: "1.5" },
+					{ column: "enabled", operator: "equals", value: "false" },
+				],
+			},
+			{
+				visits: "Nullable(UInt64)",
+				score: "Decimal(12, 2)",
+				enabled: "Nullable(Bool)",
+			},
+		);
+
+		expect(expression.conditions.map((condition) => condition.value)).toEqual([
+			[
+				{ kind: "integer", value: "1" },
+				{ kind: "integer", value: "2" },
+			],
+			1.5,
+			false,
 		]);
 	});
 

--- a/src/lib/resultFilters.test.ts
+++ b/src/lib/resultFilters.test.ts
@@ -7,12 +7,9 @@ import {
 	createTableFilterState,
 	describeFilterExpression,
 	type FilterExpression,
-	getFilterColumnKind,
 	getFilterOperatorsForColumn,
 	getFilterRequest,
 	isConditionComplete,
-	shouldShowFilterEditor,
-	type TableFilterState,
 } from "./resultFilters";
 
 describe("result filters", () => {
@@ -90,27 +87,6 @@ describe("result filters", () => {
 		]);
 	});
 
-	test("classifies PostgreSQL, SQLite, and ClickHouse column types", () => {
-		expect(getFilterColumnKind("character varying")).toBe("text");
-		expect(getFilterColumnKind("VARCHAR(255)")).toBe("text");
-		expect(getFilterColumnKind("LowCardinality(String)")).toBe("text");
-		expect(getFilterColumnKind("bigint")).toBe("integer");
-		expect(getFilterColumnKind("INTEGER")).toBe("integer");
-		expect(getFilterColumnKind("Nullable(UInt64)")).toBe("integer");
-		expect(getFilterColumnKind("double precision")).toBe("decimal");
-		expect(getFilterColumnKind("REAL")).toBe("decimal");
-		expect(getFilterColumnKind("Decimal(12, 2)")).toBe("decimal");
-		expect(getFilterColumnKind("boolean")).toBe("boolean");
-		expect(getFilterColumnKind("Nullable(Bool)")).toBe("boolean");
-		expect(getFilterColumnKind("timestamp with time zone")).toBe("temporal");
-		expect(getFilterColumnKind("DATETIME")).toBe("temporal");
-		expect(getFilterColumnKind("DateTime64(3)")).toBe("temporal");
-		expect(getFilterColumnKind("uuid")).toBe("uuid");
-		expect(getFilterColumnKind("Array(String)")).toBe("other");
-		expect(getFilterColumnKind("BLOB")).toBe("other");
-		expect(getFilterColumnKind("USER-DEFINED")).toBe("other");
-	});
-
 	test("offers operators compatible with the selected column type", () => {
 		expect(getFilterOperatorsForColumn("text")).toEqual([
 			"equals",
@@ -122,7 +98,7 @@ describe("result filters", () => {
 			"is_null",
 			"is_not_null",
 		]);
-		expect(getFilterOperatorsForColumn("Nullable(Int64)")).toEqual([
+		expect(getFilterOperatorsForColumn("integer")).toEqual([
 			"equals",
 			"not_equals",
 			"greater_than",
@@ -133,7 +109,7 @@ describe("result filters", () => {
 			"is_null",
 			"is_not_null",
 		]);
-		expect(getFilterOperatorsForColumn("timestamp")).toEqual([
+		expect(getFilterOperatorsForColumn("temporal")).toEqual([
 			"equals",
 			"not_equals",
 			"greater_than",
@@ -157,7 +133,7 @@ describe("result filters", () => {
 			"is_null",
 			"is_not_null",
 		]);
-		expect(getFilterOperatorsForColumn("jsonb")).toEqual([
+		expect(getFilterOperatorsForColumn("other")).toEqual([
 			"equals",
 			"not_equals",
 			"in",
@@ -190,7 +166,7 @@ describe("result filters", () => {
 					value: "18",
 				},
 				"score",
-				"numeric",
+				"decimal",
 			),
 		).toEqual({
 			column: "score",
@@ -252,7 +228,7 @@ describe("result filters", () => {
 		});
 	});
 
-	test("coerces wrapped ClickHouse scalar and list values", () => {
+	test("coerces typed scalar and list values", () => {
 		const expression = coerceFilterExpression(
 			{
 				conjunction: "and",
@@ -263,9 +239,9 @@ describe("result filters", () => {
 				],
 			},
 			{
-				visits: "Nullable(UInt64)",
-				score: "Decimal(12, 2)",
-				enabled: "Nullable(Bool)",
+				visits: "integer",
+				score: "decimal",
+				enabled: "boolean",
 			},
 		);
 
@@ -274,7 +250,7 @@ describe("result filters", () => {
 				{ kind: "integer", value: "1" },
 				{ kind: "integer", value: "2" },
 			],
-			1.5,
+			{ kind: "decimal", value: "1.5" },
 			false,
 		]);
 	});
@@ -292,12 +268,34 @@ describe("result filters", () => {
 		};
 
 		const coerced = coerceFilterExpression(expression, {
-			external_id: "bigint",
+			external_id: "integer",
 		});
 
 		expect(coerced.conditions[0]?.value).toEqual({
 			kind: "integer",
 			value: "9007199254740993",
+		});
+	});
+
+	test("preserves high precision decimals without JavaScript precision loss", () => {
+		const value = "12345678901234567890.123456789012345678";
+		const expression = coerceFilterExpression(
+			{
+				conjunction: "and",
+				conditions: [
+					{
+						column: "amount",
+						operator: "equals",
+						value,
+					},
+				],
+			},
+			{ amount: "decimal" },
+		);
+
+		expect(expression.conditions[0]?.value).toEqual({
+			kind: "decimal",
+			value,
 		});
 	});
 
@@ -329,27 +327,5 @@ describe("result filters", () => {
 				conditions: [{ column: "status", operator: "equals", value: "active" }],
 			},
 		});
-	});
-
-	test("keeps the filter editor visible when an active filter has no rows", () => {
-		const state: TableFilterState = {
-			draft: {
-				kind: "structured",
-				value: {
-					conjunction: "and",
-					conditions: [{ column: "name", operator: "contains", value: "orgs" }],
-				},
-			},
-			applied: {
-				kind: "structured",
-				value: {
-					conjunction: "and",
-					conditions: [{ column: "name", operator: "contains", value: "orgs" }],
-				},
-			},
-		};
-
-		expect(shouldShowFilterEditor(false, state)).toBe(true);
-		expect(shouldShowFilterEditor(false, createTableFilterState())).toBe(false);
 	});
 });

--- a/src/lib/resultFilters.test.ts
+++ b/src/lib/resultFilters.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import {
+	changeFilterConditionColumn,
+	changeFilterConditionOperator,
 	coerceFilterExpression,
-	createTableFilterState,
 	createCellFilter,
+	createTableFilterState,
 	describeFilterExpression,
+	type FilterExpression,
 	getFilterColumnKind,
 	getFilterOperatorsForColumn,
 	getFilterRequest,
 	isConditionComplete,
-	type FilterExpression,
 } from "./resultFilters";
 
 describe("result filters", () => {
@@ -162,6 +164,92 @@ describe("result filters", () => {
 		]);
 	});
 
+	test("clears values and replaces incompatible operators when columns change", () => {
+		expect(
+			changeFilterConditionColumn(
+				{
+					column: "name",
+					operator: "contains",
+					value: "cooper",
+				},
+				"age",
+				"integer",
+			),
+		).toEqual({
+			column: "age",
+			operator: "equals",
+			value: undefined,
+		});
+		expect(
+			changeFilterConditionColumn(
+				{
+					column: "age",
+					operator: "greater_than",
+					value: "18",
+				},
+				"score",
+				"numeric",
+			),
+		).toEqual({
+			column: "score",
+			operator: "greater_than",
+			value: undefined,
+		});
+	});
+
+	test("preserves compatible scalar values and clears list or null transitions", () => {
+		expect(
+			changeFilterConditionOperator(
+				{ column: "name", operator: "equals", value: "cooper" },
+				"contains",
+			),
+		).toEqual({
+			column: "name",
+			operator: "contains",
+			value: "cooper",
+		});
+		expect(
+			changeFilterConditionOperator(
+				{ column: "name", operator: "equals", value: "cooper" },
+				"in",
+			),
+		).toEqual({
+			column: "name",
+			operator: "in",
+			value: "",
+		});
+		expect(
+			changeFilterConditionOperator(
+				{ column: "name", operator: "in", value: "a, b" },
+				"in",
+			),
+		).toEqual({
+			column: "name",
+			operator: "in",
+			value: "a, b",
+		});
+		expect(
+			changeFilterConditionOperator(
+				{ column: "name", operator: "in", value: "a, b" },
+				"not_equals",
+			),
+		).toEqual({
+			column: "name",
+			operator: "not_equals",
+			value: "",
+		});
+		expect(
+			changeFilterConditionOperator(
+				{ column: "name", operator: "equals", value: "cooper" },
+				"is_null",
+			),
+		).toEqual({
+			column: "name",
+			operator: "is_null",
+			value: undefined,
+		});
+	});
+
 	test("coerces wrapped ClickHouse scalar and list values", () => {
 		const expression = coerceFilterExpression(
 			{
@@ -236,9 +324,7 @@ describe("result filters", () => {
 		).toEqual({
 			structuredFilter: {
 				conjunction: "and",
-				conditions: [
-					{ column: "status", operator: "equals", value: "active" },
-				],
+				conditions: [{ column: "status", operator: "equals", value: "active" }],
 			},
 		});
 	});

--- a/src/lib/resultFilters.ts
+++ b/src/lib/resultFilters.ts
@@ -3,7 +3,12 @@ export interface IntegerFilterValue {
 	value: string;
 }
 
-export type FilterScalar = string | number | boolean | null | IntegerFilterValue;
+export type FilterScalar =
+	| string
+	| number
+	| boolean
+	| null
+	| IntegerFilterValue;
 
 export type FilterOperator =
 	| "equals"
@@ -83,10 +88,6 @@ export const FILTER_OPERATOR_LABELS: Record<FilterOperator, string> = {
 	is_not_null: "is not null",
 };
 
-export const FILTER_OPERATORS = Object.keys(
-	FILTER_OPERATOR_LABELS,
-) as FilterOperator[];
-
 const TEXT_FILTER_OPERATORS: FilterOperator[] = [
 	"equals",
 	"not_equals",
@@ -127,13 +128,13 @@ const CONSERVATIVE_FILTER_OPERATORS: FilterOperator[] = [
 
 function normalizeColumnType(dataType: string): string {
 	let normalizedType = dataType.trim().toLowerCase().replace(/\s+/g, " ");
-	let wrappedType = normalizedType.match(/^(?:nullable|lowcardinality)\((.*)\)$/);
+	let wrappedType = normalizedType.match(
+		/^(?:nullable|lowcardinality)\((.*)\)$/,
+	);
 
 	while (wrappedType) {
 		normalizedType = wrappedType[1].trim();
-		wrappedType = normalizedType.match(
-			/^(?:nullable|lowcardinality)\((.*)\)$/,
-		);
+		wrappedType = normalizedType.match(/^(?:nullable|lowcardinality)\((.*)\)$/);
 	}
 
 	return normalizedType;
@@ -202,6 +203,40 @@ export function getFilterOperatorsForColumn(
 
 export function operatorNeedsValue(operator: FilterOperator): boolean {
 	return operator !== "is_null" && operator !== "is_not_null";
+}
+
+export function changeFilterConditionColumn(
+	condition: FilterCondition,
+	column: string,
+	dataType: string,
+): FilterCondition {
+	const allowedOperators = getFilterOperatorsForColumn(dataType);
+
+	return {
+		column,
+		operator: allowedOperators.includes(condition.operator)
+			? condition.operator
+			: "equals",
+		value: undefined,
+	};
+}
+
+export function changeFilterConditionOperator(
+	condition: FilterCondition,
+	operator: FilterOperator,
+): FilterCondition {
+	if (!operatorNeedsValue(operator)) {
+		return { ...condition, operator, value: undefined };
+	}
+
+	const changesValueShape =
+		(condition.operator === "in") !== (operator === "in");
+
+	return {
+		...condition,
+		operator,
+		value: changesValueShape ? "" : (condition.value ?? ""),
+	};
 }
 
 export function isConditionComplete(condition: FilterCondition): boolean {

--- a/src/lib/resultFilters.ts
+++ b/src/lib/resultFilters.ts
@@ -63,6 +63,13 @@ export function createTableFilterState(): TableFilterState {
 	};
 }
 
+export function shouldShowFilterEditor(
+	showInput: boolean,
+	state: TableFilterState,
+): boolean {
+	return showInput || state.applied !== null;
+}
+
 export function getFilterRequest(filter: TableFilter | null): {
 	filter?: string;
 	structuredFilter?: FilterExpression;

--- a/src/lib/resultFilters.ts
+++ b/src/lib/resultFilters.ts
@@ -19,6 +19,15 @@ export type FilterOperator =
 	| "is_null"
 	| "is_not_null";
 
+export type FilterColumnKind =
+	| "text"
+	| "integer"
+	| "decimal"
+	| "boolean"
+	| "temporal"
+	| "uuid"
+	| "other";
+
 export interface FilterCondition {
 	column: string;
 	operator: FilterOperator;
@@ -77,6 +86,119 @@ export const FILTER_OPERATOR_LABELS: Record<FilterOperator, string> = {
 export const FILTER_OPERATORS = Object.keys(
 	FILTER_OPERATOR_LABELS,
 ) as FilterOperator[];
+
+const TEXT_FILTER_OPERATORS: FilterOperator[] = [
+	"equals",
+	"not_equals",
+	"contains",
+	"starts_with",
+	"ends_with",
+	"in",
+	"is_null",
+	"is_not_null",
+];
+
+const ORDERED_FILTER_OPERATORS: FilterOperator[] = [
+	"equals",
+	"not_equals",
+	"greater_than",
+	"greater_than_or_equal",
+	"less_than",
+	"less_than_or_equal",
+	"in",
+	"is_null",
+	"is_not_null",
+];
+
+const BOOLEAN_FILTER_OPERATORS: FilterOperator[] = [
+	"equals",
+	"not_equals",
+	"is_null",
+	"is_not_null",
+];
+
+const CONSERVATIVE_FILTER_OPERATORS: FilterOperator[] = [
+	"equals",
+	"not_equals",
+	"in",
+	"is_null",
+	"is_not_null",
+];
+
+function normalizeColumnType(dataType: string): string {
+	let normalizedType = dataType.trim().toLowerCase().replace(/\s+/g, " ");
+	let wrappedType = normalizedType.match(/^(?:nullable|lowcardinality)\((.*)\)$/);
+
+	while (wrappedType) {
+		normalizedType = wrappedType[1].trim();
+		wrappedType = normalizedType.match(
+			/^(?:nullable|lowcardinality)\((.*)\)$/,
+		);
+	}
+
+	return normalizedType;
+}
+
+export function getFilterColumnKind(dataType: string): FilterColumnKind {
+	const normalizedType = normalizeColumnType(dataType);
+
+	if (
+		/^(?:array|map|tuple|nested|object)\s*\(/.test(normalizedType) ||
+		/(^|\W)(?:jsonb?|blob|bytea|binary|varbinary)(\W|$)/.test(normalizedType)
+	) {
+		return "other";
+	}
+
+	if (/(^|\W)uuid(\W|$)/.test(normalizedType)) return "uuid";
+	if (/^(?:bool|boolean)$/.test(normalizedType)) return "boolean";
+	if (
+		/(^|\W)(?:date32|datetime64|datetime|date|timestamptz|timestamp|timetz|time|interval)(\W|$)/.test(
+			normalizedType,
+		)
+	) {
+		return "temporal";
+	}
+	if (
+		/(^|\W)(?:tinyint|smallint|mediumint|bigint|integer|int2|int4|int8|smallserial|bigserial|serial|u?int(?:8|16|32|64|128|256)?)(\W|$)/.test(
+			normalizedType,
+		)
+	) {
+		return "integer";
+	}
+	if (
+		/(^|\W)(?:decimal|numeric|number|real|float|double|money)(\W|$)/.test(
+			normalizedType,
+		)
+	) {
+		return "decimal";
+	}
+	if (
+		/(^|\W)(?:character varying|character|nvarchar|varchar|citext|text|clob|fixedstring|string)(\W|$)/.test(
+			normalizedType,
+		)
+	) {
+		return "text";
+	}
+
+	return "other";
+}
+
+export function getFilterOperatorsForColumn(
+	dataType: string,
+): FilterOperator[] {
+	switch (getFilterColumnKind(dataType)) {
+		case "text":
+			return TEXT_FILTER_OPERATORS;
+		case "integer":
+		case "decimal":
+		case "temporal":
+			return ORDERED_FILTER_OPERATORS;
+		case "boolean":
+			return BOOLEAN_FILTER_OPERATORS;
+		default:
+			return CONSERVATIVE_FILTER_OPERATORS;
+	}
+}
 
 export function operatorNeedsValue(operator: FilterOperator): boolean {
 	return operator !== "is_null" && operator !== "is_not_null";
@@ -140,21 +262,17 @@ export function describeFilterExpression(expression: FilterExpression): string {
 
 function coerceScalar(value: FilterScalar, dataType: string): FilterScalar {
 	if (typeof value !== "string") return value;
-	const normalizedType = dataType.toLowerCase();
-	if (/bool/.test(normalizedType)) {
+	const columnKind = getFilterColumnKind(dataType);
+	if (columnKind === "boolean") {
 		if (value.toLowerCase() === "true") return true;
 		if (value.toLowerCase() === "false") return false;
 	}
-	if (
-		/(^|\W)(tinyint|smallint|integer|bigint|int|serial)/.test(
-			normalizedType,
-		)
-	) {
+	if (columnKind === "integer") {
 		if (/^[+-]?\d+$/.test(value.trim())) {
 			return { kind: "integer", value: value.trim() };
 		}
 	}
-	if (/(^|\W)(decimal|numeric|real|float|double)/.test(normalizedType)) {
+	if (columnKind === "decimal") {
 		const number = Number(value);
 		if (Number.isFinite(number)) return number;
 	}

--- a/src/lib/resultFilters.ts
+++ b/src/lib/resultFilters.ts
@@ -1,5 +1,5 @@
-export interface IntegerFilterValue {
-	kind: "integer";
+export interface ExactNumberFilterValue {
+	kind: "integer" | "decimal";
 	value: string;
 }
 
@@ -8,7 +8,7 @@ export type FilterScalar =
 	| number
 	| boolean
 	| null
-	| IntegerFilterValue;
+	| ExactNumberFilterValue;
 
 export type FilterOperator =
 	| "equals"
@@ -61,13 +61,6 @@ export function createTableFilterState(): TableFilterState {
 		},
 		applied: null,
 	};
-}
-
-export function shouldShowFilterEditor(
-	showInput: boolean,
-	state: TableFilterState,
-): boolean {
-	return showInput || state.applied !== null;
 }
 
 export function getFilterRequest(filter: TableFilter | null): {
@@ -133,68 +126,10 @@ const CONSERVATIVE_FILTER_OPERATORS: FilterOperator[] = [
 	"is_not_null",
 ];
 
-function normalizeColumnType(dataType: string): string {
-	let normalizedType = dataType.trim().toLowerCase().replace(/\s+/g, " ");
-	let wrappedType = normalizedType.match(
-		/^(?:nullable|lowcardinality)\((.*)\)$/,
-	);
-
-	while (wrappedType) {
-		normalizedType = wrappedType[1].trim();
-		wrappedType = normalizedType.match(/^(?:nullable|lowcardinality)\((.*)\)$/);
-	}
-
-	return normalizedType;
-}
-
-export function getFilterColumnKind(dataType: string): FilterColumnKind {
-	const normalizedType = normalizeColumnType(dataType);
-
-	if (
-		/^(?:array|map|tuple|nested|object)\s*\(/.test(normalizedType) ||
-		/(^|\W)(?:jsonb?|blob|bytea|binary|varbinary)(\W|$)/.test(normalizedType)
-	) {
-		return "other";
-	}
-
-	if (/(^|\W)uuid(\W|$)/.test(normalizedType)) return "uuid";
-	if (/^(?:bool|boolean)$/.test(normalizedType)) return "boolean";
-	if (
-		/(^|\W)(?:date32|datetime64|datetime|date|timestamptz|timestamp|timetz|time|interval)(\W|$)/.test(
-			normalizedType,
-		)
-	) {
-		return "temporal";
-	}
-	if (
-		/(^|\W)(?:tinyint|smallint|mediumint|bigint|integer|int2|int4|int8|smallserial|bigserial|serial|u?int(?:8|16|32|64|128|256)?)(\W|$)/.test(
-			normalizedType,
-		)
-	) {
-		return "integer";
-	}
-	if (
-		/(^|\W)(?:decimal|numeric|number|real|float|double|money)(\W|$)/.test(
-			normalizedType,
-		)
-	) {
-		return "decimal";
-	}
-	if (
-		/(^|\W)(?:character varying|character|nvarchar|varchar|citext|text|clob|fixedstring|string)(\W|$)/.test(
-			normalizedType,
-		)
-	) {
-		return "text";
-	}
-
-	return "other";
-}
-
 export function getFilterOperatorsForColumn(
-	dataType: string,
+	columnKind: FilterColumnKind,
 ): FilterOperator[] {
-	switch (getFilterColumnKind(dataType)) {
+	switch (columnKind) {
 		case "text":
 			return TEXT_FILTER_OPERATORS;
 		case "integer":
@@ -215,9 +150,9 @@ export function operatorNeedsValue(operator: FilterOperator): boolean {
 export function changeFilterConditionColumn(
 	condition: FilterCondition,
 	column: string,
-	dataType: string,
+	columnKind: FilterColumnKind,
 ): FilterCondition {
-	const allowedOperators = getFilterOperatorsForColumn(dataType);
+	const allowedOperators = getFilterOperatorsForColumn(columnKind);
 
 	return {
 		column,
@@ -302,9 +237,11 @@ export function describeFilterExpression(expression: FilterExpression): string {
 		.join(` ${expression.conjunction} `);
 }
 
-function coerceScalar(value: FilterScalar, dataType: string): FilterScalar {
+function coerceScalar(
+	value: FilterScalar,
+	columnKind: FilterColumnKind,
+): FilterScalar {
 	if (typeof value !== "string") return value;
-	const columnKind = getFilterColumnKind(dataType);
 	if (columnKind === "boolean") {
 		if (value.toLowerCase() === "true") return true;
 		if (value.toLowerCase() === "false") return false;
@@ -315,15 +252,16 @@ function coerceScalar(value: FilterScalar, dataType: string): FilterScalar {
 		}
 	}
 	if (columnKind === "decimal") {
-		const number = Number(value);
-		if (Number.isFinite(number)) return number;
+		if (value.trim()) {
+			return { kind: "decimal", value: value.trim() };
+		}
 	}
 	return value;
 }
 
 export function coerceFilterExpression(
 	expression: FilterExpression,
-	columnTypes: Record<string, string>,
+	columnKinds: Record<string, FilterColumnKind>,
 ): FilterExpression {
 	return {
 		...expression,
@@ -332,14 +270,14 @@ export function coerceFilterExpression(
 				return { ...condition, value: undefined };
 			}
 
-			const type = columnTypes[condition.column] ?? "text";
+			const columnKind = columnKinds[condition.column] ?? "other";
 			const rawValues =
 				condition.operator === "in" && typeof condition.value === "string"
 					? condition.value.split(",").map((value) => value.trim())
 					: condition.value;
 			const value = Array.isArray(rawValues)
-				? rawValues.map((item) => coerceScalar(item, type))
-				: coerceScalar(rawValues ?? null, type);
+				? rawValues.map((item) => coerceScalar(item, columnKind))
+				: coerceScalar(rawValues ?? null, columnKind);
 
 			return { ...condition, value };
 		}),

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
+import type { FilterColumnKind, FilterExpression } from "@/lib/resultFilters";
 import { isSqlFunction } from "@/lib/sqlFunctions";
-import type { FilterExpression } from "@/lib/resultFilters";
 
 export interface Connection {
 	id: number;
@@ -56,6 +56,7 @@ export interface TableInfo {
 export interface ColumnInfo {
 	name: string;
 	type: string;
+	filter_kind: FilterColumnKind;
 	nullable: boolean;
 	default: string | null;
 	primary_key: boolean;

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -2517,8 +2517,6 @@ export function ConnectionDetails() {
 			pendingInlineEditsByTab[tab.id] ?? {},
 		).length;
 		const hasPendingInlineChanges = pendingInlineChangeCount > 0;
-		const hasReturnedRows = (tab.data?.data.length ?? 0) > 0;
-		const showFilterInput = tab.loading || hasReturnedRows;
 
 		return (
 			<Card className="workspace-panel">
@@ -2595,7 +2593,6 @@ export function ConnectionDetails() {
 					state={tab.filterState}
 					columns={tab.columns}
 					loading={tab.loading}
-					showInput={showFilterInput}
 					onStateChange={handleTableFilterStateChange}
 					onApply={handleApplyFilter}
 					onClear={handleClearFilter}


### PR DESCRIPTION
## Summary

- move **Apply filter** onto the Builder/Advanced toolbar and make the selected mode visually and accessibly explicit
- derive filter capabilities from backend, dialect-aware column metadata instead of frontend type-name heuristics
- provide type-aware operators and inputs while preserving wide integers and high-precision decimals without JavaScript precision loss
- keep the filter editor stable when a filter returns zero rows, reject stale column conditions safely, and expose table-data filters to the command palette's Clear Filter action
- keep internal PostgreSQL schema JSON backward-compatible when filter capability metadata is absent, then restore the correct dialect-aware capability after deserialization
- give the Settings theme selector an explicit selected style and `aria-pressed` state; audit the analogous filter mode, shared tabs, and workspace tabs for the same defect

## Root cause

The filter UI was coupled to whether the current response contained rows, while column capabilities were inferred independently in the frontend from raw type strings. That made the editor collapse on empty filtered results, misclassified dialect-specific types, allowed stale conditions to borrow another column's behavior, and converted some numeric values through lossy generic representations.

The initial capability change also made `filter_kind` mandatory on `ColumnInfo`, but PostgreSQL schema-overview rows are assembled as internal JSON without that new field. The model now defaults missing internal metadata safely and the PostgreSQL boundary classifies each parsed column before returning it.

The theme selector relied on the generic secondary button variant inside a muted segmented container, so its selected state did not remain visually distinct across themes. It now uses a dedicated segmented selector with an explicit background, border, foreground, shadow, and pressed state.

## Validation

- `bun test` — 30 tests passed
- `bun run build`
- `cargo test --lib` — 16 tests passed
- `cargo test --no-run` — all Rust test targets compiled
- Biome check on changed frontend modules
- Rustfmt check on changed Rust modules
- launched the Tauri app from this branch and opened the Nilguard PostgreSQL connection; 34 objects loaded without the previous `filter_kind` parsing error
- exercised Light, Dark, and System in the running Settings dialog and restored the selector to System

## Existing baseline

`bunx tsc --noEmit` still reports unrelated pre-existing errors in example/schema components and the repository's existing Bun test type declarations; the production build and focused changed-file checks pass.