### PR TITLE
v0.0.63 release

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

- bump the canonical Tauri app version from `0.0.62` to `0.0.63`
- release the merged table-filter UX, dialect-aware filtering, exact numeric handling, empty-result stability, and theme-selector state improvements from #124

## Validation

- `bun test` — 30 tests passed
- `bun run build`
- `cargo test --lib -- --test-threads=1` — 16 tests passed
- `cargo test --no-run` — all Rust test targets compiled
- verified the PR diff is limited to `src-tauri/tauri.conf.json`

## Existing baseline

`cargo fmt --check` reports two formatting differences already present on `main` in `src-tauri/src/database/queries/mod.rs` and `src-tauri/tests/unified_commands_tests.rs`; this release PR leaves them untouched.

## Release

Merging this PR with the `release` label will let `tag-on-merge` create `v0.0.63`, after which `publish.yml` will build the draft macOS release.