### PR TITLE
Stop replaying indeterminate database writes

### DIFF
--- a/src-tauri/src/commands/connections.rs
+++ b/src-tauri/src/commands/connections.rs
@@ -1,3 +1,4 @@
+use crate::database::pool_manager::PoolManager;
 use crate::db::models::{Connection, ConnectionFormData};
 use sqlx::SqlitePool;
 use tauri::State;
@@ -66,14 +67,30 @@ pub async fn create_connection(
 #[tauri::command]
 pub async fn update_connection(
     pool: State<'_, SqlitePool>,
+    pool_manager: State<'_, PoolManager>,
     id: i64,
     data: ConnectionFormData,
 ) -> Result<Connection, String> {
+    update_connection_inner(pool.inner(), &pool_manager, id, data).await
+}
+
+async fn update_connection_inner(
+    pool: &SqlitePool,
+    pool_manager: &PoolManager,
+    id: i64,
+    data: ConnectionFormData,
+) -> Result<Connection, String> {
+    let uuid: String = sqlx::query_scalar("SELECT uuid FROM connections WHERE id = ?")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .map_err(|e| e.to_string())?;
+    let lifecycle = pool_manager.connection_lifecycle(&uuid).await;
     let ssl = if data.ssl { 1 } else { 0 };
     let ssh_enabled = if data.ssh_enabled { 1 } else { 0 };
     let ssh_use_key = if data.ssh_use_key { 1 } else { 0 };
 
-    sqlx::query_as::<_, Connection>(
+    let connection = sqlx::query_as::<_, Connection>(
         r#"
         UPDATE connections
         SET type = ?, name = ?, host = ?, port = ?, database = ?, username = ?, password = ?, ssl = ?,
@@ -102,19 +119,40 @@ pub async fn update_connection(
     .bind(&data.ssh_key_path)
     .bind(ssh_use_key)
     .bind(id)
-    .fetch_one(pool.inner())
+    .fetch_one(pool)
     .await
-    .map_err(|e| e.to_string())
+    .map_err(|e| e.to_string())?;
+    lifecycle.invalidate().await;
+    Ok(connection)
 }
 
 #[tauri::command]
-pub async fn delete_connection(pool: State<'_, SqlitePool>, id: i64) -> Result<bool, String> {
+pub async fn delete_connection(
+    pool: State<'_, SqlitePool>,
+    pool_manager: State<'_, PoolManager>,
+    id: i64,
+) -> Result<bool, String> {
+    delete_connection_inner(pool.inner(), &pool_manager, id).await
+}
+
+async fn delete_connection_inner(
+    pool: &SqlitePool,
+    pool_manager: &PoolManager,
+    id: i64,
+) -> Result<bool, String> {
+    let uuid: String = sqlx::query_scalar("SELECT uuid FROM connections WHERE id = ?")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .map_err(|e| e.to_string())?;
+    let lifecycle = pool_manager.connection_lifecycle(&uuid).await;
     sqlx::query("DELETE FROM connections WHERE id = ?")
         .bind(id)
-        .execute(pool.inner())
+        .execute(pool)
         .await
-        .map(|_| true)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    lifecycle.invalidate().await;
+    Ok(true)
 }
 
 /// Exported connection data (without id, uuid, timestamps)
@@ -259,4 +297,154 @@ pub async fn import_connections(
     }
 
     Ok(imported_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{delete_connection_inner, update_connection_inner};
+    use crate::database::pool_manager::{ConnectionConfig, PoolManager};
+    use crate::db::models::ConnectionFormData;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use std::sync::Arc;
+    use tempfile::NamedTempFile;
+
+    async fn test_metadata_pool() -> sqlx::SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            r#"CREATE TABLE connections (
+                id INTEGER PRIMARY KEY, uuid TEXT NOT NULL UNIQUE,
+                type TEXT NOT NULL, name TEXT NOT NULL, host TEXT NOT NULL,
+                port INTEGER NOT NULL, database TEXT NOT NULL, username TEXT NOT NULL,
+                password TEXT NOT NULL, ssl INTEGER NOT NULL, db_type TEXT NOT NULL,
+                file_path TEXT, ssh_enabled INTEGER NOT NULL, ssh_host TEXT NOT NULL,
+                ssh_port INTEGER NOT NULL, ssh_user TEXT NOT NULL, ssh_password TEXT NOT NULL,
+                ssh_key_path TEXT NOT NULL, ssh_use_key INTEGER NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )"#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool
+    }
+
+    async fn insert_connection(pool: &sqlx::SqlitePool, uuid: &str, file_path: &str) {
+        sqlx::query(
+            "INSERT INTO connections VALUES (1, ?, 'sqlite', 'test', '', 0, '', '', '', 0, 'sqlite', ?, 0, '', 22, '', '', '', 0, datetime('now'), datetime('now'))",
+        )
+        .bind(uuid)
+        .bind(file_path)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    fn form(file_path: &str) -> ConnectionFormData {
+        ConnectionFormData {
+            connection_type: "sqlite".into(),
+            name: "updated".into(),
+            host: String::new(),
+            port: 0,
+            database: String::new(),
+            username: String::new(),
+            password: String::new(),
+            ssl: false,
+            db_type: "sqlite".into(),
+            file_path: Some(file_path.into()),
+            ssh_enabled: false,
+            ssh_host: String::new(),
+            ssh_port: 22,
+            ssh_user: String::new(),
+            ssh_password: String::new(),
+            ssh_key_path: String::new(),
+            ssh_use_key: false,
+        }
+    }
+
+    async fn cache_sqlite(manager: &PoolManager, uuid: &str, file_path: &str) {
+        let lifecycle = manager.connection_lifecycle(uuid).await;
+        lifecycle
+            .connect(ConnectionConfig {
+                db_type: "sqlite".into(),
+                host: None,
+                port: None,
+                database: None,
+                username: None,
+                password: None,
+                ssl: None,
+                file_path: Some(file_path.into()),
+                ssh_enabled: false,
+                ssh_host: None,
+                ssh_port: None,
+                ssh_user: None,
+                ssh_password: None,
+                ssh_key_path: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_waits_for_lifecycle_and_invalidates_cached_driver() {
+        let database = NamedTempFile::new().unwrap();
+        let path = database.path().to_string_lossy().into_owned();
+        let pool = Arc::new(test_metadata_pool().await);
+        insert_connection(&pool, "connection-uuid", &path).await;
+        let manager = Arc::new(PoolManager::new());
+        cache_sqlite(&manager, "connection-uuid", &path).await;
+        let lifecycle = manager.connection_lifecycle("connection-uuid").await;
+
+        let task = tokio::spawn({
+            let pool = pool.clone();
+            let manager = manager.clone();
+            let path = path.clone();
+            async move { update_connection_inner(&pool, &manager, 1, form(&path)).await }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert!(!task.is_finished());
+
+        drop(lifecycle);
+        task.await.unwrap().unwrap();
+        assert!(manager.get_cached("connection-uuid").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn failed_delete_keeps_cached_driver() {
+        let database = NamedTempFile::new().unwrap();
+        let path = database.path().to_string_lossy().into_owned();
+        let pool = test_metadata_pool().await;
+        insert_connection(&pool, "connection-uuid", &path).await;
+        let manager = PoolManager::new();
+        cache_sqlite(&manager, "connection-uuid", &path).await;
+        pool.close().await;
+
+        assert!(delete_connection_inner(&pool, &manager, 1).await.is_err());
+        assert!(manager.get_cached("connection-uuid").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn failed_update_keeps_cached_driver() {
+        let database = NamedTempFile::new().unwrap();
+        let path = database.path().to_string_lossy().into_owned();
+        let pool = test_metadata_pool().await;
+        insert_connection(&pool, "connection-uuid", &path).await;
+        sqlx::query(
+            "CREATE TRIGGER reject_update BEFORE UPDATE ON connections BEGIN SELECT RAISE(FAIL, 'rejected'); END",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let manager = PoolManager::new();
+        cache_sqlite(&manager, "connection-uuid", &path).await;
+
+        assert!(update_connection_inner(&pool, &manager, 1, form(&path))
+            .await
+            .is_err());
+        assert!(manager.get_cached("connection-uuid").await.is_some());
+    }
 }

--- a/src-tauri/src/commands/pool.rs
+++ b/src-tauri/src/commands/pool.rs
@@ -194,6 +194,38 @@ async fn reconnect(
     Ok(())
 }
 
+async fn execute_once<T, Operation, OperationFuture>(operation: Operation) -> Result<T, String>
+where
+    Operation: FnOnce() -> OperationFuture,
+    OperationFuture: std::future::Future<Output = Result<T, String>>,
+{
+    operation().await
+}
+
+async fn execute_read_only_with_retry<T, Operation, OperationFuture, Reconnect, ReconnectFuture>(
+    operation_name: &str,
+    mut operation: Operation,
+    reconnect: Reconnect,
+) -> Result<T, String>
+where
+    Operation: FnMut() -> OperationFuture,
+    OperationFuture: std::future::Future<Output = Result<T, String>>,
+    Reconnect: FnOnce() -> ReconnectFuture,
+    ReconnectFuture: std::future::Future<Output = Result<(), String>>,
+{
+    match operation().await {
+        Ok(result) => Ok(result),
+        Err(error) => {
+            println!(
+                "[Pool] {} failed: {}, retrying with fresh connection",
+                operation_name, error
+            );
+            reconnect().await?;
+            operation().await
+        }
+    }
+}
+
 /// List tables using the pooled connection (auto-connects if needed, auto-retries on error)
 #[tauri::command]
 pub async fn pool_list_tables(
@@ -204,19 +236,12 @@ pub async fn pool_list_tables(
     // Ensure connected
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    // Try the operation
-    match pool_manager.list_tables(&uuid).await {
-        Ok(result) => Ok(result),
-        Err(e) => {
-            // On error, disconnect and retry once with fresh connection
-            println!(
-                "[Pool] list_tables failed: {}, retrying with fresh connection",
-                e
-            );
-            reconnect(&pool_manager, sqlite_pool.inner(), &uuid).await?;
-            pool_manager.list_tables(&uuid).await
-        }
-    }
+    execute_read_only_with_retry(
+        "list_tables",
+        || pool_manager.list_tables(&uuid),
+        || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
+    )
+    .await
 }
 
 /// Get table data using the pooled connection (auto-connects if needed, auto-retries on error)
@@ -237,40 +262,23 @@ pub async fn pool_get_table_data(
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
     let table_filter = crate::db::models::TableFilter::from_parts(filter, structured_filter)?;
 
-    match pool_manager
-        .get_table_data(
-            &uuid,
-            &schema,
-            &table,
-            page,
-            limit,
-            table_filter.clone(),
-            sort_column.clone(),
-            sort_direction.clone(),
-        )
-        .await
-    {
-        Ok(result) => Ok(result),
-        Err(e) => {
-            println!(
-                "[Pool] get_table_data failed: {}, retrying with fresh connection",
-                e
-            );
-            reconnect(&pool_manager, sqlite_pool.inner(), &uuid).await?;
-            pool_manager
-                .get_table_data(
-                    &uuid,
-                    &schema,
-                    &table,
-                    page,
-                    limit,
-                    table_filter,
-                    sort_column,
-                    sort_direction,
-                )
-                .await
-        }
-    }
+    execute_read_only_with_retry(
+        "get_table_data",
+        || {
+            pool_manager.get_table_data(
+                &uuid,
+                &schema,
+                &table,
+                page,
+                limit,
+                table_filter.clone(),
+                sort_column.clone(),
+                sort_direction.clone(),
+            )
+        },
+        || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
+    )
+    .await
 }
 
 /// Get table structure using the pooled connection (auto-connects if needed, auto-retries on error)
@@ -284,25 +292,15 @@ pub async fn pool_get_table_structure(
 ) -> Result<crate::db::models::TableStructure, String> {
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    match pool_manager
-        .get_table_structure(&uuid, &schema, &table)
-        .await
-    {
-        Ok(result) => Ok(result),
-        Err(e) => {
-            println!(
-                "[Pool] get_table_structure failed: {}, retrying with fresh connection",
-                e
-            );
-            reconnect(&pool_manager, sqlite_pool.inner(), &uuid).await?;
-            pool_manager
-                .get_table_structure(&uuid, &schema, &table)
-                .await
-        }
-    }
+    execute_read_only_with_retry(
+        "get_table_structure",
+        || pool_manager.get_table_structure(&uuid, &schema, &table),
+        || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
+    )
+    .await
 }
 
-/// Execute query using the pooled connection (auto-connects if needed, auto-retries on error)
+/// Execute arbitrary SQL using the pooled connection without retrying driver errors
 #[tauri::command]
 pub async fn pool_execute_query(
     pool_manager: State<'_, PoolManager>,
@@ -312,17 +310,7 @@ pub async fn pool_execute_query(
 ) -> Result<crate::db::models::QueryResult, String> {
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    match pool_manager.execute_query(&uuid, &query).await {
-        Ok(result) => Ok(result),
-        Err(e) => {
-            println!(
-                "[Pool] execute_query failed: {}, retrying with fresh connection",
-                e
-            );
-            reconnect(&pool_manager, sqlite_pool.inner(), &uuid).await?;
-            pool_manager.execute_query(&uuid, &query).await
-        }
-    }
+    execute_once(|| pool_manager.execute_query(&uuid, &query)).await
 }
 
 /// Get schema overview using the pooled connection (auto-connects if needed, auto-retries on error)
@@ -334,17 +322,12 @@ pub async fn pool_get_schema_overview(
 ) -> Result<crate::db::models::SchemaOverview, String> {
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    match pool_manager.get_schema_overview(&uuid).await {
-        Ok(result) => Ok(result),
-        Err(e) => {
-            println!(
-                "[Pool] get_schema_overview failed: {}, retrying with fresh connection",
-                e
-            );
-            reconnect(&pool_manager, sqlite_pool.inner(), &uuid).await?;
-            pool_manager.get_schema_overview(&uuid).await
-        }
-    }
+    execute_read_only_with_retry(
+        "get_schema_overview",
+        || pool_manager.get_schema_overview(&uuid),
+        || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
+    )
+    .await
 }
 
 /// Get a function definition using the pooled connection (auto-connects if needed, auto-retries on error)
@@ -359,22 +342,12 @@ pub async fn pool_get_function_definition(
 ) -> Result<crate::db::models::FunctionDefinition, String> {
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    match pool_manager
-        .get_function_definition(&uuid, &schema, &name, &identity_args)
-        .await
-    {
-        Ok(result) => Ok(result),
-        Err(e) => {
-            println!(
-                "[Pool] get_function_definition failed: {}, retrying with fresh connection",
-                e
-            );
-            reconnect(&pool_manager, sqlite_pool.inner(), &uuid).await?;
-            pool_manager
-                .get_function_definition(&uuid, &schema, &name, &identity_args)
-                .await
-        }
-    }
+    execute_read_only_with_retry(
+        "get_function_definition",
+        || pool_manager.get_function_definition(&uuid, &schema, &name, &identity_args),
+        || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
+    )
+    .await
 }
 
 // ============================================================================
@@ -478,17 +451,7 @@ pub async fn pool_update_table_row(
 
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    match pool_manager.execute_query(&uuid, &query).await {
-        Ok(result) => Ok(result),
-        Err(e) => {
-            println!(
-                "[Pool] update_table_row failed: {}, retrying with fresh connection",
-                e
-            );
-            reconnect(&pool_manager, sqlite_pool.inner(), &uuid).await?;
-            pool_manager.execute_query(&uuid, &query).await
-        }
-    }
+    execute_once(|| pool_manager.execute_query(&uuid, &query)).await
 }
 
 /// Delete a row from a table using the pooled connection
@@ -542,17 +505,7 @@ pub async fn pool_delete_table_row(
 
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    match pool_manager.execute_query(&uuid, &query).await {
-        Ok(result) => Ok(result),
-        Err(e) => {
-            println!(
-                "[Pool] delete_table_row failed: {}, retrying with fresh connection",
-                e
-            );
-            reconnect(&pool_manager, sqlite_pool.inner(), &uuid).await?;
-            pool_manager.execute_query(&uuid, &query).await
-        }
-    }
+    execute_once(|| pool_manager.execute_query(&uuid, &query)).await
 }
 
 /// Insert a new row into a table using the pooled connection
@@ -633,15 +586,56 @@ pub async fn pool_insert_table_row(
 
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    match pool_manager.execute_query(&uuid, &query).await {
-        Ok(result) => Ok(result),
-        Err(e) => {
-            println!(
-                "[Pool] insert_table_row failed: {}, retrying with fresh connection",
-                e
-            );
-            reconnect(&pool_manager, sqlite_pool.inner(), &uuid).await?;
-            pool_manager.execute_query(&uuid, &query).await
+    execute_once(|| pool_manager.execute_query(&uuid, &query)).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{execute_once, execute_read_only_with_retry};
+    use std::cell::Cell;
+
+    #[tokio::test]
+    async fn execute_policy_returns_first_error_without_reconnect() {
+        for command in ["arbitrary SQL", "update", "delete", "insert"] {
+            let operation_calls = Cell::new(0);
+            let reconnect_calls = Cell::new(0);
+
+            let result: Result<(), String> = execute_once(|| async {
+                operation_calls.set(operation_calls.get() + 1);
+                Err(format!("{command} failed"))
+            })
+            .await;
+
+            assert_eq!(result, Err(format!("{command} failed")));
+            assert_eq!(operation_calls.get(), 1, "{command}");
+            assert_eq!(reconnect_calls.get(), 0, "{command}");
         }
+    }
+
+    #[tokio::test]
+    async fn read_only_policy_reconnects_once_and_runs_operation_twice() {
+        let operation_calls = Cell::new(0);
+        let reconnect_calls = Cell::new(0);
+
+        let result = execute_read_only_with_retry(
+            "test_read",
+            || async {
+                operation_calls.set(operation_calls.get() + 1);
+                if operation_calls.get() == 1 {
+                    Err("stale connection".to_string())
+                } else {
+                    Ok("rows")
+                }
+            },
+            || async {
+                reconnect_calls.set(reconnect_calls.get() + 1);
+                Ok(())
+            },
+        )
+        .await;
+
+        assert_eq!(result, Ok("rows"));
+        assert_eq!(operation_calls.get(), 2);
+        assert_eq!(reconnect_calls.get(), 1);
     }
 }

--- a/src-tauri/src/commands/pool.rs
+++ b/src-tauri/src/commands/pool.rs
@@ -22,6 +22,8 @@ pub async fn pool_connect(
     sqlite_pool: State<'_, SqlitePool>,
     uuid: String,
 ) -> Result<ConnectionStatusResponse, String> {
+    let lifecycle = pool_manager.connection_lifecycle(&uuid).await;
+
     // Get connection details from database
     let conn: crate::db::models::Connection =
         sqlx::query_as("SELECT * FROM connections WHERE uuid = ?")
@@ -63,12 +65,7 @@ pub async fn pool_connect(
         },
     };
 
-    // Serialize with data-op (re)connects for this UUID so a UI-initiated
-    // connect can't race a concurrent ensure_connection/reconnect.
-    let lock = pool_manager.get_connect_lock(&uuid).await;
-    let _guard = lock.lock().await;
-
-    match pool_manager.connect(&uuid, config).await {
+    match lifecycle.connect(config).await {
         Ok(_) => Ok(ConnectionStatusResponse {
             status: ConnectionStatus::Connected,
             error: None,
@@ -86,7 +83,8 @@ pub async fn pool_disconnect(
     pool_manager: State<'_, PoolManager>,
     uuid: String,
 ) -> Result<(), String> {
-    pool_manager.disconnect(&uuid).await;
+    let lifecycle = pool_manager.connection_lifecycle(&uuid).await;
+    lifecycle.invalidate().await;
     Ok(())
 }
 
@@ -162,9 +160,7 @@ async fn ensure_connection(
     sqlite_pool: &SqlitePool,
     uuid: &str,
 ) -> Result<(), String> {
-    // Acquire lock to serialize connect attempts for this UUID
-    let lock = pool_manager.get_connect_lock(uuid).await;
-    let _guard = lock.lock().await;
+    let lifecycle = pool_manager.connection_lifecycle(uuid).await;
 
     // Check if already connected (another thread may have just connected)
     if pool_manager.get_cached(uuid).await.is_some() {
@@ -172,7 +168,7 @@ async fn ensure_connection(
     }
     // Not connected, get config and connect
     let config = get_connection_config(sqlite_pool, uuid).await?;
-    pool_manager.connect(uuid, config).await?;
+    lifecycle.connect(config).await?;
     Ok(())
 }
 
@@ -182,15 +178,14 @@ async fn reconnect(
     sqlite_pool: &SqlitePool,
     uuid: &str,
 ) -> Result<(), String> {
-    let lock = pool_manager.get_connect_lock(uuid).await;
-    let _guard = lock.lock().await;
+    let lifecycle = pool_manager.connection_lifecycle(uuid).await;
 
     // Disconnect stale connection
-    pool_manager.disconnect(uuid).await;
+    lifecycle.invalidate().await;
 
     // Reconnect
     let config = get_connection_config(sqlite_pool, uuid).await?;
-    pool_manager.connect(uuid, config).await?;
+    lifecycle.connect(config).await?;
     Ok(())
 }
 

--- a/src-tauri/src/commands/pool.rs
+++ b/src-tauri/src/commands/pool.rs
@@ -189,16 +189,15 @@ async fn reconnect(
     Ok(())
 }
 
-async fn execute_once<T, Operation, OperationFuture>(operation: Operation) -> Result<T, String>
-where
-    Operation: FnOnce() -> OperationFuture,
-    OperationFuture: std::future::Future<Output = Result<T, String>>,
-{
-    operation().await
+#[derive(Clone, Copy)]
+enum RetryPolicy {
+    Never,
+    ReconnectOnce,
 }
 
-async fn execute_read_only_with_retry<T, Operation, OperationFuture, Reconnect, ReconnectFuture>(
+async fn execute_with_retry_policy<T, Operation, OperationFuture, Reconnect, ReconnectFuture>(
     operation_name: &str,
+    retry_policy: RetryPolicy,
     mut operation: Operation,
     reconnect: Reconnect,
 ) -> Result<T, String>
@@ -210,6 +209,7 @@ where
 {
     match operation().await {
         Ok(result) => Ok(result),
+        Err(error) if matches!(retry_policy, RetryPolicy::Never) => Err(error),
         Err(error) => {
             println!(
                 "[Pool] {} failed: {}, retrying with fresh connection",
@@ -231,8 +231,9 @@ pub async fn pool_list_tables(
     // Ensure connected
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    execute_read_only_with_retry(
+    execute_with_retry_policy(
         "list_tables",
+        RetryPolicy::ReconnectOnce,
         || pool_manager.list_tables(&uuid),
         || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
     )
@@ -257,8 +258,9 @@ pub async fn pool_get_table_data(
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
     let table_filter = crate::db::models::TableFilter::from_parts(filter, structured_filter)?;
 
-    execute_read_only_with_retry(
+    execute_with_retry_policy(
         "get_table_data",
+        RetryPolicy::ReconnectOnce,
         || {
             pool_manager.get_table_data(
                 &uuid,
@@ -287,8 +289,9 @@ pub async fn pool_get_table_structure(
 ) -> Result<crate::db::models::TableStructure, String> {
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    execute_read_only_with_retry(
+    execute_with_retry_policy(
         "get_table_structure",
+        RetryPolicy::ReconnectOnce,
         || pool_manager.get_table_structure(&uuid, &schema, &table),
         || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
     )
@@ -305,7 +308,13 @@ pub async fn pool_execute_query(
 ) -> Result<crate::db::models::QueryResult, String> {
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    execute_once(|| pool_manager.execute_query(&uuid, &query)).await
+    execute_with_retry_policy(
+        "execute_query",
+        RetryPolicy::Never,
+        || pool_manager.execute_query(&uuid, &query),
+        || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
+    )
+    .await
 }
 
 /// Get schema overview using the pooled connection (auto-connects if needed, auto-retries on error)
@@ -317,8 +326,9 @@ pub async fn pool_get_schema_overview(
 ) -> Result<crate::db::models::SchemaOverview, String> {
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    execute_read_only_with_retry(
+    execute_with_retry_policy(
         "get_schema_overview",
+        RetryPolicy::ReconnectOnce,
         || pool_manager.get_schema_overview(&uuid),
         || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
     )
@@ -337,8 +347,9 @@ pub async fn pool_get_function_definition(
 ) -> Result<crate::db::models::FunctionDefinition, String> {
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    execute_read_only_with_retry(
+    execute_with_retry_policy(
         "get_function_definition",
+        RetryPolicy::ReconnectOnce,
         || pool_manager.get_function_definition(&uuid, &schema, &name, &identity_args),
         || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
     )
@@ -446,7 +457,13 @@ pub async fn pool_update_table_row(
 
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    execute_once(|| pool_manager.execute_query(&uuid, &query)).await
+    execute_with_retry_policy(
+        "update_table_row",
+        RetryPolicy::Never,
+        || pool_manager.execute_query(&uuid, &query),
+        || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
+    )
+    .await
 }
 
 /// Delete a row from a table using the pooled connection
@@ -500,7 +517,13 @@ pub async fn pool_delete_table_row(
 
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    execute_once(|| pool_manager.execute_query(&uuid, &query)).await
+    execute_with_retry_policy(
+        "delete_table_row",
+        RetryPolicy::Never,
+        || pool_manager.execute_query(&uuid, &query),
+        || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
+    )
+    .await
 }
 
 /// Insert a new row into a table using the pooled connection
@@ -581,24 +604,38 @@ pub async fn pool_insert_table_row(
 
     ensure_connection(&pool_manager, sqlite_pool.inner(), &uuid).await?;
 
-    execute_once(|| pool_manager.execute_query(&uuid, &query)).await
+    execute_with_retry_policy(
+        "insert_table_row",
+        RetryPolicy::Never,
+        || pool_manager.execute_query(&uuid, &query),
+        || reconnect(&pool_manager, sqlite_pool.inner(), &uuid),
+    )
+    .await
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{execute_once, execute_read_only_with_retry};
+    use super::{execute_with_retry_policy, RetryPolicy};
     use std::cell::Cell;
 
     #[tokio::test]
-    async fn execute_policy_returns_first_error_without_reconnect() {
+    async fn never_retry_policy_returns_first_error_without_reconnect() {
         for command in ["arbitrary SQL", "update", "delete", "insert"] {
             let operation_calls = Cell::new(0);
             let reconnect_calls = Cell::new(0);
 
-            let result: Result<(), String> = execute_once(|| async {
-                operation_calls.set(operation_calls.get() + 1);
-                Err(format!("{command} failed"))
-            })
+            let result: Result<(), String> = execute_with_retry_policy(
+                command,
+                RetryPolicy::Never,
+                || async {
+                    operation_calls.set(operation_calls.get() + 1);
+                    Err(format!("{command} failed"))
+                },
+                || async {
+                    reconnect_calls.set(reconnect_calls.get() + 1);
+                    Ok(())
+                },
+            )
             .await;
 
             assert_eq!(result, Err(format!("{command} failed")));
@@ -612,8 +649,9 @@ mod tests {
         let operation_calls = Cell::new(0);
         let reconnect_calls = Cell::new(0);
 
-        let result = execute_read_only_with_retry(
+        let result = execute_with_retry_policy(
             "test_read",
+            RetryPolicy::ReconnectOnce,
             || async {
                 operation_calls.set(operation_calls.get() + 1);
                 if operation_calls.get() == 1 {

--- a/src-tauri/src/database/pool_manager.rs
+++ b/src-tauri/src/database/pool_manager.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, OwnedMutexGuard, RwLock};
 
 use super::clickhouse::ClickhouseDriver;
 use super::postgres::PostgresDriver;
@@ -67,6 +67,25 @@ pub struct PoolManager {
     connect_locks: RwLock<HashMap<String, Arc<Mutex<()>>>>,
 }
 
+pub(crate) struct ConnectionLifecycle<'a> {
+    pool_manager: &'a PoolManager,
+    uuid: String,
+    _guard: OwnedMutexGuard<()>,
+}
+
+impl ConnectionLifecycle<'_> {
+    pub async fn connect(
+        &self,
+        config: ConnectionConfig,
+    ) -> Result<Arc<Box<dyn DatabaseDriver>>, String> {
+        self.pool_manager.connect_unlocked(&self.uuid, config).await
+    }
+
+    pub async fn invalidate(&self) {
+        self.pool_manager.remove_unlocked(&self.uuid).await;
+    }
+}
+
 impl Default for PoolManager {
     fn default() -> Self {
         Self::new()
@@ -81,8 +100,7 @@ impl PoolManager {
         }
     }
 
-    /// Get or create a lock for a specific connection UUID
-    pub async fn get_connect_lock(&self, uuid: &str) -> Arc<Mutex<()>> {
+    async fn get_connect_lock(&self, uuid: &str) -> Arc<Mutex<()>> {
         {
             let locks = self.connect_locks.read().await;
             if let Some(lock) = locks.get(uuid) {
@@ -95,6 +113,16 @@ impl PoolManager {
             .entry(uuid.to_string())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone()
+    }
+
+    pub(crate) async fn connection_lifecycle(&self, uuid: &str) -> ConnectionLifecycle<'_> {
+        let lock = self.get_connect_lock(uuid).await;
+        let guard = lock.lock_owned().await;
+        ConnectionLifecycle {
+            pool_manager: self,
+            uuid: uuid.to_string(),
+            _guard: guard,
+        }
     }
 
     /// Create a driver from configuration (with optional SSH tunnel)
@@ -203,7 +231,7 @@ impl PoolManager {
     }
 
     /// Explicitly connect (or reconnect) a connection
-    pub async fn connect(
+    async fn connect_unlocked(
         &self,
         uuid: &str,
         config: ConnectionConfig,
@@ -254,8 +282,7 @@ impl PoolManager {
         }
     }
 
-    /// Disconnect and remove a connection from the pool
-    pub async fn disconnect(&self, uuid: &str) {
+    async fn remove_unlocked(&self, uuid: &str) {
         let mut pools = self.pools.write().await;
         pools.remove(uuid);
     }


### PR DESCRIPTION
## Summary
- execute arbitrary SQL and generated row mutations at most once after connection setup
- preserve one reconnect/retry for intrinsically read-only pool operations
- centralize the two execution policies in production-used helpers with call-count regression tests

## Why
A write may commit before its response is lost. Automatically reconnecting and replaying it can duplicate inserts or apply updates/deletes twice.

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml commands::pool::tests`
- `cargo test --manifest-path src-tauri/Cargo.toml --no-run`
- `git diff --check origin/main..HEAD`

Full service-backed integration tests were not run; all Rust test targets compile successfully.