### PR TITLE
Parameterize ClickHouse catalog queries

### DIFF
--- a/src-tauri/src/database/clickhouse.rs
+++ b/src-tauri/src/database/clickhouse.rs
@@ -51,6 +51,14 @@ pub struct ClickhouseDriver {
     client: reqwest::Client,
 }
 
+#[derive(Debug, PartialEq)]
+enum ClickhouseParamValue {
+    EscapedText(String),
+    Raw(String),
+}
+
+type ClickhouseParam = (String, ClickhouseParamValue);
+
 impl ClickhouseDriver {
     pub fn new(config: ClickhouseConfig) -> Self {
         Self {
@@ -72,7 +80,7 @@ impl ClickhouseDriver {
     async fn execute_bounded_query_json_with_params(
         &self,
         query: &str,
-        params: &[(String, String)],
+        params: &[ClickhouseParam],
     ) -> Result<(Vec<Value>, bool), String> {
         let cleaned_query = query.trim().trim_end_matches(';').trim();
         let upper = cleaned_query.to_uppercase();
@@ -100,32 +108,12 @@ impl ClickhouseDriver {
     async fn execute_query_json_with_params(
         &self,
         query: &str,
-        params: &[(String, String)],
+        params: &[ClickhouseParam],
     ) -> Result<Vec<Value>, String> {
-        let url = self.build_url();
         let client = &self.client;
+        let request = self.build_query_request(client, query, params)?;
 
-        // Clean up the query: trim whitespace, remove trailing semicolons
-        let cleaned_query = query.trim().trim_end_matches(';').trim();
-
-        // Only add FORMAT if not already present
-        let full_query = if cleaned_query.to_uppercase().contains("FORMAT ") {
-            cleaned_query.to_string()
-        } else {
-            format!("{} FORMAT JSONEachRow", cleaned_query)
-        };
-
-        let mut query_params = vec![("database".to_string(), self.config.database.clone())];
-        query_params.extend_from_slice(params);
-
-        let response = client
-            .post(&url)
-            .basic_auth(&self.config.username, Some(&self.config.password))
-            .query(&query_params)
-            .body(full_query)
-            .send()
-            .await
-            .map_err(|e| e.to_string())?;
+        let response = client.execute(request).await.map_err(|e| e.to_string())?;
 
         if !response.status().is_success() {
             let error_text = response.text().await.unwrap_or_default();
@@ -144,27 +132,95 @@ impl ClickhouseDriver {
         Ok(rows)
     }
 
-    fn filter_params(values: &[FilterValue]) -> Vec<(String, String)> {
+    fn build_query_request(
+        &self,
+        client: &reqwest::Client,
+        query: &str,
+        params: &[ClickhouseParam],
+    ) -> Result<reqwest::Request, String> {
+        let url = self.build_url();
+
+        // Clean up the query: trim whitespace, remove trailing semicolons
+        let cleaned_query = query.trim().trim_end_matches(';').trim();
+
+        // Only add FORMAT if not already present
+        let full_query = if cleaned_query.to_uppercase().contains("FORMAT ") {
+            cleaned_query.to_string()
+        } else {
+            format!("{} FORMAT JSONEachRow", cleaned_query)
+        };
+
+        let mut query_params = vec![("database".to_string(), self.config.database.clone())];
+        query_params.extend(params.iter().map(|(key, value)| {
+            let value = match value {
+                ClickhouseParamValue::EscapedText(value) => Self::escape_param_text(value),
+                ClickhouseParamValue::Raw(value) => value.clone(),
+            };
+            (key.clone(), value)
+        }));
+
+        client
+            .post(&url)
+            .basic_auth(&self.config.username, Some(&self.config.password))
+            .query(&query_params)
+            .body(full_query)
+            .build()
+            .map_err(|error| error.to_string())
+    }
+
+    fn escape_param_text(value: &str) -> String {
+        let mut escaped = String::with_capacity(value.len());
+        for character in value.chars() {
+            match character {
+                '\0' => escaped.push_str("\\0"),
+                '\u{7}' => escaped.push_str("\\a"),
+                '\u{8}' => escaped.push_str("\\b"),
+                '\t' => escaped.push_str("\\t"),
+                '\n' => escaped.push_str("\\n"),
+                '\u{b}' => escaped.push_str("\\v"),
+                '\u{c}' => escaped.push_str("\\f"),
+                '\r' => escaped.push_str("\\r"),
+                '\\' => escaped.push_str("\\\\"),
+                character if character.is_ascii_control() => {
+                    escaped.push_str(&format!("\\x{:02x}", character as u32));
+                }
+                character => escaped.push(character),
+            }
+        }
+        escaped
+    }
+
+    fn filter_params(values: &[FilterValue]) -> Vec<ClickhouseParam> {
         values
             .iter()
             .enumerate()
             .map(|(index, value)| {
                 let value = match value {
-                    FilterValue::Text(value) => value.clone(),
-                    FilterValue::Integer(value) => value.to_string(),
-                    FilterValue::Float(value) => value.to_string(),
-                    FilterValue::Boolean(value) => u8::from(*value).to_string(),
-                    FilterValue::ExactNumber { value, .. } => value.clone(),
+                    FilterValue::Text(value) => ClickhouseParamValue::EscapedText(value.clone()),
+                    FilterValue::Integer(value) => ClickhouseParamValue::Raw(value.to_string()),
+                    FilterValue::Float(value) => ClickhouseParamValue::Raw(value.to_string()),
+                    FilterValue::Boolean(value) => {
+                        ClickhouseParamValue::Raw(u8::from(*value).to_string())
+                    }
+                    FilterValue::ExactNumber { value, .. } => {
+                        ClickhouseParamValue::Raw(value.clone())
+                    }
                 };
                 (format!("param_f{index}"), value)
             })
             .collect()
     }
 
-    fn catalog_params(database: &str, table: Option<&str>) -> Vec<(String, String)> {
-        let mut params = vec![("param_database".to_string(), database.to_string())];
+    fn catalog_params(database: &str, table: Option<&str>) -> Vec<ClickhouseParam> {
+        let mut params = vec![(
+            "param_database".to_string(),
+            ClickhouseParamValue::EscapedText(database.to_string()),
+        )];
         if let Some(table) = table {
-            params.push(("param_table".to_string(), table.to_string()));
+            params.push((
+                "param_table".to_string(),
+                ClickhouseParamValue::EscapedText(table.to_string()),
+            ));
         }
         params
     }
@@ -424,7 +480,10 @@ impl DatabaseDriver for ClickhouseDriver {
     async fn execute_query_read_only(&self, query: &str) -> Result<QueryResult, String> {
         let start_time = std::time::Instant::now();
         // `readonly=1` is enforced server-side: writes, DDL, and SET are rejected.
-        let params = vec![("readonly".to_string(), "1".to_string())];
+        let params = vec![(
+            "readonly".to_string(),
+            ClickhouseParamValue::Raw("1".to_string()),
+        )];
         match self
             .execute_bounded_query_json_with_params(query, &params)
             .await
@@ -545,7 +604,10 @@ impl DatabaseDriver for ClickhouseDriver {
         identity_args: &str,
     ) -> Result<FunctionDefinition, String> {
         let mut params = Self::catalog_params(&self.config.database, None);
-        params.push(("param_name".to_string(), name.to_string()));
+        params.push((
+            "param_name".to_string(),
+            ClickhouseParamValue::EscapedText(name.to_string()),
+        ));
         let row = self
             .execute_query_json_with_params(FUNCTION_DEFINITION_QUERY, &params)
             .await?
@@ -639,45 +701,85 @@ mod tests {
     use super::*;
 
     #[test]
-    fn catalog_queries_keep_hostile_values_out_of_sql() {
-        let database = "catalog' OR 1 = 1 --";
-        let table = "table'} UNION ALL SELECT * --";
-        let params = ClickhouseDriver::catalog_params(database, Some(table));
-
-        for query in [TABLES_QUERY, TABLE_COLUMNS_QUERY, TABLE_INDEXES_QUERY] {
-            assert!(!query.contains(database));
-            assert!(!query.contains(table));
-            assert!(query.contains("{database:String}"));
-        }
-        assert!(TABLE_COLUMNS_QUERY.contains("{table:String}"));
-        assert!(TABLE_INDEXES_QUERY.contains("{table:String}"));
+    fn serializes_clickhouse_escaped_text_without_sql_quoting() {
         assert_eq!(
-            params,
-            vec![
-                ("param_database".to_string(), database.to_string()),
-                ("param_table".to_string(), table.to_string()),
-            ]
+            ClickhouseDriver::escape_param_text("quote'\\\0\u{7}\u{8}\t\n\u{b}\u{c}\r\u{1f}\u{7f}"),
+            "quote'\\\\\\0\\a\\b\\t\\n\\v\\f\\r\\x1f\\x7f"
         );
     }
 
     #[test]
-    fn overview_and_function_queries_use_typed_params() {
-        let database = "catalog' ; DROP DATABASE prod --";
-        let function = "function' OR name != '";
-        let mut params = ClickhouseDriver::catalog_params(database, None);
-        params.push(("param_name".to_string(), function.to_string()));
+    fn request_keeps_typed_placeholders_and_encodes_values_only_in_url() {
+        let database = "catalog'\\line\nnext\0";
+        let table = "table'\\\tend";
+        let driver = ClickhouseDriver::new(ClickhouseConfig {
+            host: "localhost".to_string(),
+            port: 8123,
+            database: database.to_string(),
+            username: "default".to_string(),
+            password: String::new(),
+            protocol: ClickhouseProtocol::Http,
+            ssl: false,
+        });
+        let params = ClickhouseDriver::catalog_params(database, Some(table));
+        let client = reqwest::Client::new();
 
-        for query in [COLUMNS_QUERY, INDEXES_QUERY, FUNCTION_SUMMARIES_QUERY] {
-            assert!(!query.contains(database));
-            assert!(query.contains("{database:String}"));
-        }
-        assert!(!FUNCTION_DEFINITION_QUERY.contains(function));
-        assert!(FUNCTION_DEFINITION_QUERY.contains("{database:String}"));
-        assert!(FUNCTION_DEFINITION_QUERY.contains("{name:String}"));
+        let request = driver
+            .build_query_request(&client, TABLE_COLUMNS_QUERY, &params)
+            .unwrap();
+        let body = request.body().unwrap().as_bytes().unwrap();
+        let body = std::str::from_utf8(body).unwrap();
+        let query_params: HashMap<_, _> = request.url().query_pairs().into_owned().collect();
+
+        assert!(body.contains("database = {database:String}"));
+        assert!(body.contains("table = {table:String}"));
+        assert!(body.ends_with("FORMAT JSONEachRow"));
+        assert!(!body.contains(database));
+        assert!(!body.contains(table));
+        assert_eq!(query_params["database"], database);
+        assert_eq!(query_params["param_database"], "catalog'\\\\line\\nnext\\0");
+        assert_eq!(query_params["param_table"], "table'\\\\\\tend");
+    }
+
+    #[test]
+    fn filter_request_escapes_only_text_values() {
+        let driver = ClickhouseDriver::new(ClickhouseConfig {
+            host: "localhost".to_string(),
+            port: 8123,
+            database: "default".to_string(),
+            username: "default".to_string(),
+            password: String::new(),
+            protocol: ClickhouseProtocol::Http,
+            ssl: false,
+        });
+        let values = vec![
+            FilterValue::Text("a\\b\n".to_string()),
+            FilterValue::Integer(-12),
+            FilterValue::Float(1.5),
+            FilterValue::Boolean(true),
+            FilterValue::ExactNumber {
+                value: "340282366920938463463374607431768211455".to_string(),
+                data_type: "UInt128".to_string(),
+            },
+        ];
+        let params = ClickhouseDriver::filter_params(&values);
+        let client = reqwest::Client::new();
+        let request = driver
+            .build_query_request(
+                &client,
+                "SELECT {f0:String}, {f1:Int64}, {f2:Float64}, {f3:UInt8}, {f4:UInt128}",
+                &params,
+            )
+            .unwrap();
+        let query_params: HashMap<_, _> = request.url().query_pairs().into_owned().collect();
+
+        assert_eq!(query_params["param_f0"], "a\\\\b\\n");
+        assert_eq!(query_params["param_f1"], "-12");
+        assert_eq!(query_params["param_f2"], "1.5");
+        assert_eq!(query_params["param_f3"], "1");
         assert_eq!(
-            params[0],
-            ("param_database".to_string(), database.to_string())
+            query_params["param_f4"],
+            "340282366920938463463374607431768211455"
         );
-        assert_eq!(params[1], ("param_name".to_string(), function.to_string()));
     }
 }

--- a/src-tauri/src/database/clickhouse.rs
+++ b/src-tauri/src/database/clickhouse.rs
@@ -9,6 +9,7 @@ use super::filter::{
 use super::{DatabaseDriver, MAX_QUERY_RESULT_ROWS};
 use crate::database::queries::clickhouse::{
     COLUMNS_QUERY, FUNCTION_DEFINITION_QUERY, FUNCTION_SUMMARIES_QUERY, INDEXES_QUERY,
+    TABLES_QUERY, TABLE_COLUMNS_QUERY, TABLE_INDEXES_QUERY,
 };
 use crate::db::models::{
     ColumnInfo, ForeignKeyInfo, FunctionDefinition, FunctionSummary, IndexInfo, QueryResult,
@@ -160,6 +161,14 @@ impl ClickhouseDriver {
             .collect()
     }
 
+    fn catalog_params(database: &str, table: Option<&str>) -> Vec<(String, String)> {
+        let mut params = vec![("param_database".to_string(), database.to_string())];
+        if let Some(table) = table {
+            params.push(("param_table".to_string(), table.to_string()));
+        }
+        params
+    }
+
     /// Execute a non-SELECT query
     async fn execute_command(&self, query: &str) -> Result<(), String> {
         let url = self.build_url();
@@ -180,10 +189,6 @@ impl ClickhouseDriver {
         }
 
         Ok(())
-    }
-
-    fn escape_string_literal(value: &str) -> String {
-        value.replace('\\', "\\\\").replace('\'', "\\'")
     }
 
     fn parse_function_arguments(arguments: &str, create_query: &str) -> String {
@@ -262,12 +267,10 @@ impl DatabaseDriver for ClickhouseDriver {
     }
 
     async fn list_tables(&self) -> Result<Vec<TableInfo>, String> {
-        let query = format!(
-            "SELECT database, name, engine FROM system.tables WHERE database = '{}'  ORDER BY name",
-            self.config.database
-        );
-
-        let rows = self.execute_query_json(&query).await?;
+        let params = Self::catalog_params(&self.config.database, None);
+        let rows = self
+            .execute_query_json_with_params(TABLES_QUERY, &params)
+            .await?;
 
         Ok(rows
             .into_iter()
@@ -363,15 +366,10 @@ impl DatabaseDriver for ClickhouseDriver {
         table: &str,
     ) -> Result<TableStructure, String> {
         // Get columns
-        let columns_query = format!(
-            "SELECT name, type, default_kind, default_expression, is_in_primary_key 
-             FROM system.columns 
-             WHERE database = '{}' AND table = '{}'
-             ORDER BY position",
-            self.config.database, table
-        );
-
-        let columns = self.execute_query_json(&columns_query).await?;
+        let params = Self::catalog_params(&self.config.database, Some(table));
+        let columns = self
+            .execute_query_json_with_params(TABLE_COLUMNS_QUERY, &params)
+            .await?;
 
         let column_infos: Vec<ColumnInfo> = columns
             .into_iter()
@@ -398,14 +396,8 @@ impl DatabaseDriver for ClickhouseDriver {
             .collect();
 
         // Get indexes (data skipping indexes)
-        let indexes_query = format!(
-            "SELECT name, expr, type FROM system.data_skipping_indices 
-             WHERE database = '{}' AND table = '{}'",
-            self.config.database, table
-        );
-
         let indexes = self
-            .execute_query_json(&indexes_query)
+            .execute_query_json_with_params(TABLE_INDEXES_QUERY, &params)
             .await
             .unwrap_or_default();
 
@@ -443,18 +435,16 @@ impl DatabaseDriver for ClickhouseDriver {
     }
 
     async fn get_schema_overview(&self) -> Result<SchemaOverview, String> {
-        let columns_query =
-            COLUMNS_QUERY.replace("currentDatabase()", &format!("'{}'", self.config.database));
-        let columns_rows = self.execute_query_json(&columns_query).await?;
-
-        let indexes_query =
-            INDEXES_QUERY.replace("currentDatabase()", &format!("'{}'", self.config.database));
+        let params = Self::catalog_params(&self.config.database, None);
+        let columns_rows = self
+            .execute_query_json_with_params(COLUMNS_QUERY, &params)
+            .await?;
         let indexes_rows = self
-            .execute_query_json(&indexes_query)
+            .execute_query_json_with_params(INDEXES_QUERY, &params)
             .await
             .unwrap_or_default();
         let functions_rows = self
-            .execute_query_json(FUNCTION_SUMMARIES_QUERY)
+            .execute_query_json_with_params(FUNCTION_SUMMARIES_QUERY, &params)
             .await
             .unwrap_or_default();
 
@@ -554,9 +544,10 @@ impl DatabaseDriver for ClickhouseDriver {
         name: &str,
         identity_args: &str,
     ) -> Result<FunctionDefinition, String> {
-        let query = FUNCTION_DEFINITION_QUERY.replace("{name}", &Self::escape_string_literal(name));
+        let mut params = Self::catalog_params(&self.config.database, None);
+        params.push(("param_name".to_string(), name.to_string()));
         let row = self
-            .execute_query_json(&query)
+            .execute_query_json_with_params(FUNCTION_DEFINITION_QUERY, &params)
             .await?
             .into_iter()
             .next()
@@ -640,5 +631,53 @@ impl DatabaseDriver for ClickhouseDriver {
                 }),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_queries_keep_hostile_values_out_of_sql() {
+        let database = "catalog' OR 1 = 1 --";
+        let table = "table'} UNION ALL SELECT * --";
+        let params = ClickhouseDriver::catalog_params(database, Some(table));
+
+        for query in [TABLES_QUERY, TABLE_COLUMNS_QUERY, TABLE_INDEXES_QUERY] {
+            assert!(!query.contains(database));
+            assert!(!query.contains(table));
+            assert!(query.contains("{database:String}"));
+        }
+        assert!(TABLE_COLUMNS_QUERY.contains("{table:String}"));
+        assert!(TABLE_INDEXES_QUERY.contains("{table:String}"));
+        assert_eq!(
+            params,
+            vec![
+                ("param_database".to_string(), database.to_string()),
+                ("param_table".to_string(), table.to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn overview_and_function_queries_use_typed_params() {
+        let database = "catalog' ; DROP DATABASE prod --";
+        let function = "function' OR name != '";
+        let mut params = ClickhouseDriver::catalog_params(database, None);
+        params.push(("param_name".to_string(), function.to_string()));
+
+        for query in [COLUMNS_QUERY, INDEXES_QUERY, FUNCTION_SUMMARIES_QUERY] {
+            assert!(!query.contains(database));
+            assert!(query.contains("{database:String}"));
+        }
+        assert!(!FUNCTION_DEFINITION_QUERY.contains(function));
+        assert!(FUNCTION_DEFINITION_QUERY.contains("{database:String}"));
+        assert!(FUNCTION_DEFINITION_QUERY.contains("{name:String}"));
+        assert_eq!(
+            params[0],
+            ("param_database".to_string(), database.to_string())
+        );
+        assert_eq!(params[1], ("param_name".to_string(), function.to_string()));
     }
 }

--- a/src-tauri/src/database/queries/clickhouse.rs
+++ b/src-tauri/src/database/queries/clickhouse.rs
@@ -1,3 +1,23 @@
+pub const TABLES_QUERY: &str = r#"
+SELECT database, name, engine
+FROM system.tables
+WHERE database = {database:String}
+ORDER BY name;
+"#;
+
+pub const TABLE_COLUMNS_QUERY: &str = r#"
+SELECT name, type, default_kind, default_expression, is_in_primary_key
+FROM system.columns
+WHERE database = {database:String} AND table = {table:String}
+ORDER BY position;
+"#;
+
+pub const TABLE_INDEXES_QUERY: &str = r#"
+SELECT name, expr, type
+FROM system.data_skipping_indices
+WHERE database = {database:String} AND table = {table:String};
+"#;
+
 pub const COLUMNS_QUERY: &str = r#"
 SELECT 
     c.database as schema,
@@ -15,7 +35,7 @@ SELECT
     )) as columns_raw
 FROM system.columns c
 JOIN system.tables t ON c.database = t.database AND c.table = t.name
-WHERE c.database = currentDatabase()
+WHERE c.database = {database:String}
     AND c.database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')
 GROUP BY c.database, c.table, t.engine
 ORDER BY c.database, c.table;
@@ -27,13 +47,13 @@ SELECT
     table,
     groupArray(tuple(name, expr, type)) as indexes_raw
 FROM system.data_skipping_indices
-WHERE database = currentDatabase()
+WHERE database = {database:String}
 GROUP BY database, table;
 "#;
 
 pub const FUNCTION_SUMMARIES_QUERY: &str = r#"
 SELECT
-    currentDatabase() AS schema,
+    {database:String} AS schema,
     name,
     origin,
     arguments,
@@ -45,7 +65,7 @@ ORDER BY name;
 
 pub const FUNCTION_DEFINITION_QUERY: &str = r#"
 SELECT
-    currentDatabase() AS schema,
+    {database:String} AS schema,
     name,
     origin,
     arguments,
@@ -53,6 +73,6 @@ SELECT
     create_query
 FROM system.functions
 WHERE origin != 'System'
-    AND name = '{name}'
+    AND name = {name:String}
 LIMIT 1;
 "#;


### PR DESCRIPTION
## Summary
- replace catalog database, table, and function literal interpolation with typed ClickHouse parameters
- encode string parameter values using ClickHouse escaped-text before reqwest URL encoding
- preserve raw typed numeric and boolean filter parameters plus the `readonly=1` request setting
- add offline request-boundary coverage for hostile quotes, backslashes, controls, and wide numeric values

## Verification
- `cargo fmt --check`
- `cargo test database::clickhouse::tests -- --test-threads=1` (3 passed)
- `cargo test --lib -- --test-threads=1` (116 passed, 1 ignored)
- `git diff --check`

Updated directly onto `main` at `e2016f3`. No live ClickHouse service test was run; request construction is covered offline.