### PR TITLE
Avoid duplicate schema layout work

### DIFF
--- a/src/components/SchemaVisualizer.tsx
+++ b/src/components/SchemaVisualizer.tsx
@@ -349,24 +349,24 @@ export function SchemaVisualizer({
 		}
 	}, [tableFilter, filteredTable, selectedTablesArray, onSelectedTablesChange]);
 
-	const { nodes: initialNodes, edges: initialEdges } = useMemo(() => {
+	const layoutedElements = useMemo(() => {
 		if (!schemaOverview || filteredTables.length === 0) {
 			return { nodes: [], edges: [] };
 		}
 		return getLayoutedElements(filteredTables, showColumns);
 	}, [schemaOverview, filteredTables, showColumns]);
 
-	const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
-	const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+	const [nodes, setNodes, onNodesChange] = useNodesState(
+		layoutedElements.nodes,
+	);
+	const [edges, setEdges, onEdgesChange] = useEdgesState(
+		layoutedElements.edges,
+	);
 
 	useEffect(() => {
-		const { nodes: newNodes, edges: newEdges } = getLayoutedElements(
-			filteredTables,
-			showColumns,
-		);
-		setNodes(newNodes);
-		setEdges(newEdges);
-	}, [filteredTables, showColumns, setNodes, setEdges]);
+		setNodes(layoutedElements.nodes);
+		setEdges(layoutedElements.edges);
+	}, [layoutedElements, setNodes, setEdges]);
 
 	const onConnect = useCallback(
 		(params: Connection) => setEdges((eds) => addEdge(params, eds)),


### PR DESCRIPTION
## Summary
- make one memoized Dagre result own schema node/edge layout
- initialize and synchronize React Flow state from that result instead of running Dagre again in the effect
- preserve existing table-selection, column-toggle, and schema update behavior

## Verification
- `bun install --frozen-lockfile --offline --ignore-scripts`
- `bun run check` (141 tests, typecheck, ESLint, production build)
- `git diff --check`

Updated directly onto `main` at `e2016f3`. React StrictMode may still intentionally replay memo calculations in development; the application-owned duplicate effect pass is removed.