### PR TITLE
Prevent stale tab request commits

### DIFF
--- a/src/components/connection-details/SqlConnectionWorkspace.tsx
+++ b/src/components/connection-details/SqlConnectionWorkspace.tsx
@@ -1,4 +1,11 @@
-import { lazy, Suspense, useCallback, useMemo, useState } from "react";
+import {
+	lazy,
+	Suspense,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
 import { ClockCounterClockwise, Code, Table } from "@phosphor-icons/react";
 import { toast } from "sonner";
 import { CommandPalette } from "@/components/CommandPalette";
@@ -36,6 +43,7 @@ import {
 	type DispatchTabPatch,
 	type UpdateTab,
 } from "@/lib/connection-details/tabState";
+import { TabRequestController } from "@/lib/connection-details/tabRequestController";
 import { getCreateTableDbType } from "@/lib/databaseCatalog";
 import { api, type TableInfo } from "@/lib/tauri";
 import type { SqlConnection } from "@/types/connection";
@@ -84,9 +92,17 @@ export function SqlConnectionWorkspace({
 	const [tabs, setTabs] = useState<Tab[]>([]);
 	const [activeTabId, setActiveTabId] = useState<string | null>(null);
 	const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+	const requestController = useMemo(() => new TabRequestController(), []);
+
+	useEffect(() => {
+		requestController.reset();
+		return () => requestController.reset();
+	}, [connection.uuid, requestController]);
+
 	const queryRecords = useConnectionQueryRecords({
 		uuid: connection.uuid,
 		activePanel: sidebarTab,
+		requestController,
 	});
 	const tables = lifecycle.schema.tables;
 	const tableColumns = lifecycle.schema.tableColumns;
@@ -145,6 +161,7 @@ export function SqlConnectionWorkspace({
 		connection,
 		activeTab: activeTableDataTab,
 		updateTableDataTab,
+		requestController,
 	});
 	const tabActions = useConnectionTabActions({
 		uuid: connection.uuid,
@@ -156,6 +173,7 @@ export function SqlConnectionWorkspace({
 		patchTab,
 		fetchTableData: tableDataController.fetchTableData,
 		cancelTabGeneration,
+		requestController,
 	});
 	const queryController = useQueryWorkspaceController({
 		connection,
@@ -166,6 +184,7 @@ export function SqlConnectionWorkspace({
 		onSavedQueryDeleted: queryRecords.savedQueries.remove,
 		recordHistory: queryRecords.history.record,
 		handleOpenQuery: tabActions.handleOpenQuery,
+		requestController,
 	});
 	const handleClearFilter = useCallback(() => {
 		if (activeTableDataTab) {

--- a/src/hooks/connection-details/useConnectionQueryRecords.test.tsx
+++ b/src/hooks/connection-details/useConnectionQueryRecords.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { SavedQuery } from "../../lib/tauri";
+import { TabRequestController } from "../../lib/connection-details/tabRequestController";
 
 if (!globalThis.document) GlobalRegistrator.register();
 
@@ -64,9 +65,14 @@ beforeEach(() => {
 afterEach(cleanup);
 
 test("loads only the selected record panel and clears history atomically", async () => {
+	const requestController = new TabRequestController();
 	const { result, rerender } = renderHook(
 		({ activePanel }: { activePanel: "objects" | "queries" | "history" }) =>
-			useConnectionQueryRecords({ uuid: "connection-1", activePanel }),
+			useConnectionQueryRecords({
+				uuid: "connection-1",
+				activePanel,
+				requestController,
+			}),
 		{
 			initialProps: {
 				activePanel: "objects" as "objects" | "queries" | "history",

--- a/src/hooks/connection-details/useConnectionQueryRecords.ts
+++ b/src/hooks/connection-details/useConnectionQueryRecords.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { api, type QueryHistory, type SavedQuery } from "../../lib/tauri";
+import type { TabRequestController } from "../../lib/connection-details/tabRequestController";
 
 export interface HistoryRecordOptions {
 	status: "success" | "error";
@@ -12,11 +13,13 @@ export interface HistoryRecordOptions {
 interface UseConnectionQueryRecordsOptions {
 	uuid: string | undefined;
 	activePanel: "objects" | "queries" | "history";
+	requestController: TabRequestController;
 }
 
 export function useConnectionQueryRecords({
 	uuid,
 	activePanel,
+	requestController,
 }: UseConnectionQueryRecordsOptions) {
 	const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([]);
 	const [loadingQueries, setLoadingQueries] = useState(false);
@@ -26,57 +29,74 @@ export function useConnectionQueryRecords({
 	useEffect(() => {
 		if (!uuid || activePanel !== "queries") return;
 		const fetchSavedQueries = async () => {
+			const lifecycle = requestController.watchLifecycle();
 			setLoadingQueries(true);
 			try {
-				setSavedQueries(await api.queries.list(uuid));
+				const queries = await api.queries.list(uuid);
+				if (lifecycle.isCurrent()) setSavedQueries(queries);
 			} catch (error) {
-				console.error("Failed to fetch saved queries:", error);
+				if (lifecycle.isCurrent()) {
+					console.error("Failed to fetch saved queries:", error);
+				}
 			} finally {
-				setLoadingQueries(false);
+				if (lifecycle.isCurrent()) setLoadingQueries(false);
 			}
 		};
 		void fetchSavedQueries();
-	}, [uuid, activePanel]);
+	}, [uuid, activePanel, requestController]);
 
 	const fetchQueryHistory = useCallback(async () => {
 		if (!uuid) return;
+		const lifecycle = requestController.watchLifecycle();
 		try {
-			setQueryHistory(await api.queries.history(uuid));
+			const history = await api.queries.history(uuid);
+			if (lifecycle.isCurrent()) setQueryHistory(history);
 		} catch (error) {
-			console.error("Failed to fetch query history:", error);
+			if (lifecycle.isCurrent()) {
+				console.error("Failed to fetch query history:", error);
+			}
 		}
-	}, [uuid]);
+	}, [uuid, requestController]);
 
 	useEffect(() => {
 		if (!uuid || activePanel !== "history") return;
+		const lifecycle = requestController.watchLifecycle();
 		setLoadingHistory(true);
-		void fetchQueryHistory().finally(() => setLoadingHistory(false));
-	}, [uuid, activePanel, fetchQueryHistory]);
+		void fetchQueryHistory().finally(() => {
+			if (lifecycle.isCurrent()) setLoadingHistory(false);
+		});
+	}, [uuid, activePanel, fetchQueryHistory, requestController]);
 
 	const recordHistory = useCallback(
 		(query: string, options: HistoryRecordOptions) => {
 			if (!uuid) return;
+			const lifecycle = requestController.watchLifecycle();
 			api.queries
 				.recordHistory({ connectionUuid: uuid, query, ...options })
 				.then(() => {
-					if (activePanel === "history") void fetchQueryHistory();
+					if (lifecycle.isCurrent() && activePanel === "history") {
+						void fetchQueryHistory();
+					}
 				})
 				.catch((error) =>
 					console.error("Failed to record query history:", error),
 				);
 		},
-		[uuid, activePanel, fetchQueryHistory],
+		[uuid, activePanel, fetchQueryHistory, requestController],
 	);
 
 	const clearHistory = useCallback(async () => {
 		if (!uuid) return;
+		const lifecycle = requestController.watchLifecycle();
 		try {
 			await api.queries.clearHistory(uuid);
-			setQueryHistory([]);
+			if (lifecycle.isCurrent()) setQueryHistory([]);
 		} catch (error) {
-			console.error("Failed to clear query history:", error);
+			if (lifecycle.isCurrent()) {
+				console.error("Failed to clear query history:", error);
+			}
 		}
-	}, [uuid]);
+	}, [uuid, requestController]);
 
 	const addSavedQuery = useCallback((query: SavedQuery) => {
 		setSavedQueries((currentQueries) => [query, ...currentQueries]);

--- a/src/hooks/connection-details/useConnectionTabActions.ts
+++ b/src/hooks/connection-details/useConnectionTabActions.ts
@@ -3,6 +3,7 @@ import { createCellFilter } from "@/lib/resultFilters";
 import { normalizeColumnLayout } from "@/lib/savedViews";
 import { api } from "@/lib/tauri";
 import type { DispatchTabPatch } from "@/lib/connection-details/tabState";
+import type { TabRequestController } from "@/lib/connection-details/tabRequestController";
 import { useNativeCloseListener } from "./useNativeCloseListener";
 import {
 	createFunctionDefinitionTab,
@@ -30,6 +31,7 @@ export interface UseConnectionTabActionsOptions {
 	patchTab: DispatchTabPatch;
 	fetchTableData: (tab: TableDataTab) => Promise<void>;
 	cancelTabGeneration: (tabId: string) => void;
+	requestController: TabRequestController;
 }
 
 export function useConnectionTabActions({
@@ -42,6 +44,7 @@ export function useConnectionTabActions({
 	patchTab,
 	fetchTableData,
 	cancelTabGeneration,
+	requestController,
 }: UseConnectionTabActionsOptions) {
 	const fetchTableStructure = useCallback(
 		async (tab: TableStructureTab) => {
@@ -318,6 +321,7 @@ export function useConnectionTabActions({
 	const handleCloseTab = useCallback(
 		(tabId: string) => {
 			cancelTabGeneration(tabId);
+			requestController.invalidateTab(tabId);
 			setTabs((previous) => {
 				const newTabs = previous.filter((tab) => tab.id !== tabId);
 
@@ -332,7 +336,13 @@ export function useConnectionTabActions({
 				return newTabs;
 			});
 		},
-		[activeTabId, cancelTabGeneration, setTabs, setActiveTabId],
+		[
+			activeTabId,
+			cancelTabGeneration,
+			requestController,
+			setTabs,
+			setActiveTabId,
+		],
 	);
 
 	const handleTabSelect = useCallback(

--- a/src/hooks/connection-details/useQueryWorkspaceController.test.tsx
+++ b/src/hooks/connection-details/useQueryWorkspaceController.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { useCallback, useState } from "react";
 import type { SavedQuery } from "../../lib/tauri";
+import { TabRequestController } from "../../lib/connection-details/tabRequestController";
 import type { SqlConnection } from "../../types/connection";
 import type { QueryTab, Tab } from "../../types/tabTypes";
 
@@ -26,6 +27,7 @@ function deferred<T>() {
 
 let executeQueryResult = deferred<QueryResult>();
 let createQueryResult = deferred<SavedQuery>();
+let executeQueryCalls = 0;
 
 mock.module("sonner", () => ({
 	toast: {
@@ -38,7 +40,10 @@ mock.module("sonner", () => ({
 mock.module("../../lib/tauri", () => ({
 	api: {
 		pool: {
-			executeQuery: () => executeQueryResult.promise,
+			executeQuery: () => {
+				executeQueryCalls += 1;
+				return executeQueryResult.promise;
+			},
 		},
 		queries: {
 			create: () => createQueryResult.promise,
@@ -59,6 +64,7 @@ const { useQueryWorkspaceController } = await import(
 beforeEach(() => {
 	executeQueryResult = deferred<QueryResult>();
 	createQueryResult = deferred<SavedQuery>();
+	executeQueryCalls = 0;
 });
 
 afterEach(cleanup);
@@ -109,9 +115,10 @@ const connection: SqlConnection = {
 	updated_at: "2026-07-27 00:00:00",
 };
 
-function renderController() {
-	const first = queryTab("query-1", "SELECT 1");
+function renderController(firstQuery = "SELECT 1") {
+	const first = queryTab("query-1", firstQuery);
 	const second = queryTab("query-2", "SELECT 2");
+	const requestController = new TabRequestController();
 	return renderHook(() => {
 		const [tabs, setTabs] = useState<Tab[]>([first, second]);
 		const [activeTabId, setActiveTabId] = useState(first.id);
@@ -146,6 +153,7 @@ function renderController() {
 				),
 			recordHistory: () => {},
 			handleOpenQuery: () => {},
+			requestController,
 		});
 		return {
 			tabs,
@@ -187,6 +195,101 @@ test("finishes a query on its originating tab after the user switches tabs", asy
 	expect(result.current.tabs[1]).toMatchObject({
 		id: "query-2",
 		results: null,
+	});
+});
+
+test("keeps the newest query result when requests finish out of order", async () => {
+	const { result } = renderController();
+	const olderResult = deferred<QueryResult>();
+	const newerResult = deferred<QueryResult>();
+
+	executeQueryResult = olderResult;
+	let olderExecution: Promise<void> | undefined;
+	act(() => {
+		olderExecution = result.current.controller.commands.runQuery();
+	});
+
+	executeQueryResult = newerResult;
+	let newerExecution: Promise<void> | undefined;
+	act(() => {
+		newerExecution = result.current.controller.commands.runQuery();
+	});
+
+	await act(async () => {
+		newerResult.resolve({
+			data: [{ value: "newer" }],
+			error: null,
+			time_taken_ms: 2,
+			rows_affected: null,
+			row_count: 1,
+			truncated: false,
+		});
+		await newerExecution;
+	});
+	await act(async () => {
+		olderResult.resolve({
+			data: [{ value: "older" }],
+			error: null,
+			time_taken_ms: 8,
+			rows_affected: null,
+			row_count: 1,
+			truncated: false,
+		});
+		await olderExecution;
+	});
+
+	expect(result.current.tabs[0]).toMatchObject({
+		id: "query-1",
+		results: [{ value: "newer" }],
+		executionTime: 2,
+		executing: false,
+	});
+});
+
+test("stops run-all before another statement after a newer query starts", async () => {
+	const { result } = renderController("SELECT 1; SELECT 2;");
+	const batchResult = deferred<QueryResult>();
+	const newerResult = deferred<QueryResult>();
+
+	executeQueryResult = batchResult;
+	let batchExecution: Promise<void> | undefined;
+	act(() => {
+		batchExecution = result.current.controller.workspace.runAllQueries();
+	});
+
+	executeQueryResult = newerResult;
+	let newerExecution: Promise<void> | undefined;
+	act(() => {
+		newerExecution = result.current.controller.commands.runQuery();
+	});
+
+	await act(async () => {
+		batchResult.resolve({
+			data: [{ value: "batch" }],
+			error: null,
+			time_taken_ms: 3,
+			rows_affected: null,
+			row_count: 1,
+			truncated: false,
+		});
+		await batchExecution;
+	});
+	await act(async () => {
+		newerResult.resolve({
+			data: [{ value: "newer" }],
+			error: null,
+			time_taken_ms: 1,
+			rows_affected: null,
+			row_count: 1,
+			truncated: false,
+		});
+		await newerExecution;
+	});
+
+	expect(executeQueryCalls).toBe(2);
+	expect(result.current.tabs[0]).toMatchObject({
+		results: [{ value: "newer" }],
+		executing: false,
 	});
 });
 

--- a/src/hooks/connection-details/useQueryWorkspaceController.ts
+++ b/src/hooks/connection-details/useQueryWorkspaceController.ts
@@ -8,6 +8,7 @@ import {
 	stripTrailingSemicolon,
 } from "../../lib/connection-details/queryTableState";
 import type { UpdateTab } from "../../lib/connection-details/tabState";
+import type { TabRequestController } from "../../lib/connection-details/tabRequestController";
 import {
 	getStatementAtCursor,
 	parseStatements as parseSqlStatements,
@@ -24,6 +25,7 @@ interface UseQueryWorkspaceControllerOptions {
 	onSavedQueryUpdated: (query: SavedQuery) => void;
 	onSavedQueryDeleted: (id: number) => void;
 	recordHistory: (query: string, options: HistoryRecordOptions) => void;
+	requestController: TabRequestController;
 	handleOpenQuery: (
 		query: string,
 		savedQueryId?: number | null,
@@ -39,6 +41,7 @@ export function useQueryWorkspaceController({
 	onSavedQueryUpdated,
 	onSavedQueryDeleted,
 	recordHistory,
+	requestController,
 	handleOpenQuery,
 }: UseQueryWorkspaceControllerOptions) {
 	const [saveQueryName, setSaveQueryName] = useState("");
@@ -58,11 +61,14 @@ export function useQueryWorkspaceController({
 
 	const runQueryResultViewQuery = useCallback(
 		async (tab: QueryTab, nextFilter: string, nextSort: SortConfig | null) => {
+			const request = requestController.beginQuery(tab.id);
 			if (!tab.resultBaseQuery) {
-				updateQueryTab(tab.id, { executing: false });
-				toast.error(
-					"Query-level filter/sort is available only for SELECT-style query results",
-				);
+				request.commit(() => {
+					updateQueryTab(tab.id, { executing: false });
+					toast.error(
+						"Query-level filter/sort is available only for SELECT-style query results",
+					);
+				});
 				return;
 			}
 
@@ -81,38 +87,49 @@ export function useQueryWorkspaceController({
 				const executionTime = result.time_taken_ms ?? 0;
 
 				if (result.error) {
-					updateQueryTab(tab.id, {
-						error: result.error,
-						executionTime,
-						affectedRows: null,
-						executing: false,
-					});
+					request.commit(() =>
+						updateQueryTab(tab.id, {
+							error: result.error,
+							executionTime,
+							affectedRows: null,
+							executing: false,
+						}),
+					);
 					return;
 				}
 
-				updateQueryTab(tab.id, {
-					results: result.data as Record<string, unknown>[],
-					success: true,
-					error: null,
-					executionTime,
-					affectedRows: null,
-					executing: false,
-					filter: nextFilter,
-					sort: nextSort,
-				});
+				request.commit(() =>
+					updateQueryTab(tab.id, {
+						results: result.data as Record<string, unknown>[],
+						success: true,
+						error: null,
+						executionTime,
+						affectedRows: null,
+						executing: false,
+						filter: nextFilter,
+						sort: nextSort,
+					}),
+				);
 			} catch (error) {
-				updateQueryTab(tab.id, {
-					error:
-						error instanceof Error
-							? error.message
-							: "Failed to apply query filter/sort",
-					executionTime: null,
-					affectedRows: null,
-					executing: false,
-				});
+				request.commit(() =>
+					updateQueryTab(tab.id, {
+						error:
+							error instanceof Error
+								? error.message
+								: "Failed to apply query filter/sort",
+						executionTime: null,
+						affectedRows: null,
+						executing: false,
+					}),
+				);
 			}
 		},
-		[updateQueryTab, connection.uuid, connection.db_type],
+		[
+			updateQueryTab,
+			connection.uuid,
+			connection.db_type,
+			requestController,
+		],
 	);
 
 	const handleQueryFilterInputChange = useCallback(
@@ -178,6 +195,7 @@ export function useQueryWorkspaceController({
 			toast.error("No statement at cursor position");
 			return;
 		}
+		const request = requestController.beginQuery(activeTab.id);
 
 		updateQueryTab(activeTab.id, {
 			executing: true,
@@ -194,7 +212,7 @@ export function useQueryWorkspaceController({
 
 		try {
 			const result = await api.pool.executeQuery(connection.uuid, queryToRun);
-			if (result.truncated) {
+			if (result.truncated && request.isCurrent()) {
 				toast.warning("Result limited to 10,000 rows", {
 					description: "Refine the query to load a smaller result window.",
 				});
@@ -202,12 +220,14 @@ export function useQueryWorkspaceController({
 			const executionTime = result.time_taken_ms ?? 0;
 
 			if (result.error) {
-				updateQueryTab(activeTab.id, {
-					error: result.error,
-					executionTime,
-					affectedRows: null,
-					executing: false,
-				});
+				request.commit(() =>
+					updateQueryTab(activeTab.id, {
+						error: result.error,
+						executionTime,
+						affectedRows: null,
+						executing: false,
+					}),
+				);
 				recordHistory(queryToRun, {
 					status: "error",
 					timeTakenMs: result.time_taken_ms ?? null,
@@ -216,19 +236,21 @@ export function useQueryWorkspaceController({
 				return;
 			}
 
-			updateQueryTab(activeTab.id, {
-				results: result.data as Record<string, unknown>[],
-				success: true,
-				executionTime,
-				affectedRows: result.rows_affected ?? null,
-				executing: false,
-				filterInput: "",
-				filter: "",
-				sort: null,
-				resultBaseQuery: isWrappableQuery(queryToRun)
-					? stripTrailingSemicolon(queryToRun)
-					: null,
-			});
+			request.commit(() =>
+				updateQueryTab(activeTab.id, {
+					results: result.data as Record<string, unknown>[],
+					success: true,
+					executionTime,
+					affectedRows: result.rows_affected ?? null,
+					executing: false,
+					filterInput: "",
+					filter: "",
+					sort: null,
+					resultBaseQuery: isWrappableQuery(queryToRun)
+						? stripTrailingSemicolon(queryToRun)
+						: null,
+				}),
+			);
 			recordHistory(queryToRun, {
 				status: "success",
 				timeTakenMs: result.time_taken_ms ?? null,
@@ -238,12 +260,14 @@ export function useQueryWorkspaceController({
 		} catch (error) {
 			const message =
 				error instanceof Error ? error.message : "Failed to execute query";
-			updateQueryTab(activeTab.id, {
-				error: message,
-				executionTime: null,
-				affectedRows: null,
-				executing: false,
-			});
+			request.commit(() =>
+				updateQueryTab(activeTab.id, {
+					error: message,
+					executionTime: null,
+					affectedRows: null,
+					executing: false,
+				}),
+			);
 			recordHistory(queryToRun, { status: "error", error: message });
 		}
 	}, [
@@ -253,12 +277,14 @@ export function useQueryWorkspaceController({
 		cursorLine,
 		cursorChar,
 		recordHistory,
+		requestController,
 	]);
 
 	const handleRunAllQueries = useCallback(async () => {
 		if (!activeTab || !activeTab.query.trim()) return;
 		const statements = parseSqlStatements(activeTab.query);
 		if (statements.length === 0) return;
+		const request = requestController.beginQuery(activeTab.id);
 
 		updateQueryTab(activeTab.id, {
 			executing: true,
@@ -278,13 +304,16 @@ export function useQueryWorkspaceController({
 		let lastError: string | null = null;
 		let lastBaseQuery: string | null = null;
 		let lastAffectedRows: number | null = null;
+		let currentQuery: string | null = null;
 
 		try {
 			for (const statement of statements) {
+				if (!request.isCurrent()) return;
 				const queryToRun = statement.text.trim();
 				if (!queryToRun) continue;
+				currentQuery = queryToRun;
 				const result = await api.pool.executeQuery(connection.uuid, queryToRun);
-				if (result.truncated) {
+				if (result.truncated && request.isCurrent()) {
 					toast.warning("Result limited to 10,000 rows", {
 						description: "Refine the query to load a smaller result window.",
 					});
@@ -298,6 +327,7 @@ export function useQueryWorkspaceController({
 						timeTakenMs: result.time_taken_ms ?? null,
 						error: result.error,
 					});
+					if (!request.isCurrent()) return;
 					break;
 				}
 
@@ -312,39 +342,55 @@ export function useQueryWorkspaceController({
 					rowCount: result.row_count ?? null,
 					rowsAffected: result.rows_affected ?? null,
 				});
+				if (!request.isCurrent()) return;
+				currentQuery = null;
 			}
 
-			updateQueryTab(
-				activeTab.id,
-				lastError
-					? {
-							error: lastError,
-							executionTime: totalTime,
-							affectedRows: null,
-							executing: false,
-						}
-					: {
-							results: lastResult,
-							success: true,
-							executionTime: totalTime,
-							affectedRows: lastAffectedRows,
-							executing: false,
-							filterInput: "",
-							filter: "",
-							sort: null,
-							resultBaseQuery: lastBaseQuery,
-						},
+			request.commit(() =>
+				updateQueryTab(
+					activeTab.id,
+					lastError
+						? {
+								error: lastError,
+								executionTime: totalTime,
+								affectedRows: null,
+								executing: false,
+							}
+						: {
+								results: lastResult,
+								success: true,
+								executionTime: totalTime,
+								affectedRows: lastAffectedRows,
+								executing: false,
+								filterInput: "",
+								filter: "",
+								sort: null,
+								resultBaseQuery: lastBaseQuery,
+							},
+				),
 			);
 		} catch (error) {
-			updateQueryTab(activeTab.id, {
-				error:
-					error instanceof Error ? error.message : "Failed to execute queries",
-				executionTime: null,
-				affectedRows: null,
-				executing: false,
-			});
+			const message =
+				error instanceof Error ? error.message : "Failed to execute queries";
+			if (currentQuery) {
+				recordHistory(currentQuery, { status: "error", error: message });
+			}
+			request.commit(() =>
+				updateQueryTab(activeTab.id, {
+					error: message,
+					executionTime: null,
+					affectedRows: null,
+					executing: false,
+				}),
+			);
 		}
-	}, [activeTab, connection.uuid, updateQueryTab, recordHistory]);
+	}, [
+		activeTab,
+		connection.uuid,
+		updateQueryTab,
+		recordHistory,
+		requestController,
+	]);
 
 	const handleQueryChange = useCallback(
 		(query: string) => {

--- a/src/hooks/connection-details/useTableDataController.test.tsx
+++ b/src/hooks/connection-details/useTableDataController.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import { useCallback, useState } from "react";
 import type { SqlConnection } from "../../types/connection";
+import { TabRequestController } from "../../lib/connection-details/tabRequestController";
 import type { Tab, TableDataTab } from "../../types/tabTypes";
 import type { TableDataResponse } from "../../types/tableData";
 
@@ -127,6 +128,7 @@ function tableTab(id: string, tableName: string): TableDataTab {
 function renderController() {
 	const first = tableTab("table-1", "public.users");
 	const second = tableTab("table-2", "public.teams");
+	const requestController = new TabRequestController();
 	return renderHook(() => {
 		const [tabs, setTabs] = useState<Tab[]>([first, second]);
 		const [activeTabId, setActiveTabId] = useState(first.id);
@@ -149,6 +151,7 @@ function renderController() {
 			connection,
 			activeTab: activeTableDataTab,
 			updateTableDataTab,
+			requestController,
 		});
 		return { tabs, controller, selectTab: setActiveTabId };
 	});
@@ -181,6 +184,50 @@ test("finishes loading data on its originating tab after switching tabs", async 
 		loading: false,
 	});
 	expect(result.current.tabs[1]).toMatchObject({ id: "table-2", data: null });
+});
+
+test("keeps the newest table data when requests finish out of order", async () => {
+	const { result } = renderController();
+	const olderResult = deferred<TableDataResponse>();
+	const newerResult = deferred<TableDataResponse>();
+	const tab = result.current.tabs[0] as TableDataTab;
+
+	tableDataResult = olderResult;
+	let olderRequest: Promise<void> | undefined;
+	act(() => {
+		olderRequest = result.current.controller.fetchTableData(tab);
+	});
+
+	tableDataResult = newerResult;
+	let newerRequest: Promise<void> | undefined;
+	act(() => {
+		newerRequest = result.current.controller.fetchTableData(tab);
+	});
+
+	await act(async () => {
+		newerResult.resolve({
+			data: [{ id: 2, name: "Newer" }],
+			total: 1,
+			page: 1,
+			limit: 100,
+		});
+		await newerRequest;
+	});
+	await act(async () => {
+		olderResult.resolve({
+			data: [{ id: 1, name: "Older" }],
+			total: 1,
+			page: 1,
+			limit: 100,
+		});
+		await olderRequest;
+	});
+
+	expect(result.current.tabs[0]).toMatchObject({
+		id: "table-1",
+		data: { data: [{ id: 2, name: "Newer" }] },
+		loading: false,
+	});
 });
 
 test("keeps staged inline edits isolated by tab", async () => {

--- a/src/hooks/connection-details/useTableDataController.ts
+++ b/src/hooks/connection-details/useTableDataController.ts
@@ -1,12 +1,14 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useSavedViewApplication } from "../useSavedViewApplication";
 import { useTableDataFilters } from "../useTableDataFilters";
+import { continueWhileCurrent } from "../../lib/connection-details/latestRequestRegistry";
 import {
 	areCellValuesEqual,
 	getPrimaryKeyRowKey,
 } from "../../lib/connection-details/queryTableState";
 import type { UpdateTab } from "../../lib/connection-details/tabState";
+import type { TabRequestController } from "../../lib/connection-details/tabRequestController";
 import { getFilterRequest } from "../../lib/resultFilters";
 import type { TableColumnLayout } from "../../lib/savedViews";
 import { api } from "../../lib/tauri";
@@ -34,12 +36,14 @@ export interface UseTableDataControllerOptions {
 	connection: SqlConnection;
 	activeTab: TableDataTab | null;
 	updateTableDataTab: UpdateTab<TableDataTab>;
+	requestController: TabRequestController;
 }
 
 export function useTableDataController({
 	connection,
 	activeTab,
 	updateTableDataTab,
+	requestController,
 }: UseTableDataControllerOptions) {
 	const [rowEditSheetOpen, setRowEditSheetOpen] = useState(false);
 	const [editingRow, setEditingRow] = useState<Record<string, unknown> | null>(
@@ -55,6 +59,13 @@ export function useTableDataController({
 	const [savingInlineEdits, setSavingInlineEdits] = useState(false);
 	const [rowInsertSheetOpen, setRowInsertSheetOpen] = useState(false);
 	const [insertingRow, setInsertingRow] = useState(false);
+
+	useEffect(() => {
+		setSavingRow(false);
+		setSavingInlineEdits(false);
+		setDeletingRow(false);
+		setInsertingRow(false);
+	}, [connection.uuid]);
 
 	const requestTableData = useCallback(
 		async (tab: TableDataTab) => {
@@ -77,11 +88,15 @@ export function useTableDataController({
 
 	const fetchTableData = useCallback(
 		async (tab: TableDataTab) => {
+			const request = requestController.beginTable(tab.id);
 			updateTableDataTab(tab.id, { loading: true });
 			try {
 				const data = await requestTableData(tab);
-				updateTableDataTab(tab.id, { data, loading: false });
+				request.commit(() =>
+					updateTableDataTab(tab.id, { data, loading: false }),
+				);
 			} catch (error) {
+				if (!request.isCurrent()) return;
 				console.error("Failed to fetch table data:", error);
 				toast.error("Failed to load table data", {
 					description: error instanceof Error ? error.message : String(error),
@@ -89,7 +104,7 @@ export function useTableDataController({
 				updateTableDataTab(tab.id, { data: null, loading: false });
 			}
 		},
-		[requestTableData, updateTableDataTab],
+		[requestController, requestTableData, updateTableDataTab],
 	);
 
 	const {
@@ -106,6 +121,7 @@ export function useTableDataController({
 	const handleApplySavedView = useSavedViewApplication({
 		tab: activeTab,
 		requestTableData,
+		requestController,
 		updateTab: updateTableDataTab,
 	});
 
@@ -172,6 +188,7 @@ export function useTableDataController({
 			if (!activeTab || !editingRow) return;
 
 			const tab = activeTab;
+			const tableRequest = requestController.watchTable(tab.id);
 			const [schema, tableName] = tab.tableName.split(".");
 			const primaryKeyColumns = tab.columns
 				.filter((column) => column.primary_key)
@@ -197,6 +214,7 @@ export function useTableDataController({
 					updates,
 				);
 
+				if (!tableRequest.isCurrent()) return;
 				if (result.error) {
 					toast.error("Failed to update row", { description: result.error });
 				} else {
@@ -207,18 +225,26 @@ export function useTableDataController({
 					toast.success("Row updated successfully");
 					setRowEditSheetOpen(false);
 					setEditingRow(null);
-					fetchTableData(tab);
+					setSavingRow(false);
+					void fetchTableData(tab);
 				}
 			} catch (error) {
+				if (!tableRequest.isCurrent()) return;
 				console.error("Failed to update row:", error);
 				toast.error("Failed to update row", {
 					description: error instanceof Error ? error.message : String(error),
 				});
 			} finally {
-				setSavingRow(false);
+				if (tableRequest.isCurrent()) setSavingRow(false);
 			}
 		},
-		[connection, activeTab, editingRow, fetchTableData],
+		[
+			connection,
+			activeTab,
+			editingRow,
+			fetchTableData,
+			requestController,
+		],
 	);
 
 	const handleInlineCellSave = useCallback(
@@ -267,6 +293,7 @@ export function useTableDataController({
 		if (!activeTab) return;
 
 		const tab = activeTab;
+		const tableRequest = requestController.watchTable(tab.id);
 		const pendingEdits = Object.entries(pendingInlineEditsByTab[tab.id] ?? {});
 		if (pendingEdits.length === 0) return;
 
@@ -308,25 +335,28 @@ export function useTableDataController({
 
 		setSavingInlineEdits(true);
 		try {
-			for (const [rowKey, editGroup] of editsByRow) {
-				const primaryKeyValues = primaryKeyColumns.map(
-					(column) => editGroup.row[column],
-				);
-				const result = await api.pool.updateTableRow(
-					connection.uuid,
-					schema,
-					tableName,
-					primaryKeyColumns,
-					primaryKeyValues,
-					editGroup.updates,
-				);
-
-				if (result.error) {
-					throw new Error(result.error);
-				}
-
-				setHighlightedTableRow({ tableName: tab.tableName, rowKey });
-			}
+			const completed = await continueWhileCurrent(
+				editsByRow,
+				() => tableRequest.isCurrent(),
+				async ([, editGroup]) => {
+					const primaryKeyValues = primaryKeyColumns.map(
+						(column) => editGroup.row[column],
+					);
+					return api.pool.updateTableRow(
+						connection.uuid,
+						schema,
+						tableName,
+						primaryKeyColumns,
+						primaryKeyValues,
+						editGroup.updates,
+					);
+				},
+				(result, [rowKey]) => {
+					if (result.error) throw new Error(result.error);
+					setHighlightedTableRow({ tableName: tab.tableName, rowKey });
+				},
+			);
+			if (!completed) return;
 
 			setPendingInlineEditsByTab((previous) => {
 				const next = { ...previous };
@@ -336,16 +366,24 @@ export function useTableDataController({
 			toast.success(
 				`Committed ${pendingEdits.length} inline change${pendingEdits.length === 1 ? "" : "s"}`,
 			);
+			setSavingInlineEdits(false);
 			await fetchTableData(tab);
 		} catch (error) {
+			if (!tableRequest.isCurrent()) return;
 			console.error("Failed to save inline changes:", error);
 			toast.error("Failed to save inline changes", {
 				description: error instanceof Error ? error.message : String(error),
 			});
 		} finally {
-			setSavingInlineEdits(false);
+			if (tableRequest.isCurrent()) setSavingInlineEdits(false);
 		}
-	}, [connection, activeTab, pendingInlineEditsByTab, fetchTableData]);
+	}, [
+		connection,
+		activeTab,
+		pendingInlineEditsByTab,
+		fetchTableData,
+		requestController,
+	]);
 
 	const handleDiscardInlineChanges = useCallback(() => {
 		if (!activeTab) return;
@@ -366,6 +404,7 @@ export function useTableDataController({
 		if (!activeTab || !editingRow) return;
 
 		const tab = activeTab;
+		const tableRequest = requestController.watchTable(tab.id);
 		const [schema, tableName] = tab.tableName.split(".");
 		const primaryKeyColumns = tab.columns
 			.filter((column) => column.primary_key)
@@ -390,29 +429,39 @@ export function useTableDataController({
 				primaryKeyValues,
 			);
 
+			if (!tableRequest.isCurrent()) return;
 			if (result.error) {
 				toast.error("Failed to delete row", { description: result.error });
 			} else {
 				toast.success("Row deleted successfully");
 				setRowEditSheetOpen(false);
 				setEditingRow(null);
-				fetchTableData(tab);
+				setDeletingRow(false);
+				void fetchTableData(tab);
 			}
 		} catch (error) {
+			if (!tableRequest.isCurrent()) return;
 			console.error("Failed to delete row:", error);
 			toast.error("Failed to delete row", {
 				description: error instanceof Error ? error.message : String(error),
 			});
 		} finally {
-			setDeletingRow(false);
+			if (tableRequest.isCurrent()) setDeletingRow(false);
 		}
-	}, [connection, activeTab, editingRow, fetchTableData]);
+	}, [
+		connection,
+		activeTab,
+		editingRow,
+		fetchTableData,
+		requestController,
+	]);
 
 	const handleInsertRow = useCallback(
 		async (values: RowMutationValue[]) => {
 			if (!activeTab) return;
 
 			const tab = activeTab;
+			const tableRequest = requestController.watchTable(tab.id);
 			const [schema, tableName] = tab.tableName.split(".");
 			setInsertingRow(true);
 
@@ -424,23 +473,26 @@ export function useTableDataController({
 					values,
 				);
 
+				if (!tableRequest.isCurrent()) return;
 				if (result.error) {
 					toast.error("Failed to insert row", { description: result.error });
 				} else {
 					toast.success("Row inserted successfully");
 					setRowInsertSheetOpen(false);
-					fetchTableData(tab);
+					setInsertingRow(false);
+					void fetchTableData(tab);
 				}
 			} catch (error) {
+				if (!tableRequest.isCurrent()) return;
 				console.error("Failed to insert row:", error);
 				toast.error("Failed to insert row", {
 					description: error instanceof Error ? error.message : String(error),
 				});
 			} finally {
-				setInsertingRow(false);
+				if (tableRequest.isCurrent()) setInsertingRow(false);
 			}
 		},
-		[connection, activeTab, fetchTableData],
+		[connection, activeTab, fetchTableData, requestController],
 	);
 
 	return {

--- a/src/hooks/useSavedViewApplication.ts
+++ b/src/hooks/useSavedViewApplication.ts
@@ -4,6 +4,7 @@ import { createTableFilterState } from "../lib/resultFilters";
 import { reconcileSavedViewState } from "../lib/savedViews";
 import type { SavedView, TableDataResponse } from "../lib/tauri";
 import type { UpdateTab } from "../lib/connection-details/tabState";
+import type { TabRequestController } from "../lib/connection-details/tabRequestController";
 import type { TableDataTab } from "../types/tabTypes";
 
 interface PreparedSavedViewApplication {
@@ -47,12 +48,14 @@ export function prepareSavedViewApplication(
 interface UseSavedViewApplicationOptions {
 	tab: TableDataTab | null;
 	requestTableData: (tab: TableDataTab) => Promise<TableDataResponse>;
+	requestController: TabRequestController;
 	updateTab: UpdateTab<TableDataTab>;
 }
 
 export function useSavedViewApplication({
 	tab,
 	requestTableData,
+	requestController,
 	updateTab,
 }: UseSavedViewApplicationOptions) {
 	return useCallback(
@@ -67,24 +70,27 @@ export function useSavedViewApplication({
 			}
 
 			const nextTab = prepared.nextTab;
+			const request = requestController.beginTable(tab.id);
 			updateTab(tab.id, { loading: true });
 			try {
 				const data = await requestTableData(nextTab);
-				updateTab(tab.id, {
-					data,
-					currentPage: nextTab.currentPage,
-					filterState: nextTab.filterState,
-					sort: nextTab.sort,
-					columnLayout: nextTab.columnLayout,
-					loading: false,
-				});
-				if (prepared.warning) {
-					toast.warning("Saved view adjusted", {
-						description: prepared.warning,
+				return request.commit(() => {
+					updateTab(tab.id, {
+						data,
+						currentPage: nextTab.currentPage,
+						filterState: nextTab.filterState,
+						sort: nextTab.sort,
+						columnLayout: nextTab.columnLayout,
+						loading: false,
 					});
-				}
-				return true;
+					if (prepared.warning) {
+						toast.warning("Saved view adjusted", {
+							description: prepared.warning,
+						});
+					}
+				});
 			} catch (error) {
+				if (!request.isCurrent()) return false;
 				toast.error("Couldn’t apply saved view", {
 					description: error instanceof Error ? error.message : String(error),
 				});
@@ -92,6 +98,6 @@ export function useSavedViewApplication({
 				return false;
 			}
 		},
-		[requestTableData, tab, updateTab],
+		[requestController, requestTableData, tab, updateTab],
 	);
 }

--- a/src/lib/connection-details/latestRequestRegistry.test.ts
+++ b/src/lib/connection-details/latestRequestRegistry.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import {
+	commitIfLatest,
+	continueWhileCurrent,
+	LatestRequestRegistry,
+} from "./latestRequestRegistry";
+
+describe("LatestRequestRegistry", () => {
+	test("ignores an older response after a newer request starts", () => {
+		const registry = new LatestRequestRegistry();
+		const older = registry.issue("table:users");
+		const newer = registry.issue("table:users");
+		const commits: string[] = [];
+
+		commitIfLatest(registry, older, () => commits.push("older"));
+		commitIfLatest(registry, newer, () => commits.push("newer"));
+
+		expect(commits).toEqual(["newer"]);
+	});
+
+	test("keeps unrelated channels independent", () => {
+		const registry = new LatestRequestRegistry();
+		const firstTab = registry.issue("query:first");
+		registry.issue("query:second");
+
+		expect(registry.isLatest(firstTab)).toBe(true);
+	});
+
+	test("invalidateAll stales handles and checkpoints", () => {
+		const registry = new LatestRequestRegistry();
+		const handle = registry.issue("table:users");
+		const checkpoint = registry.checkpoint("lifecycle");
+
+		registry.invalidateAll();
+
+		expect(registry.isLatest(handle)).toBe(false);
+		expect(registry.isCurrent(checkpoint)).toBe(false);
+	});
+
+	test("batch continuation stops before another operation after invalidation", async () => {
+		const registry = new LatestRequestRegistry();
+		const lifecycle = registry.checkpoint("lifecycle");
+		const completed: number[] = [];
+
+		const finished = await continueWhileCurrent(
+			[1, 2],
+			() => registry.isCurrent(lifecycle),
+			async (item) => {
+				completed.push(item);
+				registry.invalidateAll();
+			},
+		);
+
+		expect(finished).toBe(false);
+		expect(completed).toEqual([1]);
+	});
+});

--- a/src/lib/connection-details/latestRequestRegistry.ts
+++ b/src/lib/connection-details/latestRequestRegistry.ts
@@ -1,0 +1,79 @@
+declare const requestHandleBrand: unique symbol;
+
+export interface RequestHandle {
+	readonly channel: string;
+	readonly revision: number;
+	readonly epoch: number;
+	readonly [requestHandleBrand]: true;
+}
+
+export type RequestCheckpoint = RequestHandle;
+
+export class LatestRequestRegistry {
+	private readonly revisions = new Map<string, number>();
+	private epoch = 0;
+
+	issue(channel: string): RequestHandle {
+		const revision = this.nextRevision(channel);
+		return { channel, revision, epoch: this.epoch } as RequestHandle;
+	}
+
+	isLatest(handle: RequestHandle): boolean {
+		return this.isCurrent(handle);
+	}
+
+	invalidate(channel: string): void {
+		this.nextRevision(channel);
+	}
+
+	invalidateAll(): void {
+		this.epoch += 1;
+		this.revisions.clear();
+	}
+
+	checkpoint(channel: string): RequestCheckpoint {
+		return {
+			channel,
+			revision: this.revisions.get(channel) ?? 0,
+			epoch: this.epoch,
+		} as RequestCheckpoint;
+	}
+
+	isCurrent(checkpoint: RequestCheckpoint): boolean {
+		return (
+			checkpoint.epoch === this.epoch &&
+			checkpoint.revision === (this.revisions.get(checkpoint.channel) ?? 0)
+		);
+	}
+
+	private nextRevision(channel: string): number {
+		const revision = (this.revisions.get(channel) ?? 0) + 1;
+		this.revisions.set(channel, revision);
+		return revision;
+	}
+}
+
+export function commitIfLatest(
+	registry: LatestRequestRegistry,
+	handle: RequestHandle,
+	commit: () => void,
+): boolean {
+	if (!registry.isLatest(handle)) return false;
+	commit();
+	return true;
+}
+
+export async function continueWhileCurrent<T, R>(
+	items: Iterable<T>,
+	isCurrent: () => boolean,
+	operation: (item: T) => Promise<R>,
+	onCompleted?: (result: R, item: T) => void,
+): Promise<boolean> {
+	for (const item of items) {
+		if (!isCurrent()) return false;
+		const result = await operation(item);
+		if (!isCurrent()) return false;
+		onCompleted?.(result, item);
+	}
+	return true;
+}

--- a/src/lib/connection-details/tabRequestController.test.ts
+++ b/src/lib/connection-details/tabRequestController.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { continueWhileCurrent } from "./latestRequestRegistry";
+import { TabRequestController } from "./tabRequestController";
+
+describe("TabRequestController", () => {
+	test("only the latest request for a tab can commit", () => {
+		const controller = new TabRequestController();
+		const older = controller.beginTable("users");
+		const newer = controller.beginTable("users");
+		const commits: string[] = [];
+
+		older.commit(() => commits.push("older"));
+		newer.commit(() => commits.push("newer"));
+
+		expect(commits).toEqual(["newer"]);
+	});
+
+	test("tab work becomes stale when its tab closes or connection resets", () => {
+		const controller = new TabRequestController();
+		const beforeClose = controller.watchTable("users");
+
+		controller.invalidateTab("users");
+		expect(beforeClose.isCurrent()).toBe(false);
+
+		const beforeReset = controller.watchTable("users");
+		controller.reset();
+		expect(beforeReset.isCurrent()).toBe(false);
+	});
+
+	test("table invalidation stops a batch before the next write", async () => {
+		const controller = new TabRequestController();
+		const table = controller.watchTable("users");
+		const completed: number[] = [];
+
+		const finished = await continueWhileCurrent(
+			[1, 2],
+			() => table.isCurrent(),
+			async (item) => {
+				completed.push(item);
+				controller.invalidateTab("users");
+			},
+		);
+
+		expect(finished).toBe(false);
+		expect(completed).toEqual([1]);
+	});
+
+	test("table and query channels stay independent", () => {
+		const controller = new TabRequestController();
+		const table = controller.beginTable("users");
+
+		controller.beginQuery("users");
+
+		expect(table.isCurrent()).toBe(true);
+	});
+});

--- a/src/lib/connection-details/tabRequestController.ts
+++ b/src/lib/connection-details/tabRequestController.ts
@@ -1,0 +1,54 @@
+import {
+	commitIfLatest,
+	LatestRequestRegistry,
+	type RequestHandle,
+} from "./latestRequestRegistry";
+
+export interface CurrentRequest {
+	isCurrent(): boolean;
+	commit(commit: () => void): boolean;
+}
+
+export class TabRequestController {
+	private readonly registry = new LatestRequestRegistry();
+
+	reset(): void {
+		this.registry.invalidateAll();
+	}
+
+	beginTable(tabId: string): CurrentRequest {
+		return this.request(this.registry.issue(this.tableChannel(tabId)));
+	}
+
+	watchTable(tabId: string): CurrentRequest {
+		return this.request(this.registry.checkpoint(this.tableChannel(tabId)));
+	}
+
+	beginQuery(tabId: string): CurrentRequest {
+		return this.request(this.registry.issue(this.queryChannel(tabId)));
+	}
+
+	watchLifecycle(): CurrentRequest {
+		return this.request(this.registry.checkpoint("lifecycle"));
+	}
+
+	invalidateTab(tabId: string): void {
+		this.registry.invalidate(this.tableChannel(tabId));
+		this.registry.invalidate(this.queryChannel(tabId));
+	}
+
+	private request(handle: RequestHandle): CurrentRequest {
+		return {
+			isCurrent: () => this.registry.isCurrent(handle),
+			commit: (commit) => commitIfLatest(this.registry, handle, commit),
+		};
+	}
+
+	private tableChannel(tabId: string): string {
+		return `table:${tabId}`;
+	}
+
+	private queryChannel(tabId: string): string {
+		return `query:${tabId}`;
+	}
+}

--- a/src/lib/uuid.test.ts
+++ b/src/lib/uuid.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { generateUuidV4, type UuidCrypto } from "./uuid";
+
+describe("generateUuidV4", () => {
+	test("uses the native randomUUID implementation when available", () => {
+		let fallbackUsed = false;
+		const source: UuidCrypto = {
+			randomUUID: () => "native-uuid",
+			getRandomValues: (array) => {
+				fallbackUsed = true;
+				return array;
+			},
+		};
+
+		expect(generateUuidV4(source)).toBe("native-uuid");
+		expect(fallbackUsed).toBe(false);
+	});
+
+	test("creates unique RFC v4 UUIDs when randomUUID is unavailable", () => {
+		let seed = 0;
+		const source: UuidCrypto = {
+			getRandomValues: (array) => {
+				const bytes = array as Uint8Array;
+				for (let index = 0; index < bytes.length; index += 1) {
+					bytes[index] = seed + index;
+				}
+				seed += 16;
+				return array;
+			},
+		};
+
+		const first = generateUuidV4(source);
+		const second = generateUuidV4(source);
+		expect(first).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+		);
+		expect(second).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+		);
+		expect(second).not.toBe(first);
+	});
+});

--- a/src/lib/uuid.ts
+++ b/src/lib/uuid.ts
@@ -1,0 +1,14 @@
+export interface UuidCrypto {
+	randomUUID?: () => string;
+	getRandomValues<T extends ArrayBufferView | null>(array: T): T;
+}
+
+export function generateUuidV4(source: UuidCrypto = crypto): string {
+	if (typeof source.randomUUID === "function") return source.randomUUID();
+
+	const bytes = source.getRandomValues(new Uint8Array(16));
+	bytes[6] = (bytes[6] & 0x0f) | 0x40;
+	bytes[8] = (bytes[8] & 0x3f) | 0x80;
+	const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0"));
+	return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10).join("")}`;
+}

--- a/src/types/tabTypes.ts
+++ b/src/types/tabTypes.ts
@@ -5,6 +5,7 @@ import {
 	type TableFilterState,
 } from "@/lib/resultFilters";
 import { createColumnLayout, type TableColumnLayout } from "@/lib/savedViews";
+import { generateUuidV4 } from "@/lib/uuid";
 import type {
 	ColumnInfo,
 	ForeignKeyInfo,
@@ -131,7 +132,7 @@ export function formatFunctionSignature(
 
 export function createTableDataTab(tableName: string): TableDataTab {
 	return {
-		id: `table-data-${tableName}-${Date.now()}`,
+		id: `table-data-${tableName}-${generateUuidV4()}`,
 		type: "table-data",
 		title: tableName.split(".").pop() || tableName,
 		tableName,
@@ -149,7 +150,7 @@ export function createTableDataTab(tableName: string): TableDataTab {
 
 export function createTableStructureTab(tableName: string): TableStructureTab {
 	return {
-		id: `table-structure-${tableName}-${Date.now()}`,
+		id: `table-structure-${tableName}-${generateUuidV4()}`,
 		type: "table-structure",
 		title: `${tableName.split(".").pop() || tableName} (structure)`,
 		tableName,
@@ -164,7 +165,7 @@ export function createQueryTab(
 	savedQueryName: string | null = null,
 ): QueryTab {
 	return {
-		id: `query-${Date.now()}`,
+		id: `query-${generateUuidV4()}`,
 		type: "query",
 		title: savedQueryName || "New Query",
 		query,
@@ -186,7 +187,7 @@ export function createQueryTab(
 
 export function createRedisQueryTab(pattern: string = "*"): RedisQueryTab {
 	return {
-		id: `redis-query-${Date.now()}`,
+		id: `redis-query-${generateUuidV4()}`,
 		type: "redis-query",
 		title: "Redis Keys",
 		pattern,
@@ -202,7 +203,7 @@ export function createSchemaVisualizerTab(
 	selectedTables: string[] = [],
 ): SchemaVisualizerTab {
 	return {
-		id: `schema-visualizer-${Date.now()}`,
+		id: `schema-visualizer-${generateUuidV4()}`,
 		type: "schema-visualizer",
 		title: "Schema Visualizer",
 		schemaOverview: null,
@@ -216,7 +217,7 @@ export function createFunctionDefinitionTab(
 	functionSummary: FunctionSummary,
 ): FunctionDefinitionTab {
 	return {
-		id: `function-definition-${functionSummary.schema}-${functionSummary.name}-${functionSummary.identity_args}-${Date.now()}`,
+		id: `function-definition-${functionSummary.schema}-${functionSummary.name}-${functionSummary.identity_args}-${generateUuidV4()}`,
 		type: "function-definition",
 		title: formatFunctionSignature(functionSummary, false),
 		functionSummary,


### PR DESCRIPTION
## Summary
- correlate table pagination, filter, sort, refresh, and mutation refreshes per table tab
- correlate manual queries, run-all, and result filter/sort operations per query tab
- prevent stale responses, errors, loading finalizers, and global toasts from overwriting newer actions or a new connection lifecycle
- stop run-all and inline mutation batches before starting further operations after close, supersession, or UUID change
- preserve history for statements that actually completed or failed
- replace timestamp tab IDs with collision-safe UUID v4 generation, including an older-WebKit `getRandomValues` fallback

## Verification
- `bun run check` (154 tests, typecheck, ESLint, production build)
- async reverse-completion, lifecycle invalidation, batch-stop, checkpoint, and UUID fallback tests
- `git diff --check`

Updated directly onto `main` at `e2016f3`. Tauri invokes are not cancellable; stale ownership is enforced at operation boundaries and commits.