### PR TITLE
Release v0.0.64

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary
- bump DBcooper from 0.0.63 to 0.0.64
- prepare the first stable release containing opt-in canary releases and channel-aware update checks

## Release flow
After merge, the release label triggers tag-on-merge to create v0.0.64. The publish workflow then builds the signed macOS release as a GitHub draft.

## Validation
- bun install --frozen-lockfile
- bun run check
- cargo test --lib -- --test-threads=1
- cargo test --no-run
- actionlint .github/workflows/test.yml .github/workflows/publish.yml
- git diff --check