### PR TITLE
Retry transient canary upload failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,6 +138,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
+          retryAttempts: 3
           tagName: ${{ steps.canary.outputs.tag }}
           releaseName: DBcooper ${{ steps.canary.outputs.version }} (canary)
           releaseBody: |


### PR DESCRIPTION
## Summary
- retry tauri-action canary builds and release-asset uploads up to three times
- prevent a single transient GitHub release upload failure from breaking the canary pipeline

## Verification
- actionlint .github/workflows/test.yml
- git diff --check