### PR TITLE
Use shadcn select in database creation

### DIFF
--- a/src/components/docker/CreateDatabaseDialog.test.tsx
+++ b/src/components/docker/CreateDatabaseDialog.test.tsx
@@ -24,6 +24,28 @@ mock.module("@/components/ui/input", () => ({
 mock.module("@/components/ui/label", () => ({
 	Label: (props: ComponentProps<"label">) => <label {...props} />,
 }));
+mock.module("@/components/ui/select", () => ({
+	Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	SelectContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	SelectItem: ({
+		children,
+		value,
+	}: {
+		children: ReactNode;
+		value: string;
+	}) => <div data-value={value}>{children}</div>,
+	SelectTrigger: ({
+		children,
+		...props
+	}: ComponentProps<"button">) => (
+		<button data-slot="select-trigger" {...props}>
+			{children}
+		</button>
+	),
+	SelectValue: () => <span data-slot="select-value" />,
+}));
 mock.module("@/components/ui/spinner", () => ({
 	Spinner: () => <span>Loading</span>,
 }));
@@ -57,7 +79,20 @@ test("offers every Docker database engine supported by the backend", () => {
 		/>,
 	);
 
-	expect(markup).toContain('value="postgres"');
-	expect(markup).toContain('value="redis"');
-	expect(markup).toContain('value="clickhouse"');
+	expect(markup).toContain('data-value="postgres"');
+	expect(markup).toContain('data-value="redis"');
+	expect(markup).toContain('data-value="clickhouse"');
+});
+
+test("uses the shared select component for the database engine", () => {
+	const markup = renderToStaticMarkup(
+		<CreateDatabaseDialog
+			open
+			onOpenChange={() => undefined}
+			onCreated={async () => undefined}
+		/>,
+	);
+
+	expect(markup).toContain('data-slot="select-trigger"');
+	expect(markup).not.toContain("<select");
 });

--- a/src/components/docker/CreateDatabaseDialog.tsx
+++ b/src/components/docker/CreateDatabaseDialog.tsx
@@ -11,6 +11,13 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import {
 	api,
@@ -76,23 +83,26 @@ export function CreateDatabaseDialog({
 				<div className="space-y-4">
 					<div className="space-y-2">
 						<Label htmlFor="docker-engine">Database</Label>
-						<select
-							id="docker-engine"
+						<Select
 							value={engine.value}
-							onChange={(event) => {
+							onValueChange={(value) => {
 								const selected = DOCKER_DATABASE_ENGINES.find(
-									(option) => option.value === event.target.value,
+									(option) => option.value === value,
 								);
 								if (selected) setEngine(selected);
 							}}
-							className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-xs outline-none focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50"
 						>
-							{DOCKER_DATABASE_ENGINES.map((option) => (
-								<option key={option.value} value={option.value}>
-									{option.label}
-								</option>
-							))}
-						</select>
+							<SelectTrigger id="docker-engine" className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{DOCKER_DATABASE_ENGINES.map((option) => (
+									<SelectItem key={option.value} value={option.value}>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
 					</div>
 					<div className="space-y-2">
 						<Label htmlFor="docker-name">Connection name</Label>


### PR DESCRIPTION
## Summary
- replace the native database engine select in the Docker creation dialog with the shared shadcn/Base UI Select
- preserve the existing engine choices, selected value behavior, label association, and full-width layout
- add a regression test that rejects a native select and verifies the shared trigger

## Verification
- bun test src/components/docker/CreateDatabaseDialog.test.tsx
- bun run check
- git diff --check