### PR TITLE
Keep settings navigation visible while scrolling

### DIFF
--- a/src/pages/Settings.test.ts
+++ b/src/pages/Settings.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const settingsSource = readFileSync(
+	new URL("./Settings.tsx", import.meta.url),
+	"utf8",
+);
+
+function classesFor(tag: "div" | "header" | "main") {
+	const className = settingsSource.match(
+		new RegExp(`<${tag}[\\s\\S]*?className="([^"]+)"`),
+	)?.[1];
+
+	expect(className).toBeDefined();
+	return className?.split(" ") ?? [];
+}
+
+describe("Settings page layout", () => {
+	test("keeps the page within the viewport and scrolls only the main content", () => {
+		expect(classesFor("div")).toEqual(
+			expect.arrayContaining(["h-screen", "overflow-hidden"]),
+		);
+		expect(classesFor("main")).toEqual(
+			expect.arrayContaining(["min-h-0", "flex-1", "overflow-auto"]),
+		);
+	});
+
+	test("keeps the navigation bar sticky above the scrolling content", () => {
+		expect(classesFor("header")).toEqual(
+			expect.arrayContaining(["sticky", "top-0", "z-20", "shrink-0"]),
+		);
+	});
+});

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -8,10 +8,10 @@ export function Settings() {
 	const navigate = useNavigate();
 
 	return (
-		<div className="workspace-canvas flex min-h-screen flex-col">
+		<div className="workspace-canvas flex h-screen flex-col overflow-hidden">
 			<header
 				data-tauri-drag-region
-				className="app-titlebar flex h-12 shrink-0 select-none items-center border-b px-4 pl-24"
+				className="app-titlebar sticky top-0 z-20 flex h-12 shrink-0 select-none items-center border-b px-4 pl-24"
 			>
 				<Button variant="ghost" onClick={() => navigate("/")}>
 					<ArrowLeft className="h-4 w-4" />
@@ -19,7 +19,7 @@ export function Settings() {
 				</Button>
 			</header>
 
-			<main className="flex-1 overflow-auto p-5 md:p-8">
+			<main className="min-h-0 flex-1 overflow-auto p-5 md:p-8">
 				<div className="mx-auto max-w-2xl">
 					<div className="mb-5">
 						<p className="section-label">DBcooper</p>


### PR DESCRIPTION
## Summary

- constrain the settings page shell to the application viewport
- keep the navigation bar and Back button sticky while the preferences body scrolls independently
- add regression coverage for the viewport, sticky-header, and scroll-container layout contract

## Root cause

The settings shell used `min-h-screen`, which allowed the page to grow with its form content. That handed scrolling to the document instead of the existing `main` content region, so the navigation bar scrolled out of view.

## Impact

The settings navigation remains accessible at the top of the window while users scroll through longer preferences.

## Testing

- `bun test` — 55 tests pass
- `bun run build`
- `bunx biome check src/pages/Settings.tsx src/pages/Settings.test.ts`
- Chrome runtime verification at 1024×768 confirmed `window.scrollY` remains `0`, the header remains at `top: 0`, and the main pane scrolls independently