### PR TITLE
Release v0.0.65

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DBcooper",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "identifier": "com.amalshaji.dbcooper",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

Release DBcooper v0.0.65.

### Highlights

- create and manage persistent PostgreSQL, Redis, and ClickHouse databases through Docker
- link existing Docker database containers, including stopped containers with custom host-port mappings
- design, review, and create PostgreSQL and SQLite tables from the object explorer
- keep Settings navigation visible while the page body scrolls
- use the shared shadcn select component for database creation
- make canary artifact uploads resilient to transient GitHub failures

## Release behavior

Merging this labeled PR creates the v0.0.65 tag and starts the signed stable release workflow. The workflow produces a draft GitHub release for review before publication.

## Verification

- bun run check
- cargo test --no-run
- cargo test --lib -- --test-threads=1
- verified v0.0.64 is an ancestor and v0.0.65 does not already exist