### PR TITLE
Add saved views for database tables

### DIFF
--- a/docs/src/components/RoadmapMap.astro
+++ b/docs/src/components/RoadmapMap.astro
@@ -19,7 +19,7 @@ const productStops: RoadmapStop[] = [
 	{ name: "Million-row paging", detail: "Benchmarked first-window load", status: "released" },
 	{ name: "Structured filters", detail: "Safe, visual conditions", status: "released" },
 	{ name: "Contextual AI", detail: "Preview before apply", status: "released" },
-	{ name: "Saved views", detail: "Filters, sort, layout", status: "next" },
+	{ name: "Saved views", detail: "Filters, sort, layout", status: "released" },
 	{ name: "Schema diff", detail: "Review changes locally", status: "exploring" },
 ];
 

--- a/src-tauri/migrations/008_saved_views.sql
+++ b/src-tauri/migrations/008_saved_views.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS saved_views (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    connection_uuid TEXT NOT NULL,
+    table_name TEXT NOT NULL,
+    name TEXT NOT NULL COLLATE NOCASE,
+    state_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (connection_uuid) REFERENCES connections(uuid) ON DELETE CASCADE,
+    UNIQUE (connection_uuid, table_name, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_views_connection_table_updated
+    ON saved_views(connection_uuid, table_name, updated_at DESC, id DESC);

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod mcp;
 pub mod pool;
 pub mod postgres;
 pub mod queries;
+pub mod saved_views;
 pub mod settings;
 #[cfg(desktop)]
 pub mod updates;

--- a/src-tauri/src/commands/saved_views.rs
+++ b/src-tauri/src/commands/saved_views.rs
@@ -1,0 +1,218 @@
+use crate::db::models::{SavedView, SavedViewFormData, SavedViewState, SavedViewUpdateData};
+use sqlx::{FromRow, SqlitePool};
+use tauri::State;
+
+const VIEW_STATE_VERSION: u8 = 1;
+const MIN_COLUMN_WIDTH: u16 = 80;
+const MAX_COLUMN_WIDTH: u16 = 300;
+const MAX_VIEW_NAME_LENGTH: usize = 80;
+
+#[derive(FromRow)]
+struct SavedViewRow {
+    id: i64,
+    connection_uuid: String,
+    table_name: String,
+    name: String,
+    state_json: String,
+    created_at: String,
+    updated_at: String,
+}
+
+impl SavedViewRow {
+    fn into_saved_view(self) -> Result<SavedView, String> {
+        let state = serde_json::from_str(&self.state_json)
+            .map_err(|_| format!("Saved view '{}' has invalid state", self.name))?;
+
+        Ok(SavedView {
+            id: self.id,
+            connection_uuid: self.connection_uuid,
+            table_name: self.table_name,
+            name: self.name,
+            state,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+        })
+    }
+}
+
+fn normalize_view_name(name: &str) -> Result<String, String> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err("View name is required".to_string());
+    }
+    if name.chars().count() > MAX_VIEW_NAME_LENGTH {
+        return Err(format!(
+            "View name must be {MAX_VIEW_NAME_LENGTH} characters or fewer"
+        ));
+    }
+    Ok(name.to_string())
+}
+
+fn validate_view_state(state: &SavedViewState) -> Result<(), String> {
+    if state.version != VIEW_STATE_VERSION {
+        return Err(format!("Unsupported saved view version: {}", state.version));
+    }
+
+    if state
+        .column_widths
+        .values()
+        .any(|width| !(MIN_COLUMN_WIDTH..=MAX_COLUMN_WIDTH).contains(width))
+    {
+        return Err(format!(
+            "Column widths must be between {MIN_COLUMN_WIDTH} and {MAX_COLUMN_WIDTH} pixels"
+        ));
+    }
+
+    Ok(())
+}
+
+fn map_database_error(error: sqlx::Error) -> String {
+    if error
+        .as_database_error()
+        .is_some_and(|database_error| database_error.is_unique_violation())
+    {
+        "A view with this name already exists for this table".to_string()
+    } else {
+        error.to_string()
+    }
+}
+
+fn serialize_state(state: &SavedViewState) -> Result<String, String> {
+    validate_view_state(state)?;
+    serde_json::to_string(state).map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub async fn get_saved_views(
+    pool: State<'_, SqlitePool>,
+    connection_uuid: String,
+    table_name: String,
+) -> Result<Vec<SavedView>, String> {
+    let rows = sqlx::query_as::<_, SavedViewRow>(
+        r#"
+        SELECT * FROM saved_views
+        WHERE connection_uuid = ? AND table_name = ?
+        ORDER BY updated_at DESC, id DESC
+        "#,
+    )
+    .bind(connection_uuid)
+    .bind(table_name)
+    .fetch_all(pool.inner())
+    .await
+    .map_err(map_database_error)?;
+
+    rows.into_iter()
+        .map(SavedViewRow::into_saved_view)
+        .collect()
+}
+
+#[tauri::command]
+pub async fn create_saved_view(
+    pool: State<'_, SqlitePool>,
+    connection_uuid: String,
+    data: SavedViewFormData,
+) -> Result<SavedView, String> {
+    if data.table_name.trim().is_empty() {
+        return Err("Table name is required".to_string());
+    }
+
+    let name = normalize_view_name(&data.name)?;
+    let state_json = serialize_state(&data.state)?;
+    let row = sqlx::query_as::<_, SavedViewRow>(
+        r#"
+        INSERT INTO saved_views (connection_uuid, table_name, name, state_json)
+        VALUES (?, ?, ?, ?)
+        RETURNING *
+        "#,
+    )
+    .bind(connection_uuid)
+    .bind(data.table_name)
+    .bind(name)
+    .bind(state_json)
+    .fetch_one(pool.inner())
+    .await
+    .map_err(map_database_error)?;
+
+    row.into_saved_view()
+}
+
+#[tauri::command]
+pub async fn update_saved_view(
+    pool: State<'_, SqlitePool>,
+    id: i64,
+    data: SavedViewUpdateData,
+) -> Result<SavedView, String> {
+    let name = normalize_view_name(&data.name)?;
+    let state_json = serialize_state(&data.state)?;
+    let row = sqlx::query_as::<_, SavedViewRow>(
+        r#"
+        UPDATE saved_views
+        SET name = ?, state_json = ?, updated_at = datetime('now')
+        WHERE id = ?
+        RETURNING *
+        "#,
+    )
+    .bind(name)
+    .bind(state_json)
+    .bind(id)
+    .fetch_one(pool.inner())
+    .await
+    .map_err(map_database_error)?;
+
+    row.into_saved_view()
+}
+
+#[tauri::command]
+pub async fn delete_saved_view(pool: State<'_, SqlitePool>, id: i64) -> Result<bool, String> {
+    sqlx::query("DELETE FROM saved_views WHERE id = ?")
+        .bind(id)
+        .execute(pool.inner())
+        .await
+        .map(|_| true)
+        .map_err(map_database_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_view_name, validate_view_state};
+    use crate::db::models::SavedViewState;
+    use std::collections::HashMap;
+
+    fn state() -> SavedViewState {
+        SavedViewState {
+            version: 1,
+            filter: None,
+            sort: None,
+            column_order: vec!["id".to_string()],
+            hidden_columns: Vec::new(),
+            column_widths: HashMap::from([("id".to_string(), 150)]),
+        }
+    }
+
+    #[test]
+    fn normalizes_valid_names_and_rejects_blank_or_long_names() {
+        assert_eq!(
+            normalize_view_name("  Recent events  ").unwrap(),
+            "Recent events"
+        );
+        assert!(normalize_view_name("   ").is_err());
+        assert!(normalize_view_name(&"a".repeat(81)).is_err());
+    }
+
+    #[test]
+    fn validates_the_state_version_and_column_width_bounds() {
+        assert!(validate_view_state(&state()).is_ok());
+
+        let mut unsupported = state();
+        unsupported.version = 2;
+        assert!(validate_view_state(&unsupported).is_err());
+
+        let mut too_narrow = state();
+        too_narrow.column_widths.insert("id".to_string(), 79);
+        assert!(validate_view_state(&too_narrow).is_err());
+
+        let mut too_wide = state();
+        too_wide.column_widths.insert("id".to_string(), 301);
+        assert!(validate_view_state(&too_wide).is_err());
+    }
+}

--- a/src-tauri/src/commands/saved_views.rs
+++ b/src-tauri/src/commands/saved_views.rs
@@ -1,4 +1,6 @@
-use crate::db::models::{SavedView, SavedViewFormData, SavedViewState, SavedViewUpdateData};
+use crate::db::models::{
+    SavedView, SavedViewFormData, SavedViewState, SavedViewStatePayload, SavedViewUpdateData,
+};
 use sqlx::{FromRow, SqlitePool};
 use tauri::State;
 
@@ -20,8 +22,20 @@ struct SavedViewRow {
 
 impl SavedViewRow {
     fn into_saved_view(self) -> Result<SavedView, String> {
-        let state = serde_json::from_str(&self.state_json)
+        let value = serde_json::from_str::<serde_json::Value>(&self.state_json)
             .map_err(|_| format!("Saved view '{}' has invalid state", self.name))?;
+        let version = value
+            .get("version")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| format!("Saved view '{}' has invalid state", self.name))?;
+        let state = if version == u64::from(VIEW_STATE_VERSION) {
+            SavedViewStatePayload::Current {
+                state: serde_json::from_value(value)
+                    .map_err(|_| format!("Saved view '{}' has invalid state", self.name))?,
+            }
+        } else {
+            SavedViewStatePayload::Unsupported { version }
+        };
 
         Ok(SavedView {
             id: self.id,
@@ -174,8 +188,8 @@ pub async fn delete_saved_view(pool: State<'_, SqlitePool>, id: i64) -> Result<b
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_view_name, validate_view_state};
-    use crate::db::models::SavedViewState;
+    use super::{normalize_view_name, validate_view_state, SavedViewRow};
+    use crate::db::models::{SavedViewState, SavedViewStatePayload};
     use std::collections::HashMap;
 
     fn state() -> SavedViewState {
@@ -214,5 +228,25 @@ mod tests {
         let mut too_wide = state();
         too_wide.column_widths.insert("id".to_string(), 301);
         assert!(validate_view_state(&too_wide).is_err());
+    }
+
+    #[test]
+    fn classifies_future_saved_view_state_without_parsing_v1_fields() {
+        let saved = SavedViewRow {
+            id: 1,
+            connection_uuid: "connection-1".to_string(),
+            table_name: "public.events".to_string(),
+            name: "Future".to_string(),
+            state_json: r#"{"version":2,"layout":{"density":"compact"}}"#.to_string(),
+            created_at: "2026-07-26 12:00:00".to_string(),
+            updated_at: "2026-07-26 12:00:00".to_string(),
+        }
+        .into_saved_view()
+        .unwrap();
+
+        assert!(matches!(
+            saved.state,
+            SavedViewStatePayload::Unsupported { version: 2 }
+        ));
     }
 }

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Connection {
@@ -270,6 +271,53 @@ impl TableFilter {
             (None, None) => Ok(None),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SavedViewSortDirection {
+    Asc,
+    Desc,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedViewSort {
+    pub column: String,
+    pub direction: SavedViewSortDirection,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedViewState {
+    pub version: u8,
+    pub filter: Option<TableFilter>,
+    pub sort: Option<SavedViewSort>,
+    pub column_order: Vec<String>,
+    pub hidden_columns: Vec<String>,
+    pub column_widths: HashMap<String, u16>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedView {
+    pub id: i64,
+    pub connection_uuid: String,
+    pub table_name: String,
+    pub name: String,
+    pub state: SavedViewState,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedViewFormData {
+    pub table_name: String,
+    pub name: String,
+    pub state: SavedViewState,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SavedViewUpdateData {
+    pub name: String,
+    pub state: SavedViewState,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -297,12 +297,19 @@ pub struct SavedViewState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum SavedViewStatePayload {
+    Current { state: SavedViewState },
+    Unsupported { version: u64 },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedView {
     pub id: i64,
     pub connection_uuid: String,
     pub table_name: String,
     pub name: String,
-    pub state: SavedViewState,
+    pub state: SavedViewStatePayload,
     pub created_at: String,
     pub updated_at: String,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,9 @@ use commands::queries::{
     clear_query_history, create_saved_query, delete_saved_query, get_query_history,
     get_saved_queries, record_query_history, update_saved_query,
 };
+use commands::saved_views::{
+    create_saved_view, delete_saved_view, get_saved_views, update_saved_view,
+};
 use commands::settings::{get_all_settings, get_setting, set_setting, set_settings};
 #[cfg(desktop)]
 use commands::updates::check_for_update;
@@ -269,6 +272,10 @@ pub fn run() {
             record_query_history,
             get_query_history,
             clear_query_history,
+            get_saved_views,
+            create_saved_view,
+            update_saved_view,
+            delete_saved_view,
             get_setting,
             set_setting,
             set_settings,

--- a/src-tauri/tests/app_data_tests.rs
+++ b/src-tauri/tests/app_data_tests.rs
@@ -21,6 +21,11 @@ async fn create_test_pool() -> (sqlx::SqlitePool, NamedTempFile) {
         .await
         .expect("Failed to create pool");
 
+    sqlx::query("PRAGMA foreign_keys = ON")
+        .execute(&pool)
+        .await
+        .unwrap();
+
     // Create schema
     sqlx::query(
         r#"
@@ -79,6 +84,7 @@ async fn create_test_pool() -> (sqlx::SqlitePool, NamedTempFile) {
             state_json TEXT NOT NULL,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            FOREIGN KEY (connection_uuid) REFERENCES connections(uuid) ON DELETE CASCADE,
             UNIQUE (connection_uuid, table_name, name)
         )
         "#,
@@ -100,6 +106,16 @@ async fn create_test_pool() -> (sqlx::SqlitePool, NamedTempFile) {
     .unwrap();
 
     (pool, temp_file)
+}
+
+async fn insert_test_connection(pool: &sqlx::SqlitePool, connection_uuid: &str) {
+    sqlx::query(
+        "INSERT INTO connections (uuid, type, name, host, port, database, username, password, db_type) VALUES (?, 'postgres', 'Test', 'localhost', 5432, 'db', 'user', 'pass', 'postgres')",
+    )
+    .bind(connection_uuid)
+    .execute(pool)
+    .await
+    .unwrap();
 }
 
 // ============================================================================
@@ -413,6 +429,7 @@ async fn test_delete_saved_query() {
 async fn test_saved_view_round_trip_preserves_versioned_state() {
     let (pool, _temp_file) = create_test_pool().await;
     let connection_uuid = uuid::Uuid::new_v4().to_string();
+    insert_test_connection(&pool, &connection_uuid).await;
     let state = serde_json::json!({
         "version": 1,
         "filter": null,
@@ -448,6 +465,7 @@ async fn test_saved_view_round_trip_preserves_versioned_state() {
 async fn test_saved_view_names_are_unique_per_connection_and_table() {
     let (pool, _temp_file) = create_test_pool().await;
     let connection_uuid = uuid::Uuid::new_v4().to_string();
+    insert_test_connection(&pool, &connection_uuid).await;
     let state = r#"{"version":1,"filter":null,"sort":null,"column_order":[],"hidden_columns":[],"column_widths":{}}"#;
 
     sqlx::query(
@@ -484,6 +502,33 @@ async fn test_saved_view_names_are_unique_per_connection_and_table() {
     .await;
 
     assert!(other_table.is_ok());
+}
+
+#[tokio::test]
+async fn test_saved_views_are_deleted_with_their_connection() {
+    let (pool, _temp_file) = create_test_pool().await;
+    let connection_uuid = uuid::Uuid::new_v4().to_string();
+    insert_test_connection(&pool, &connection_uuid).await;
+    sqlx::query(
+        "INSERT INTO saved_views (connection_uuid, table_name, name, state_json) VALUES (?, 'public.events', 'Recent', ?)",
+    )
+    .bind(&connection_uuid)
+    .bind(r#"{"version":1,"filter":null,"sort":null,"column_order":[],"hidden_columns":[],"column_widths":{}}"#)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query("DELETE FROM connections WHERE uuid = ?")
+        .bind(&connection_uuid)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM saved_views")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(count, 0);
 }
 
 // ============================================================================

--- a/src-tauri/tests/app_data_tests.rs
+++ b/src-tauri/tests/app_data_tests.rs
@@ -71,6 +71,24 @@ async fn create_test_pool() -> (sqlx::SqlitePool, NamedTempFile) {
 
     sqlx::query(
         r#"
+        CREATE TABLE IF NOT EXISTS saved_views (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            connection_uuid TEXT NOT NULL,
+            table_name TEXT NOT NULL,
+            name TEXT NOT NULL COLLATE NOCASE,
+            state_json TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (connection_uuid, table_name, name)
+        )
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        r#"
         CREATE TABLE IF NOT EXISTS settings (
             key TEXT PRIMARY KEY,
             value TEXT NOT NULL
@@ -385,6 +403,87 @@ async fn test_delete_saved_query() {
         .unwrap();
 
     assert_eq!(count.0, 0);
+}
+
+// ============================================================================
+// Saved View CRUD Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_saved_view_round_trip_preserves_versioned_state() {
+    let (pool, _temp_file) = create_test_pool().await;
+    let connection_uuid = uuid::Uuid::new_v4().to_string();
+    let state = serde_json::json!({
+        "version": 1,
+        "filter": null,
+        "sort": { "column": "created_at", "direction": "desc" },
+        "column_order": ["id", "created_at"],
+        "hidden_columns": ["id"],
+        "column_widths": { "created_at": 220 }
+    })
+    .to_string();
+
+    let saved: (String, String, String, String) = sqlx::query_as(
+        r#"
+        INSERT INTO saved_views (connection_uuid, table_name, name, state_json)
+        VALUES (?, ?, ?, ?)
+        RETURNING connection_uuid, table_name, name, state_json
+        "#,
+    )
+    .bind(&connection_uuid)
+    .bind("public.events")
+    .bind("Recent events")
+    .bind(&state)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(saved.0, connection_uuid);
+    assert_eq!(saved.1, "public.events");
+    assert_eq!(saved.2, "Recent events");
+    assert_eq!(saved.3, state);
+}
+
+#[tokio::test]
+async fn test_saved_view_names_are_unique_per_connection_and_table() {
+    let (pool, _temp_file) = create_test_pool().await;
+    let connection_uuid = uuid::Uuid::new_v4().to_string();
+    let state = r#"{"version":1,"filter":null,"sort":null,"column_order":[],"hidden_columns":[],"column_widths":{}}"#;
+
+    sqlx::query(
+        "INSERT INTO saved_views (connection_uuid, table_name, name, state_json) VALUES (?, ?, ?, ?)",
+    )
+    .bind(&connection_uuid)
+    .bind("public.events")
+    .bind("Recent")
+    .bind(state)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let duplicate = sqlx::query(
+        "INSERT INTO saved_views (connection_uuid, table_name, name, state_json) VALUES (?, ?, ?, ?)",
+    )
+    .bind(&connection_uuid)
+    .bind("public.events")
+    .bind("recent")
+    .bind(state)
+    .execute(&pool)
+    .await;
+
+    assert!(duplicate.is_err());
+
+    let other_table = sqlx::query(
+        "INSERT INTO saved_views (connection_uuid, table_name, name, state_json) VALUES (?, ?, ?, ?)",
+    )
+    .bind(&connection_uuid)
+    .bind("public.audit_log")
+    .bind("Recent")
+    .bind(state)
+    .execute(&pool)
+    .await;
+
+    assert!(other_table.is_ok());
 }
 
 // ============================================================================

--- a/src/components/DataTable.test.tsx
+++ b/src/components/DataTable.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { ComponentProps, ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("@/components/ui/button", () => ({
+	Button: ({ children, ...props }: ComponentProps<"button">) => (
+		<button {...props}>{children}</button>
+	),
+}));
+mock.module("@/components/ui/context-menu", () => ({
+	ContextMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+	ContextMenuContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	ContextMenuItem: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	ContextMenuTrigger: ({
+		render,
+		children,
+	}: {
+		render: ReactNode;
+		children: ReactNode;
+	}) => (
+		<>
+			{render}
+			{children}
+		</>
+	),
+}));
+
+const { DataTable } = await import("./DataTable");
+
+interface Row {
+	id: number;
+	name: string;
+}
+
+const columns: ColumnDef<Row>[] = [
+	{ accessorKey: "id", header: "ID" },
+	{ accessorKey: "name", header: "Name" },
+];
+
+describe("DataTable column layout", () => {
+	test("renders controlled order, visibility, width, and an accessible resize handle", () => {
+		const markup = renderToStaticMarkup(
+			<DataTable
+				data={[{ id: 1, name: "Ada" }]}
+				columns={columns}
+				hidePagination
+				columnLayout={{
+					columnOrder: ["name", "id"],
+					hiddenColumns: ["name"],
+					columnWidths: { id: 220 },
+				}}
+				onColumnLayoutChange={() => {}}
+			/>,
+		);
+
+		expect(markup).toContain(">ID<");
+		expect(markup).not.toContain(">Name<");
+		expect(markup).toContain("width:220px");
+		expect(markup).toContain('role="separator"');
+		expect(markup).toContain('aria-label="Resize ID column"');
+	});
+});

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -6,12 +6,13 @@ import {
 } from "@phosphor-icons/react";
 import {
 	type ColumnDef,
+	functionalUpdate,
 	flexRender,
 	getCoreRowModel,
 	useReactTable,
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	ContextMenu,
@@ -19,6 +20,13 @@ import {
 	ContextMenuItem,
 	ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import {
+	DEFAULT_COLUMN_WIDTH,
+	MAX_COLUMN_WIDTH,
+	MIN_COLUMN_WIDTH,
+	type TableColumnLayout,
+} from "../lib/savedViews";
+import { ColumnResizeHandle } from "./data-table/ColumnResizeHandle";
 
 export interface SortState {
 	column: string;
@@ -40,12 +48,11 @@ interface DataTableProps<TData> {
 	onSortChange?: (sort: SortState | null) => void;
 	isRowHighlighted?: (row: TData) => boolean;
 	onCellFilter?: (column: string, value: unknown, exclude: boolean) => void;
+	columnLayout?: TableColumnLayout;
+	onColumnLayoutChange?: (layout: TableColumnLayout) => void;
 }
 
-const COLUMN_WIDTH = 150;
 const VISIBLE_ROW_CAPACITY = 30;
-const MIN_COLUMN_WIDTH = 80;
-const MAX_COLUMN_WIDTH = 300;
 
 export function DataTable<TData>({
 	data,
@@ -62,12 +69,21 @@ export function DataTable<TData>({
 	onSortChange,
 	isRowHighlighted,
 	onCellFilter,
+	columnLayout,
+	onColumnLayoutChange,
 }: DataTableProps<TData>) {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [contextCell, setContextCell] = useState<{
 		column: string;
 		value: unknown;
 	} | null>(null);
+	const columnVisibility = useMemo(
+		() =>
+			Object.fromEntries(
+				(columnLayout?.hiddenColumns ?? []).map((column) => [column, false]),
+			),
+		[columnLayout?.hiddenColumns],
+	);
 
 	// TanStack Table returns functions that cannot be safely memoized by React Compiler.
 	// eslint-disable-next-line react-hooks/incompatible-library
@@ -77,6 +93,25 @@ export function DataTable<TData>({
 		getCoreRowModel: getCoreRowModel(),
 		manualPagination: true,
 		pageCount,
+		defaultColumn: {
+			size: DEFAULT_COLUMN_WIDTH,
+			minSize: MIN_COLUMN_WIDTH,
+			maxSize: MAX_COLUMN_WIDTH,
+		},
+		columnResizeMode: "onChange",
+		state: {
+			columnOrder: columnLayout?.columnOrder,
+			columnVisibility,
+			columnSizing: columnLayout?.columnWidths,
+		},
+		onColumnSizingChange: (updater) => {
+			if (!columnLayout || !onColumnLayoutChange) return;
+			const columnWidths = functionalUpdate(
+				updater,
+				columnLayout.columnWidths,
+			);
+			onColumnLayoutChange({ ...columnLayout, columnWidths });
+		},
 	});
 
 	const { rows } = table.getRowModel();
@@ -98,10 +133,15 @@ export function DataTable<TData>({
 		horizontal: true,
 		count: visibleColumns.length,
 		getScrollElement: () => containerRef.current,
-		estimateSize: () => COLUMN_WIDTH,
+		estimateSize: (index) =>
+			visibleColumns[index]?.column.getSize() ?? DEFAULT_COLUMN_WIDTH,
 		overscan: 4,
 		enabled: shouldVirtualizeColumns,
 	});
+
+	useEffect(() => {
+		columnVirtualizer.measure();
+	}, [columnVirtualizer, columnLayout]);
 
 	const virtualRows = shouldVirtualizeRows
 		? rowVirtualizer.getVirtualItems()
@@ -113,15 +153,15 @@ export function DataTable<TData>({
 				key: index,
 			}));
 
+	let staticColumnOffset = 0;
 	const virtualColumns = shouldVirtualizeColumns
 		? columnVirtualizer.getVirtualItems()
-		: visibleColumns.map((_, index) => ({
-				index,
-				start: index * COLUMN_WIDTH,
-				end: (index + 1) * COLUMN_WIDTH,
-				size: COLUMN_WIDTH,
-				key: index,
-			}));
+		: visibleColumns.map((header, index) => {
+				const size = header.column.getSize();
+				const start = staticColumnOffset;
+				staticColumnOffset += size;
+				return { index, start, end: start + size, size, key: index };
+			});
 
 	const totalRowHeight = shouldVirtualizeRows
 		? rowVirtualizer.getTotalSize()
@@ -129,7 +169,10 @@ export function DataTable<TData>({
 
 	const totalColumnWidth = shouldVirtualizeColumns
 		? columnVirtualizer.getTotalSize()
-		: visibleColumns.length * COLUMN_WIDTH;
+		: visibleColumns.reduce(
+				(total, header) => total + header.column.getSize(),
+				0,
+			);
 
 	const paddingTop =
 		shouldVirtualizeRows && virtualRows.length > 0
@@ -182,12 +225,13 @@ export function DataTable<TData>({
 		(row: (typeof rows)[number], columnIndex: number) => {
 			const cell = row.getVisibleCells()[columnIndex];
 			if (!cell) return null;
+			const columnWidth = cell.column.getSize();
 
 			const cellProps = {
 				style: {
-					width: COLUMN_WIDTH,
-					minWidth: MIN_COLUMN_WIDTH,
-					maxWidth: MAX_COLUMN_WIDTH,
+					width: columnWidth,
+					minWidth: columnWidth,
+					maxWidth: columnWidth,
 				},
 				className:
 					"h-10 px-3 align-middle whitespace-nowrap overflow-hidden text-ellipsis box-border",
@@ -285,8 +329,25 @@ export function DataTable<TData>({
 		if (shouldVirtualizeColumns) {
 			return totalColumnWidth;
 		}
-		return Math.max(visibleColumns.length * COLUMN_WIDTH, 100);
-	}, [shouldVirtualizeColumns, totalColumnWidth, visibleColumns.length]);
+		return Math.max(totalColumnWidth, 100);
+	}, [shouldVirtualizeColumns, totalColumnWidth]);
+
+	const updateColumnWidth = useCallback(
+		(column: string, width: number) => {
+			if (!columnLayout || !onColumnLayoutChange) return;
+			onColumnLayoutChange({
+				...columnLayout,
+				columnWidths: {
+					...columnLayout.columnWidths,
+					[column]: Math.min(
+						MAX_COLUMN_WIDTH,
+						Math.max(MIN_COLUMN_WIDTH, Math.round(width)),
+					),
+				},
+			});
+		},
+		[columnLayout, onColumnLayoutChange],
+	);
 
 	const getSortIcon = (columnId: string) => {
 		if (!sortable) return null;
@@ -338,15 +399,20 @@ export function DataTable<TData>({
 											typeof columnDef.accessorKey === "string"
 												? columnDef.accessorKey
 												: header.id;
+										const columnWidth = header.column.getSize();
+										const columnLabel =
+											typeof header.column.columnDef.header === "string"
+												? header.column.columnDef.header
+												: columnId;
 										return (
 											<th
 												key={header.id}
 												style={{
-													width: COLUMN_WIDTH,
-													minWidth: MIN_COLUMN_WIDTH,
-													maxWidth: MAX_COLUMN_WIDTH,
+													width: columnWidth,
+													minWidth: columnWidth,
+													maxWidth: columnWidth,
 												}}
-												className={`h-10 overflow-hidden text-ellipsis whitespace-nowrap bg-transparent px-3 text-left align-middle font-medium text-foreground box-border ${
+												className={`group/header relative h-10 overflow-hidden text-ellipsis whitespace-nowrap bg-transparent px-3 text-left align-middle font-medium text-foreground box-border ${
 													sortable
 														? "cursor-pointer hover:bg-muted/50 select-none"
 														: ""
@@ -364,6 +430,17 @@ export function DataTable<TData>({
 													</span>
 													{getSortIcon(columnId)}
 												</div>
+											{onColumnLayoutChange && (
+													<ColumnResizeHandle
+														columnLabel={columnLabel}
+														width={columnWidth}
+														isResizing={header.column.getIsResizing()}
+														onResizeStart={header.getResizeHandler()}
+														onWidthChange={(width) =>
+															updateColumnWidth(columnId, width)
+														}
+													/>
+												)}
 											</th>
 										);
 									})}

--- a/src/components/connection-details/ColumnLayoutPopover.test.tsx
+++ b/src/components/connection-details/ColumnLayoutPopover.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ComponentProps, ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("@/components/ui/button", () => ({
+	Button: ({ children, ...props }: ComponentProps<"button">) => (
+		<button {...props}>{children}</button>
+	),
+}));
+mock.module("@/components/ui/checkbox", () => ({
+	Checkbox: ({
+		onCheckedChange: _onCheckedChange,
+		...props
+	}: ComponentProps<"input"> & {
+		onCheckedChange?: (checked: boolean) => void;
+	}) => <input type="checkbox" readOnly {...props} />,
+}));
+mock.module("@/components/ui/popover", () => ({
+	Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	PopoverContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	PopoverDescription: ({ children }: { children: ReactNode }) => (
+		<p>{children}</p>
+	),
+	PopoverHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	PopoverTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+	PopoverTrigger: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
+const { ColumnLayoutPopover } = await import("./ColumnLayoutPopover");
+
+describe("ColumnLayoutPopover", () => {
+	test("renders direct and accessible controls for each column", () => {
+		const markup = renderToStaticMarkup(
+			<ColumnLayoutPopover
+				columns={["id", "name"]}
+				layout={{
+					columnOrder: ["id", "name"],
+					hiddenColumns: [],
+					columnWidths: { id: 220 },
+				}}
+				onChange={() => {}}
+			/>,
+		);
+
+		expect(markup).toContain("Columns");
+		expect(markup).toContain("Drag to reorder");
+		expect(markup).toContain('aria-label="Show id column"');
+		expect(markup).toContain('aria-label="Move name column up"');
+		expect(markup).toContain('aria-label="Move id column down"');
+		expect(markup).toContain("Reset columns");
+	});
+});

--- a/src/components/connection-details/ColumnLayoutPopover.tsx
+++ b/src/components/connection-details/ColumnLayoutPopover.tsx
@@ -1,0 +1,177 @@
+import {
+	ArrowCounterClockwise,
+	CaretDown,
+	CaretUp,
+	Columns,
+	DotsSixVertical,
+} from "@phosphor-icons/react";
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Popover,
+	PopoverContent,
+	PopoverDescription,
+	PopoverHeader,
+	PopoverTitle,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+	createColumnLayout,
+	moveColumn,
+	reorderColumn,
+	type TableColumnLayout,
+} from "../../lib/savedViews";
+
+interface ColumnLayoutPopoverProps {
+	columns: string[];
+	layout: TableColumnLayout;
+	onChange: (layout: TableColumnLayout) => void;
+}
+
+export function ColumnLayoutPopover({
+	columns,
+	layout,
+	onChange,
+}: ColumnLayoutPopoverProps) {
+	const dragColumn = useRef<string | null>(null);
+	const [draggingColumn, setDraggingColumn] = useState<string | null>(null);
+	const orderedColumns = layout.columnOrder.filter((column) =>
+		columns.includes(column),
+	);
+	for (const column of columns) {
+		if (!orderedColumns.includes(column)) orderedColumns.push(column);
+	}
+	const visibleCount = columns.length - layout.hiddenColumns.length;
+
+	const setColumnVisibility = (column: string, visible: boolean) => {
+		if (!visible && visibleCount <= 1) return;
+		const hiddenColumns = visible
+			? layout.hiddenColumns.filter((item) => item !== column)
+			: [...layout.hiddenColumns, column];
+		onChange({ ...layout, hiddenColumns });
+	};
+
+	const handlePointerMove = (event: React.PointerEvent<HTMLButtonElement>) => {
+		const column = dragColumn.current;
+		if (!column || !document.elementsFromPoint) return;
+		const row = document
+			.elementsFromPoint(event.clientX, event.clientY)
+			.map((element) => element.closest<HTMLElement>("[data-column-name]"))
+			.find(Boolean);
+		const target = row?.dataset.columnName;
+		if (!target || target === column) return;
+		onChange({
+			...layout,
+			columnOrder: reorderColumn(orderedColumns, column, target),
+		});
+	};
+
+	const finishDrag = (event: React.PointerEvent<HTMLButtonElement>) => {
+		if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+			event.currentTarget.releasePointerCapture(event.pointerId);
+		}
+		dragColumn.current = null;
+		setDraggingColumn(null);
+	};
+
+	return (
+		<Popover>
+			<PopoverTrigger
+				render={<Button variant="outline" size="sm" disabled={!columns.length} />}
+			>
+				<Columns className="size-4" />
+				Columns
+			</PopoverTrigger>
+			<PopoverContent align="end" className="w-80 gap-0 p-0">
+				<PopoverHeader className="border-b px-3 py-3">
+					<PopoverTitle>Table columns</PopoverTitle>
+					<PopoverDescription>
+						Drag to reorder, or use the arrow buttons.
+					</PopoverDescription>
+				</PopoverHeader>
+				<div className="max-h-72 overflow-y-auto p-1.5">
+					{orderedColumns.map((column, index) => {
+						const visible = !layout.hiddenColumns.includes(column);
+						return (
+							<div
+								key={column}
+								data-column-name={column}
+								data-dragging={draggingColumn === column || undefined}
+								className="group/column flex h-9 items-center rounded-lg px-1.5 text-xs transition-colors hover:bg-muted/70 data-[dragging=true]:bg-primary/8 data-[dragging=true]:text-foreground"
+							>
+								<button
+									type="button"
+									aria-label={`Drag to reorder ${column} column`}
+									className="mr-1 flex size-7 touch-none cursor-grab items-center justify-center rounded-md text-muted-foreground outline-none active:cursor-grabbing active:scale-95 focus-visible:ring-1 focus-visible:ring-ring"
+									onPointerDown={(event) => {
+										dragColumn.current = column;
+										setDraggingColumn(column);
+										event.currentTarget.setPointerCapture(event.pointerId);
+									}}
+									onPointerMove={handlePointerMove}
+									onPointerUp={finishDrag}
+									onPointerCancel={finishDrag}
+								>
+									<DotsSixVertical className="size-4" />
+								</button>
+								<label className="flex min-w-0 flex-1 cursor-pointer items-center">
+									<Checkbox
+										checked={visible}
+										disabled={visible && visibleCount <= 1}
+										onCheckedChange={(checked) =>
+											setColumnVisibility(column, checked === true)
+										}
+										aria-label={`Show ${column} column`}
+									/>
+									<span className="ml-2 truncate font-mono">{column}</span>
+								</label>
+								<div className="flex opacity-0 transition-opacity group-hover/column:opacity-100 focus-within:opacity-100">
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										disabled={index === 0}
+										aria-label={`Move ${column} column up`}
+										onClick={() =>
+											onChange({
+												...layout,
+												columnOrder: moveColumn(orderedColumns, column, -1),
+											})
+										}
+									>
+										<CaretUp className="size-3.5" />
+									</Button>
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										disabled={index === orderedColumns.length - 1}
+										aria-label={`Move ${column} column down`}
+										onClick={() =>
+											onChange({
+												...layout,
+												columnOrder: moveColumn(orderedColumns, column, 1),
+											})
+										}
+									>
+										<CaretDown className="size-3.5" />
+									</Button>
+								</div>
+							</div>
+						);
+					})}
+				</div>
+				<div className="border-t p-1.5">
+					<Button
+						variant="ghost"
+						size="sm"
+						className="w-full justify-start text-muted-foreground"
+						onClick={() => onChange(createColumnLayout(columns))}
+					>
+						<ArrowCounterClockwise className="size-4" />
+						Reset columns
+					</Button>
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/src/components/connection-details/ConnectionWelcome.tsx
+++ b/src/components/connection-details/ConnectionWelcome.tsx
@@ -1,4 +1,4 @@
-import { Database, Graph, Plus } from "@phosphor-icons/react";
+import { Plus, TreeStructure } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
 import type { Connection } from "@/lib/tauri";
 
@@ -26,7 +26,7 @@ export function ConnectionWelcome({
 		<div className="flex h-full items-center justify-center p-4">
 			<div className="workspace-panel w-full max-w-lg rounded-xl border px-8 py-9 text-center shadow-sm">
 				<div className="mx-auto mb-5 flex size-12 items-center justify-center rounded-lg bg-primary/10 text-primary ring-1 ring-primary/15">
-					<Database className="size-5" />
+					<TreeStructure className="size-5" />
 				</div>
 				<h2 className="text-lg font-semibold tracking-tight">
 					Welcome to {connection.name}
@@ -61,7 +61,7 @@ export function ConnectionWelcome({
 							variant="outline"
 							size="sm"
 						>
-							<Graph className="size-4" />
+							<TreeStructure className="size-4" />
 							Schema
 						</Button>
 					)}

--- a/src/components/connection-details/SavedViewDialogs.tsx
+++ b/src/components/connection-details/SavedViewDialogs.tsx
@@ -22,41 +22,40 @@ import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import type { SavedView } from "@/lib/tauri";
 
+export type SavedViewDialogAction =
+	| { type: "create"; name: string }
+	| { type: "rename"; view: SavedView; name: string }
+	| { type: "delete"; view: SavedView }
+	| { type: "switch"; view: SavedView }
+	| null;
+
 interface SavedViewDialogsProps {
-	nameDialog: "create" | "rename" | null;
-	name: string;
+	action: SavedViewDialogAction;
 	busy: boolean;
 	hasUnappliedFilterDraft: boolean;
-	deleteTarget: SavedView | null;
 	activeView: SavedView | null;
-	switchTarget: SavedView | null;
-	onNameChange: (name: string) => void;
-	onNameDialogOpenChange: (open: boolean) => void;
+	onActionChange: (action: SavedViewDialogAction) => void;
 	onNameSubmit: () => void;
-	onDeleteDialogOpenChange: (open: boolean) => void;
 	onDelete: () => void;
-	onSwitchDialogOpenChange: (open: boolean) => void;
 	onDiscardAndSwitch: () => void;
 	onSaveAndSwitch: () => void;
 }
 
 export function SavedViewDialogs({
-	nameDialog,
-	name,
+	action,
 	busy,
 	hasUnappliedFilterDraft,
-	deleteTarget,
 	activeView,
-	switchTarget,
-	onNameChange,
-	onNameDialogOpenChange,
+	onActionChange,
 	onNameSubmit,
-	onDeleteDialogOpenChange,
 	onDelete,
-	onSwitchDialogOpenChange,
 	onDiscardAndSwitch,
 	onSaveAndSwitch,
 }: SavedViewDialogsProps) {
+	const nameAction =
+		action?.type === "create" || action?.type === "rename" ? action : null;
+	const deleteTarget = action?.type === "delete" ? action.view : null;
+	const switchTarget = action?.type === "switch" ? action.view : null;
 	const submitName = (event: FormEvent) => {
 		event.preventDefault();
 		onNameSubmit();
@@ -64,15 +63,18 @@ export function SavedViewDialogs({
 
 	return (
 		<>
-			<Dialog open={nameDialog !== null} onOpenChange={onNameDialogOpenChange}>
+			<Dialog
+				open={nameAction !== null}
+				onOpenChange={(open) => !open && onActionChange(null)}
+			>
 				<DialogContent className="max-w-sm">
 					<form onSubmit={submitName}>
 						<DialogHeader>
 							<DialogTitle>
-								{nameDialog === "create" ? "Save view" : "Rename view"}
+								{nameAction?.type === "create" ? "Save view" : "Rename view"}
 							</DialogTitle>
 							<DialogDescription>
-								{nameDialog === "create"
+								{nameAction?.type === "create"
 									? "Save the applied filter, sort, and column layout for this table."
 									: "Choose a clear name for this table view."}
 							</DialogDescription>
@@ -85,11 +87,14 @@ export function SavedViewDialogs({
 								id="saved-view-name"
 								autoFocus
 								maxLength={80}
-								value={name}
-								onChange={(event) => onNameChange(event.target.value)}
+								value={nameAction?.name ?? ""}
+								onChange={(event) =>
+									nameAction &&
+									onActionChange({ ...nameAction, name: event.target.value })
+								}
 								placeholder="Recent activity"
 							/>
-							{nameDialog === "create" && hasUnappliedFilterDraft && (
+							{nameAction?.type === "create" && hasUnappliedFilterDraft && (
 								<p className="text-[11px] text-amber-700 dark:text-amber-300">
 									Unapplied filter edits won’t be included.
 								</p>
@@ -99,13 +104,13 @@ export function SavedViewDialogs({
 							<Button
 								type="button"
 								variant="outline"
-								onClick={() => onNameDialogOpenChange(false)}
+								onClick={() => onActionChange(null)}
 							>
 								Cancel
 							</Button>
-							<Button type="submit" disabled={busy || !name.trim()}>
+							<Button type="submit" disabled={busy || !nameAction?.name.trim()}>
 								{busy && <Spinner />}
-								{nameDialog === "create" ? "Save view" : "Rename view"}
+								{nameAction?.type === "create" ? "Save view" : "Rename view"}
 							</Button>
 						</DialogFooter>
 					</form>
@@ -114,7 +119,7 @@ export function SavedViewDialogs({
 
 			<AlertDialog
 				open={deleteTarget !== null}
-				onOpenChange={onDeleteDialogOpenChange}
+				onOpenChange={(open) => !open && onActionChange(null)}
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
@@ -138,7 +143,7 @@ export function SavedViewDialogs({
 
 			<Dialog
 				open={switchTarget !== null}
-				onOpenChange={onSwitchDialogOpenChange}
+				onOpenChange={(open) => !open && onActionChange(null)}
 			>
 				<DialogContent className="max-w-sm">
 					<DialogHeader>
@@ -149,10 +154,7 @@ export function SavedViewDialogs({
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter className="sm:grid sm:grid-cols-[auto_1fr_1fr]">
-						<Button
-							variant="ghost"
-							onClick={() => onSwitchDialogOpenChange(false)}
-						>
+						<Button variant="ghost" onClick={() => onActionChange(null)}>
 							Cancel
 						</Button>
 						<Button

--- a/src/components/connection-details/SavedViewDialogs.tsx
+++ b/src/components/connection-details/SavedViewDialogs.tsx
@@ -1,0 +1,173 @@
+import type { FormEvent } from "react";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import type { SavedView } from "@/lib/tauri";
+
+interface SavedViewDialogsProps {
+	nameDialog: "create" | "rename" | null;
+	name: string;
+	busy: boolean;
+	hasUnappliedFilterDraft: boolean;
+	deleteTarget: SavedView | null;
+	activeView: SavedView | null;
+	switchTarget: SavedView | null;
+	onNameChange: (name: string) => void;
+	onNameDialogOpenChange: (open: boolean) => void;
+	onNameSubmit: () => void;
+	onDeleteDialogOpenChange: (open: boolean) => void;
+	onDelete: () => void;
+	onSwitchDialogOpenChange: (open: boolean) => void;
+	onDiscardAndSwitch: () => void;
+	onSaveAndSwitch: () => void;
+}
+
+export function SavedViewDialogs({
+	nameDialog,
+	name,
+	busy,
+	hasUnappliedFilterDraft,
+	deleteTarget,
+	activeView,
+	switchTarget,
+	onNameChange,
+	onNameDialogOpenChange,
+	onNameSubmit,
+	onDeleteDialogOpenChange,
+	onDelete,
+	onSwitchDialogOpenChange,
+	onDiscardAndSwitch,
+	onSaveAndSwitch,
+}: SavedViewDialogsProps) {
+	const submitName = (event: FormEvent) => {
+		event.preventDefault();
+		onNameSubmit();
+	};
+
+	return (
+		<>
+			<Dialog open={nameDialog !== null} onOpenChange={onNameDialogOpenChange}>
+				<DialogContent className="max-w-sm">
+					<form onSubmit={submitName}>
+						<DialogHeader>
+							<DialogTitle>
+								{nameDialog === "create" ? "Save view" : "Rename view"}
+							</DialogTitle>
+							<DialogDescription>
+								{nameDialog === "create"
+									? "Save the applied filter, sort, and column layout for this table."
+									: "Choose a clear name for this table view."}
+							</DialogDescription>
+						</DialogHeader>
+						<div className="my-4 space-y-2">
+							<label htmlFor="saved-view-name" className="text-xs font-medium">
+								Name
+							</label>
+							<Input
+								id="saved-view-name"
+								autoFocus
+								maxLength={80}
+								value={name}
+								onChange={(event) => onNameChange(event.target.value)}
+								placeholder="Recent activity"
+							/>
+							{nameDialog === "create" && hasUnappliedFilterDraft && (
+								<p className="text-[11px] text-amber-700 dark:text-amber-300">
+									Unapplied filter edits won’t be included.
+								</p>
+							)}
+						</div>
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => onNameDialogOpenChange(false)}
+							>
+								Cancel
+							</Button>
+							<Button type="submit" disabled={busy || !name.trim()}>
+								{busy && <Spinner />}
+								{nameDialog === "create" ? "Save view" : "Rename view"}
+							</Button>
+						</DialogFooter>
+					</form>
+				</DialogContent>
+			</Dialog>
+
+			<AlertDialog
+				open={deleteTarget !== null}
+				onOpenChange={onDeleteDialogOpenChange}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete “{deleteTarget?.name}”?</AlertDialogTitle>
+						<AlertDialogDescription>
+							Your current table layout and filter will stay in place.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							variant="destructive"
+							onClick={onDelete}
+							disabled={busy}
+						>
+							{busy && <Spinner />} Delete view
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<Dialog
+				open={switchTarget !== null}
+				onOpenChange={onSwitchDialogOpenChange}
+			>
+				<DialogContent className="max-w-sm">
+					<DialogHeader>
+						<DialogTitle>Save changes to “{activeView?.name}”?</DialogTitle>
+						<DialogDescription>
+							You edited this view. Save those changes before switching to “
+							{switchTarget?.name}”.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter className="sm:grid sm:grid-cols-[auto_1fr_1fr]">
+						<Button
+							variant="ghost"
+							onClick={() => onSwitchDialogOpenChange(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							variant="outline"
+							onClick={onDiscardAndSwitch}
+							disabled={busy}
+						>
+							Discard and switch
+						</Button>
+						<Button onClick={onSaveAndSwitch} disabled={busy}>
+							{busy && <Spinner />} Save and switch
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/src/components/connection-details/SavedViewsMenu.test.tsx
+++ b/src/components/connection-details/SavedViewsMenu.test.tsx
@@ -1,0 +1,129 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ComponentProps, ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+	captureSavedViewState,
+	createColumnLayout,
+	getSavedViewStatus,
+} from "../../lib/savedViews";
+
+mock.module("@/components/ui/button", () => ({
+	Button: ({ children, ...props }: ComponentProps<"button">) => (
+		<button {...props}>{children}</button>
+	),
+}));
+mock.module("@/components/ui/input", () => ({
+	Input: (props: ComponentProps<"input">) => <input {...props} />,
+}));
+mock.module("@/components/ui/spinner", () => ({
+	Spinner: () => <span>Loading</span>,
+}));
+mock.module("@/lib/savedViews", () => ({ getSavedViewStatus }));
+mock.module("@/lib/tauri", () => ({
+	api: {
+		savedViews: {
+			list: async () => [],
+			create: async () => null,
+			update: async () => null,
+			delete: async () => true,
+		},
+	},
+}));
+mock.module("sonner", () => ({
+	toast: { error: () => {}, success: () => {} },
+}));
+
+mock.module("@/components/ui/dropdown-menu", () => ({
+	DropdownMenu: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DropdownMenuItem: ({ children }: { children: ReactNode }) => (
+		<button type="button">{children}</button>
+	),
+	DropdownMenuLabel: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DropdownMenuSeparator: () => <hr />,
+	DropdownMenuSub: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	DropdownMenuSubContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DropdownMenuSubTrigger: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+}));
+
+mock.module("@/components/ui/dialog", () => ({
+	Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	DialogContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DialogDescription: ({ children }: { children: ReactNode }) => (
+		<p>{children}</p>
+	),
+	DialogFooter: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DialogHeader: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+mock.module("@/components/ui/alert-dialog", () => ({
+	AlertDialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	AlertDialogAction: ({ children }: { children: ReactNode }) => (
+		<button type="button">{children}</button>
+	),
+	AlertDialogCancel: ({ children }: { children: ReactNode }) => (
+		<button type="button">{children}</button>
+	),
+	AlertDialogContent: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	AlertDialogDescription: ({ children }: { children: ReactNode }) => (
+		<p>{children}</p>
+	),
+	AlertDialogFooter: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	AlertDialogHeader: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
+	AlertDialogTitle: ({ children }: { children: ReactNode }) => (
+		<h2>{children}</h2>
+	),
+}));
+
+const { SavedViewsMenu } = await import("./SavedViewsMenu");
+
+describe("SavedViewsMenu", () => {
+	test("shows a compact empty state and the save action", () => {
+		const currentState = captureSavedViewState(null, null, {
+			...createColumnLayout(["id"]),
+			columnWidths: { id: 220 },
+		});
+		const html = renderToStaticMarkup(
+			<SavedViewsMenu
+				connectionUuid="connection-1"
+				tableName="public.events"
+				currentState={currentState}
+				activeViewId={1}
+				loading={false}
+				hasUnappliedFilterDraft={false}
+				onActiveViewChange={() => {}}
+				onApply={async () => true}
+			/>,
+		);
+
+		expect(html).toContain("Views");
+		expect(html).toContain("No views saved for this table");
+		expect(html).toContain("Save current view");
+	});
+});

--- a/src/components/connection-details/SavedViewsMenu.test.tsx
+++ b/src/components/connection-details/SavedViewsMenu.test.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps, ReactNode } from "react";
 import {
 	captureSavedViewState,
 	createColumnLayout,
+	decodeSavedViewState,
 	getSavedViewStatus,
 } from "../../lib/savedViews";
 import type { SavedView } from "../../lib/tauri";
@@ -26,7 +27,10 @@ mock.module("@/components/ui/input", () => ({
 mock.module("@/components/ui/spinner", () => ({
 	Spinner: () => <span>Loading</span>,
 }));
-mock.module("@/lib/savedViews", () => ({ getSavedViewStatus }));
+mock.module("@/lib/savedViews", () => ({
+	decodeSavedViewState,
+	getSavedViewStatus,
+}));
 mock.module("@/lib/tauri", () => ({
 	api: {
 		savedViews: {
@@ -62,7 +66,9 @@ mock.module("@/components/ui/dropdown-menu", () => ({
 		<div>{children}</div>
 	),
 	DropdownMenuSeparator: () => <hr />,
-	DropdownMenuSub: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+	DropdownMenuSub: ({ children }: { children: ReactNode }) => (
+		<div>{children}</div>
+	),
 	DropdownMenuSubContent: ({ children }: { children: ReactNode }) => (
 		<div>{children}</div>
 	),
@@ -137,7 +143,7 @@ function view(id: number, tableName: string, name: string): SavedView {
 		connection_uuid: "connection-1",
 		table_name: tableName,
 		name,
-		state: currentState,
+		state: { status: "current", state: currentState },
 		created_at: "2026-07-26 12:00:00",
 		updated_at: "2026-07-26 12:00:00",
 	};
@@ -184,7 +190,9 @@ describe("SavedViewsMenu", () => {
 			<SavedViewsMenu {...props} tableName="public.events" />,
 		);
 
-		expect((await screen.findAllByText("Recent events")).length).toBeGreaterThan(0);
+		expect(
+			(await screen.findAllByText("Recent events")).length,
+		).toBeGreaterThan(0);
 		rerender(<SavedViewsMenu {...props} tableName="public.audit_log" />);
 
 		await waitFor(() => {

--- a/src/components/connection-details/SavedViewsMenu.test.tsx
+++ b/src/components/connection-details/SavedViewsMenu.test.tsx
@@ -1,11 +1,19 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { ComponentProps, ReactNode } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 import {
 	captureSavedViewState,
 	createColumnLayout,
 	getSavedViewStatus,
 } from "../../lib/savedViews";
+import type { SavedView } from "../../lib/tauri";
+
+if (!globalThis.document) GlobalRegistrator.register();
+
+let listHandler = async (
+	_connectionUuid: string,
+	_tableName: string,
+): Promise<SavedView[]> => [];
 
 mock.module("@/components/ui/button", () => ({
 	Button: ({ children, ...props }: ComponentProps<"button">) => (
@@ -22,7 +30,8 @@ mock.module("@/lib/savedViews", () => ({ getSavedViewStatus }));
 mock.module("@/lib/tauri", () => ({
 	api: {
 		savedViews: {
-			list: async () => [],
+			list: (connectionUuid: string, tableName: string) =>
+				listHandler(connectionUuid, tableName),
 			create: async () => null,
 			update: async () => null,
 			delete: async () => true,
@@ -30,7 +39,7 @@ mock.module("@/lib/tauri", () => ({
 	},
 }));
 mock.module("sonner", () => ({
-	toast: { error: () => {}, success: () => {} },
+	toast: { error: () => {}, success: () => {}, warning: () => {} },
 }));
 
 mock.module("@/components/ui/dropdown-menu", () => ({
@@ -40,8 +49,14 @@ mock.module("@/components/ui/dropdown-menu", () => ({
 	DropdownMenuContent: ({ children }: { children: ReactNode }) => (
 		<div>{children}</div>
 	),
-	DropdownMenuItem: ({ children }: { children: ReactNode }) => (
-		<button type="button">{children}</button>
+	DropdownMenuItem: ({
+		children,
+		variant: _variant,
+		...props
+	}: ComponentProps<"button"> & { variant?: string }) => (
+		<button type="button" {...props}>
+			{children}
+		</button>
 	),
 	DropdownMenuLabel: ({ children }: { children: ReactNode }) => (
 		<div>{children}</div>
@@ -102,14 +117,35 @@ mock.module("@/components/ui/alert-dialog", () => ({
 }));
 
 const { SavedViewsMenu } = await import("./SavedViewsMenu");
+const { act, cleanup, render, screen, waitFor } = await import(
+	"@testing-library/react"
+);
+
+afterEach(() => {
+	cleanup();
+	listHandler = async () => [];
+});
+
+const currentState = captureSavedViewState(null, null, {
+	...createColumnLayout(["id"]),
+	columnWidths: { id: 220 },
+});
+
+function view(id: number, tableName: string, name: string): SavedView {
+	return {
+		id,
+		connection_uuid: "connection-1",
+		table_name: tableName,
+		name,
+		state: currentState,
+		created_at: "2026-07-26 12:00:00",
+		updated_at: "2026-07-26 12:00:00",
+	};
+}
 
 describe("SavedViewsMenu", () => {
-	test("shows a compact empty state and the save action", () => {
-		const currentState = captureSavedViewState(null, null, {
-			...createColumnLayout(["id"]),
-			columnWidths: { id: 220 },
-		});
-		const html = renderToStaticMarkup(
+	test("shows a compact empty state and the save action", async () => {
+		render(
 			<SavedViewsMenu
 				connectionUuid="connection-1"
 				tableName="public.events"
@@ -121,9 +157,38 @@ describe("SavedViewsMenu", () => {
 				onApply={async () => true}
 			/>,
 		);
+		await act(async () => {});
 
-		expect(html).toContain("Views");
-		expect(html).toContain("No views saved for this table");
-		expect(html).toContain("Save current view");
+		expect(screen.getByText("Views")).not.toBeNull();
+		expect(screen.getByText(/No views saved for this table/)).not.toBeNull();
+		expect(screen.getByText(/Save current view/)).not.toBeNull();
+	});
+
+	test("does not retain another table's views when the scope changes", async () => {
+		listHandler = async (_connectionUuid, tableName) => {
+			if (tableName === "public.events") {
+				return [view(1, tableName, "Recent events")];
+			}
+			throw new Error("load failed");
+		};
+		const props = {
+			connectionUuid: "connection-1",
+			currentState,
+			activeViewId: null,
+			loading: false,
+			hasUnappliedFilterDraft: false,
+			onActiveViewChange: () => {},
+			onApply: async () => true,
+		};
+		const { rerender } = render(
+			<SavedViewsMenu {...props} tableName="public.events" />,
+		);
+
+		expect((await screen.findAllByText("Recent events")).length).toBeGreaterThan(0);
+		rerender(<SavedViewsMenu {...props} tableName="public.audit_log" />);
+
+		await waitFor(() => {
+			expect(screen.queryAllByText("Recent events")).toHaveLength(0);
+		});
 	});
 });

--- a/src/components/connection-details/SavedViewsMenu.tsx
+++ b/src/components/connection-details/SavedViewsMenu.tsx
@@ -7,25 +7,7 @@ import {
 } from "@phosphor-icons/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
-import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -36,10 +18,9 @@ import {
 	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { Spinner } from "@/components/ui/spinner";
 import { getSavedViewStatus } from "@/lib/savedViews";
 import { api, type SavedView, type SavedViewStateV1 } from "@/lib/tauri";
+import { SavedViewDialogs } from "./SavedViewDialogs";
 
 interface SavedViewsMenuProps {
 	connectionUuid: string;
@@ -228,6 +209,19 @@ export function SavedViewsMenu({
 		}
 	};
 
+	const closeNameDialog = (open: boolean) => {
+		if (!open) {
+			setNameDialog(null);
+			setRenameTarget(null);
+		}
+	};
+
+	const discardAndSwitch = () => {
+		const target = switchTarget;
+		setSwitchTarget(null);
+		if (target) void applyView(target);
+	};
+
 	const disabled = loading || loadingViews || busy;
 
 	return (
@@ -273,11 +267,9 @@ export function SavedViewsMenu({
 						<FloppyDisk /> Save current view…
 					</DropdownMenuItem>
 					{activeView && (
-						<>
-							<DropdownMenuItem onClick={() => void updateActiveView()}>
-								<FloppyDisk /> Update “{activeView.name}”
-							</DropdownMenuItem>
-						</>
+						<DropdownMenuItem onClick={() => void updateActiveView()}>
+							<FloppyDisk /> Update “{activeView.name}”
+						</DropdownMenuItem>
 					)}
 					{views.length > 0 && (
 						<>
@@ -321,129 +313,25 @@ export function SavedViewsMenu({
 				</DropdownMenuContent>
 			</DropdownMenu>
 
-			<Dialog
-				open={nameDialog !== null}
-				onOpenChange={(open) => {
-					if (!open) {
-						setNameDialog(null);
-						setRenameTarget(null);
-					}
-				}}
-			>
-				<DialogContent className="max-w-sm">
-					<form
-						onSubmit={(event) => {
-							event.preventDefault();
-							void (nameDialog === "create"
-								? createView()
-								: renameView());
-						}}
-					>
-						<DialogHeader>
-							<DialogTitle>
-								{nameDialog === "create" ? "Save view" : "Rename view"}
-							</DialogTitle>
-							<DialogDescription>
-								{nameDialog === "create"
-									? "Save the applied filter, sort, and column layout for this table."
-									: "Choose a clear name for this table view."}
-							</DialogDescription>
-						</DialogHeader>
-						<div className="my-4 space-y-2">
-							<label htmlFor="saved-view-name" className="text-xs font-medium">
-								Name
-							</label>
-							<Input
-								id="saved-view-name"
-								autoFocus
-								maxLength={80}
-								value={name}
-								onChange={(event) => setName(event.target.value)}
-								placeholder="Recent activity"
-							/>
-							{nameDialog === "create" && hasUnappliedFilterDraft && (
-								<p className="text-[11px] text-amber-700 dark:text-amber-300">
-									Unapplied filter edits won’t be included.
-								</p>
-							)}
-						</div>
-						<DialogFooter>
-							<Button
-								type="button"
-								variant="outline"
-								onClick={() => {
-									setNameDialog(null);
-									setRenameTarget(null);
-								}}
-							>
-								Cancel
-							</Button>
-							<Button type="submit" disabled={busy || !name.trim()}>
-								{busy && <Spinner />}
-								{nameDialog === "create" ? "Save view" : "Rename view"}
-							</Button>
-						</DialogFooter>
-					</form>
-				</DialogContent>
-			</Dialog>
-
-			<AlertDialog
-				open={deleteTarget !== null}
-				onOpenChange={(open) => !open && setDeleteTarget(null)}
-			>
-				<AlertDialogContent>
-					<AlertDialogHeader>
-						<AlertDialogTitle>Delete “{deleteTarget?.name}”?</AlertDialogTitle>
-						<AlertDialogDescription>
-							Your current table layout and filter will stay in place.
-						</AlertDialogDescription>
-					</AlertDialogHeader>
-					<AlertDialogFooter>
-						<AlertDialogCancel>Cancel</AlertDialogCancel>
-						<AlertDialogAction
-							variant="destructive"
-							onClick={() => void deleteView()}
-							disabled={busy}
-						>
-							{busy && <Spinner />} Delete view
-						</AlertDialogAction>
-					</AlertDialogFooter>
-				</AlertDialogContent>
-			</AlertDialog>
-
-			<Dialog
-				open={switchTarget !== null}
-				onOpenChange={(open) => !open && setSwitchTarget(null)}
-			>
-				<DialogContent className="max-w-sm">
-					<DialogHeader>
-						<DialogTitle>Save changes to “{activeView?.name}”?</DialogTitle>
-						<DialogDescription>
-							You edited this view. Save those changes before switching to “
-							{switchTarget?.name}”.
-						</DialogDescription>
-					</DialogHeader>
-					<DialogFooter className="sm:grid sm:grid-cols-[auto_1fr_1fr]">
-						<Button variant="ghost" onClick={() => setSwitchTarget(null)}>
-							Cancel
-						</Button>
-						<Button
-							variant="outline"
-							onClick={() => {
-								const target = switchTarget;
-								setSwitchTarget(null);
-								if (target) void applyView(target);
-							}}
-							disabled={busy}
-						>
-							Discard and switch
-						</Button>
-						<Button onClick={() => void saveAndSwitch()} disabled={busy}>
-							{busy && <Spinner />} Save and switch
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+			<SavedViewDialogs
+				nameDialog={nameDialog}
+				name={name}
+				busy={busy}
+				hasUnappliedFilterDraft={hasUnappliedFilterDraft}
+				deleteTarget={deleteTarget}
+				activeView={activeView}
+				switchTarget={switchTarget}
+				onNameChange={setName}
+				onNameDialogOpenChange={closeNameDialog}
+				onNameSubmit={() =>
+					void (nameDialog === "create" ? createView() : renameView())
+				}
+				onDeleteDialogOpenChange={(open) => !open && setDeleteTarget(null)}
+				onDelete={() => void deleteView()}
+				onSwitchDialogOpenChange={(open) => !open && setSwitchTarget(null)}
+				onDiscardAndSwitch={discardAndSwitch}
+				onSaveAndSwitch={() => void saveAndSwitch()}
+			/>
 		</>
 	);
 }

--- a/src/components/connection-details/SavedViewsMenu.tsx
+++ b/src/components/connection-details/SavedViewsMenu.tsx
@@ -20,7 +20,10 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { getSavedViewStatus } from "@/lib/savedViews";
 import { api, type SavedView, type SavedViewStateV1 } from "@/lib/tauri";
-import { SavedViewDialogs } from "./SavedViewDialogs";
+import {
+	SavedViewDialogs,
+	type SavedViewDialogAction,
+} from "./SavedViewDialogs";
 
 interface SavedViewsMenuProps {
 	connectionUuid: string;
@@ -32,8 +35,6 @@ interface SavedViewsMenuProps {
 	onActiveViewChange: (id: number | null) => void;
 	onApply: (view: SavedView) => Promise<boolean>;
 }
-
-type NameDialogMode = "create" | "rename" | null;
 
 function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
@@ -61,11 +62,7 @@ function SavedViewsMenuContent({
 	const [views, setViews] = useState<SavedView[]>([]);
 	const [loadingViews, setLoadingViews] = useState(true);
 	const [busy, setBusy] = useState(false);
-	const [nameDialog, setNameDialog] = useState<NameDialogMode>(null);
-	const [name, setName] = useState("");
-	const [renameTarget, setRenameTarget] = useState<SavedView | null>(null);
-	const [deleteTarget, setDeleteTarget] = useState<SavedView | null>(null);
-	const [switchTarget, setSwitchTarget] = useState<SavedView | null>(null);
+	const [dialogAction, setDialogAction] = useState<SavedViewDialogAction>(null);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -118,7 +115,7 @@ function SavedViewsMenuContent({
 		(view: SavedView) => {
 			if (view.id === activeViewId) return;
 			if (activeView && isEdited) {
-				setSwitchTarget(view);
+				setDialogAction({ type: "switch", view });
 				return;
 			}
 			void applyView(view);
@@ -127,18 +124,17 @@ function SavedViewsMenuContent({
 	);
 
 	const createView = async () => {
-		if (!name.trim()) return;
+		if (dialogAction?.type !== "create" || !dialogAction.name.trim()) return;
 		setBusy(true);
 		try {
 			const created = await api.savedViews.create(connectionUuid, {
 				table_name: tableName,
-				name,
+				name: dialogAction.name,
 				state: currentState,
 			});
 			replaceView(created);
 			onActiveViewChange(created.id);
-			setNameDialog(null);
-			setName("");
+			setDialogAction(null);
 			toast.success(`Saved “${created.name}”`);
 		} catch (error) {
 			toast.error("Failed to save view", { description: errorMessage(error) });
@@ -169,17 +165,15 @@ function SavedViewsMenuContent({
 	}, [activeView, currentState, replaceView]);
 
 	const renameView = async () => {
-		if (!renameTarget || !name.trim()) return;
+		if (dialogAction?.type !== "rename" || !dialogAction.name.trim()) return;
 		setBusy(true);
 		try {
-			const updated = await api.savedViews.update(renameTarget.id, {
-				name,
-				state: renameTarget.state,
+			const updated = await api.savedViews.update(dialogAction.view.id, {
+				name: dialogAction.name,
+				state: dialogAction.view.state,
 			});
 			replaceView(updated);
-			setNameDialog(null);
-			setRenameTarget(null);
-			setName("");
+			setDialogAction(null);
 		} catch (error) {
 			toast.error("Failed to rename view", {
 				description: errorMessage(error),
@@ -190,16 +184,15 @@ function SavedViewsMenuContent({
 	};
 
 	const deleteView = async () => {
-		if (!deleteTarget) return;
+		if (dialogAction?.type !== "delete") return;
+		const target = dialogAction.view;
 		setBusy(true);
 		try {
-			await api.savedViews.delete(deleteTarget.id);
-			setViews((current) =>
-				current.filter((view) => view.id !== deleteTarget.id),
-			);
-			if (deleteTarget.id === activeViewId) onActiveViewChange(null);
-			setDeleteTarget(null);
-			toast.success(`Deleted “${deleteTarget.name}”`);
+			await api.savedViews.delete(target.id);
+			setViews((current) => current.filter((view) => view.id !== target.id));
+			if (target.id === activeViewId) onActiveViewChange(null);
+			setDialogAction(null);
+			toast.success(`Deleted “${target.name}”`);
 		} catch (error) {
 			toast.error("Failed to delete view", {
 				description: errorMessage(error),
@@ -210,25 +203,19 @@ function SavedViewsMenuContent({
 	};
 
 	const saveAndSwitch = async () => {
-		if (!switchTarget) return;
-		const target = switchTarget;
+		if (dialogAction?.type !== "switch") return;
+		const target = dialogAction.view;
 		if (await updateActiveView()) {
-			setSwitchTarget(null);
+			setDialogAction(null);
 			await applyView(target);
 		}
 	};
 
-	const closeNameDialog = (open: boolean) => {
-		if (!open) {
-			setNameDialog(null);
-			setRenameTarget(null);
-		}
-	};
-
 	const discardAndSwitch = () => {
-		const target = switchTarget;
-		setSwitchTarget(null);
-		if (target) void applyView(target);
+		if (dialogAction?.type !== "switch") return;
+		const target = dialogAction.view;
+		setDialogAction(null);
+		void applyView(target);
 	};
 
 	const disabled = loading || loadingViews || busy;
@@ -268,10 +255,7 @@ function SavedViewsMenuContent({
 					)}
 					<DropdownMenuSeparator />
 					<DropdownMenuItem
-						onClick={() => {
-							setName("");
-							setNameDialog("create");
-						}}
+						onClick={() => setDialogAction({ type: "create", name: "" })}
 					>
 						<FloppyDisk /> Save current view…
 					</DropdownMenuItem>
@@ -291,9 +275,11 @@ function SavedViewsMenuContent({
 										<DropdownMenuItem
 											key={view.id}
 											onClick={() => {
-												setRenameTarget(view);
-												setName(view.name);
-												setNameDialog("rename");
+												setDialogAction({
+													type: "rename",
+													view,
+													name: view.name,
+												});
 											}}
 										>
 											<span className="truncate">{view.name}</span>
@@ -310,7 +296,7 @@ function SavedViewsMenuContent({
 										<DropdownMenuItem
 											key={view.id}
 											variant="destructive"
-											onClick={() => setDeleteTarget(view)}
+											onClick={() => setDialogAction({ type: "delete", view })}
 										>
 											<span className="truncate">{view.name}</span>
 										</DropdownMenuItem>
@@ -323,21 +309,15 @@ function SavedViewsMenuContent({
 			</DropdownMenu>
 
 			<SavedViewDialogs
-				nameDialog={nameDialog}
-				name={name}
+				action={dialogAction}
 				busy={busy}
 				hasUnappliedFilterDraft={hasUnappliedFilterDraft}
-				deleteTarget={deleteTarget}
 				activeView={activeView}
-				switchTarget={switchTarget}
-				onNameChange={setName}
-				onNameDialogOpenChange={closeNameDialog}
+				onActionChange={setDialogAction}
 				onNameSubmit={() =>
-					void (nameDialog === "create" ? createView() : renameView())
+					void (dialogAction?.type === "create" ? createView() : renameView())
 				}
-				onDeleteDialogOpenChange={(open) => !open && setDeleteTarget(null)}
 				onDelete={() => void deleteView()}
-				onSwitchDialogOpenChange={(open) => !open && setSwitchTarget(null)}
 				onDiscardAndSwitch={discardAndSwitch}
 				onSaveAndSwitch={() => void saveAndSwitch()}
 			/>

--- a/src/components/connection-details/SavedViewsMenu.tsx
+++ b/src/components/connection-details/SavedViewsMenu.tsx
@@ -18,7 +18,7 @@ import {
 	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { getSavedViewStatus } from "@/lib/savedViews";
+import { decodeSavedViewState, getSavedViewStatus } from "@/lib/savedViews";
 import { api, type SavedView, type SavedViewStateV1 } from "@/lib/tauri";
 import {
 	SavedViewDialogs,
@@ -166,11 +166,18 @@ function SavedViewsMenuContent({
 
 	const renameView = async () => {
 		if (dialogAction?.type !== "rename" || !dialogAction.name.trim()) return;
+		const decodedState = decodeSavedViewState(dialogAction.view.state);
+		if (!decodedState.state) {
+			toast.error("Failed to rename view", {
+				description: decodedState.error,
+			});
+			return;
+		}
 		setBusy(true);
 		try {
 			const updated = await api.savedViews.update(dialogAction.view.id, {
 				name: dialogAction.name,
-				state: dialogAction.view.state,
+				state: decodedState.state,
 			});
 			replaceView(updated);
 			setDialogAction(null);

--- a/src/components/connection-details/SavedViewsMenu.tsx
+++ b/src/components/connection-details/SavedViewsMenu.tsx
@@ -1,0 +1,449 @@
+import {
+	CaretDown,
+	Check,
+	FloppyDisk,
+	PencilSimple,
+	Trash,
+} from "@phosphor-icons/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuSub,
+	DropdownMenuSubContent,
+	DropdownMenuSubTrigger,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { getSavedViewStatus } from "@/lib/savedViews";
+import { api, type SavedView, type SavedViewStateV1 } from "@/lib/tauri";
+
+interface SavedViewsMenuProps {
+	connectionUuid: string;
+	tableName: string;
+	currentState: SavedViewStateV1;
+	activeViewId: number | null;
+	loading: boolean;
+	hasUnappliedFilterDraft: boolean;
+	onActiveViewChange: (id: number | null) => void;
+	onApply: (view: SavedView) => Promise<boolean>;
+}
+
+type NameDialogMode = "create" | "rename" | null;
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+export function SavedViewsMenu({
+	connectionUuid,
+	tableName,
+	currentState,
+	activeViewId,
+	loading,
+	hasUnappliedFilterDraft,
+	onActiveViewChange,
+	onApply,
+}: SavedViewsMenuProps) {
+	const [views, setViews] = useState<SavedView[]>([]);
+	const [loadingViews, setLoadingViews] = useState(true);
+	const [busy, setBusy] = useState(false);
+	const [nameDialog, setNameDialog] = useState<NameDialogMode>(null);
+	const [name, setName] = useState("");
+	const [renameTarget, setRenameTarget] = useState<SavedView | null>(null);
+	const [deleteTarget, setDeleteTarget] = useState<SavedView | null>(null);
+	const [switchTarget, setSwitchTarget] = useState<SavedView | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		setLoadingViews(true);
+		api.savedViews
+			.list(connectionUuid, tableName)
+			.then((nextViews) => {
+				if (!cancelled) setViews(nextViews);
+			})
+			.catch((error) => {
+				if (!cancelled) {
+					toast.error("Failed to load saved views", {
+						description: errorMessage(error),
+					});
+				}
+			})
+			.finally(() => {
+				if (!cancelled) setLoadingViews(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [connectionUuid, tableName]);
+
+	const { activeView, isEdited } = useMemo(
+		() => getSavedViewStatus(activeViewId, views, currentState),
+		[activeViewId, currentState, views],
+	);
+
+	const replaceView = useCallback((updated: SavedView) => {
+		setViews((current) => [
+			updated,
+			...current.filter((view) => view.id !== updated.id),
+		]);
+	}, []);
+
+	const applyView = useCallback(
+		async (view: SavedView) => {
+			setBusy(true);
+			try {
+				if (await onApply(view)) onActiveViewChange(view.id);
+			} finally {
+				setBusy(false);
+			}
+		},
+		[onActiveViewChange, onApply],
+	);
+
+	const requestView = useCallback(
+		(view: SavedView) => {
+			if (view.id === activeViewId) return;
+			if (activeView && isEdited) {
+				setSwitchTarget(view);
+				return;
+			}
+			void applyView(view);
+		},
+		[activeView, activeViewId, applyView, isEdited],
+	);
+
+	const createView = async () => {
+		if (!name.trim()) return;
+		setBusy(true);
+		try {
+			const created = await api.savedViews.create(connectionUuid, {
+				table_name: tableName,
+				name,
+				state: currentState,
+			});
+			replaceView(created);
+			onActiveViewChange(created.id);
+			setNameDialog(null);
+			setName("");
+			toast.success(`Saved “${created.name}”`);
+		} catch (error) {
+			toast.error("Failed to save view", { description: errorMessage(error) });
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	const updateActiveView = useCallback(async () => {
+		if (!activeView) return false;
+		setBusy(true);
+		try {
+			const updated = await api.savedViews.update(activeView.id, {
+				name: activeView.name,
+				state: currentState,
+			});
+			replaceView(updated);
+			toast.success(`Updated “${updated.name}”`);
+			return true;
+		} catch (error) {
+			toast.error("Failed to update view", {
+				description: errorMessage(error),
+			});
+			return false;
+		} finally {
+			setBusy(false);
+		}
+	}, [activeView, currentState, replaceView]);
+
+	const renameView = async () => {
+		if (!renameTarget || !name.trim()) return;
+		setBusy(true);
+		try {
+			const updated = await api.savedViews.update(renameTarget.id, {
+				name,
+				state: renameTarget.state,
+			});
+			replaceView(updated);
+			setNameDialog(null);
+			setRenameTarget(null);
+			setName("");
+		} catch (error) {
+			toast.error("Failed to rename view", {
+				description: errorMessage(error),
+			});
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	const deleteView = async () => {
+		if (!deleteTarget) return;
+		setBusy(true);
+		try {
+			await api.savedViews.delete(deleteTarget.id);
+			setViews((current) =>
+				current.filter((view) => view.id !== deleteTarget.id),
+			);
+			if (deleteTarget.id === activeViewId) onActiveViewChange(null);
+			setDeleteTarget(null);
+			toast.success(`Deleted “${deleteTarget.name}”`);
+		} catch (error) {
+			toast.error("Failed to delete view", {
+				description: errorMessage(error),
+			});
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	const saveAndSwitch = async () => {
+		if (!switchTarget) return;
+		const target = switchTarget;
+		if (await updateActiveView()) {
+			setSwitchTarget(null);
+			await applyView(target);
+		}
+	};
+
+	const disabled = loading || loadingViews || busy;
+
+	return (
+		<>
+			<DropdownMenu>
+				<DropdownMenuTrigger
+					render={<Button variant="outline" size="sm" disabled={disabled} />}
+				>
+					<FloppyDisk data-icon="inline-start" />
+					<span className="max-w-36 truncate">
+						{activeView?.name ?? "Views"}
+					</span>
+					{isEdited && (
+						<span className="rounded bg-amber-500/15 px-1 py-0.5 text-[10px] font-semibold text-amber-700 dark:text-amber-300">
+							Edited
+						</span>
+					)}
+					<CaretDown data-icon="inline-end" />
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end" className="w-64 p-1">
+					<p className="px-2 py-2 text-xs text-muted-foreground">
+						Saved views for this table
+					</p>
+					{views.length ? (
+						views.map((view) => (
+							<DropdownMenuItem key={view.id} onClick={() => requestView(view)}>
+								<span className="min-w-0 flex-1 truncate">{view.name}</span>
+								{view.id === activeViewId && <Check className="text-primary" />}
+							</DropdownMenuItem>
+						))
+					) : (
+						<p className="px-2 py-3 text-xs text-muted-foreground">
+							No views saved for this table.
+						</p>
+					)}
+					<DropdownMenuSeparator />
+					<DropdownMenuItem
+						onClick={() => {
+							setName("");
+							setNameDialog("create");
+						}}
+					>
+						<FloppyDisk /> Save current view…
+					</DropdownMenuItem>
+					{activeView && (
+						<>
+							<DropdownMenuItem onClick={() => void updateActiveView()}>
+								<FloppyDisk /> Update “{activeView.name}”
+							</DropdownMenuItem>
+						</>
+					)}
+					{views.length > 0 && (
+						<>
+							<DropdownMenuSub>
+								<DropdownMenuSubTrigger>
+									<PencilSimple /> Rename view
+								</DropdownMenuSubTrigger>
+								<DropdownMenuSubContent className="w-52 p-1">
+									{views.map((view) => (
+										<DropdownMenuItem
+											key={view.id}
+											onClick={() => {
+												setRenameTarget(view);
+												setName(view.name);
+												setNameDialog("rename");
+											}}
+										>
+											<span className="truncate">{view.name}</span>
+										</DropdownMenuItem>
+									))}
+								</DropdownMenuSubContent>
+							</DropdownMenuSub>
+							<DropdownMenuSub>
+								<DropdownMenuSubTrigger className="text-destructive">
+									<Trash /> Delete view
+								</DropdownMenuSubTrigger>
+								<DropdownMenuSubContent className="w-52 p-1">
+									{views.map((view) => (
+										<DropdownMenuItem
+											key={view.id}
+											variant="destructive"
+											onClick={() => setDeleteTarget(view)}
+										>
+											<span className="truncate">{view.name}</span>
+										</DropdownMenuItem>
+									))}
+								</DropdownMenuSubContent>
+							</DropdownMenuSub>
+						</>
+					)}
+				</DropdownMenuContent>
+			</DropdownMenu>
+
+			<Dialog
+				open={nameDialog !== null}
+				onOpenChange={(open) => {
+					if (!open) {
+						setNameDialog(null);
+						setRenameTarget(null);
+					}
+				}}
+			>
+				<DialogContent className="max-w-sm">
+					<form
+						onSubmit={(event) => {
+							event.preventDefault();
+							void (nameDialog === "create"
+								? createView()
+								: renameView());
+						}}
+					>
+						<DialogHeader>
+							<DialogTitle>
+								{nameDialog === "create" ? "Save view" : "Rename view"}
+							</DialogTitle>
+							<DialogDescription>
+								{nameDialog === "create"
+									? "Save the applied filter, sort, and column layout for this table."
+									: "Choose a clear name for this table view."}
+							</DialogDescription>
+						</DialogHeader>
+						<div className="my-4 space-y-2">
+							<label htmlFor="saved-view-name" className="text-xs font-medium">
+								Name
+							</label>
+							<Input
+								id="saved-view-name"
+								autoFocus
+								maxLength={80}
+								value={name}
+								onChange={(event) => setName(event.target.value)}
+								placeholder="Recent activity"
+							/>
+							{nameDialog === "create" && hasUnappliedFilterDraft && (
+								<p className="text-[11px] text-amber-700 dark:text-amber-300">
+									Unapplied filter edits won’t be included.
+								</p>
+							)}
+						</div>
+						<DialogFooter>
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => {
+									setNameDialog(null);
+									setRenameTarget(null);
+								}}
+							>
+								Cancel
+							</Button>
+							<Button type="submit" disabled={busy || !name.trim()}>
+								{busy && <Spinner />}
+								{nameDialog === "create" ? "Save view" : "Rename view"}
+							</Button>
+						</DialogFooter>
+					</form>
+				</DialogContent>
+			</Dialog>
+
+			<AlertDialog
+				open={deleteTarget !== null}
+				onOpenChange={(open) => !open && setDeleteTarget(null)}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete “{deleteTarget?.name}”?</AlertDialogTitle>
+						<AlertDialogDescription>
+							Your current table layout and filter will stay in place.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							variant="destructive"
+							onClick={() => void deleteView()}
+							disabled={busy}
+						>
+							{busy && <Spinner />} Delete view
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<Dialog
+				open={switchTarget !== null}
+				onOpenChange={(open) => !open && setSwitchTarget(null)}
+			>
+				<DialogContent className="max-w-sm">
+					<DialogHeader>
+						<DialogTitle>Save changes to “{activeView?.name}”?</DialogTitle>
+						<DialogDescription>
+							You edited this view. Save those changes before switching to “
+							{switchTarget?.name}”.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter className="sm:grid sm:grid-cols-[auto_1fr_1fr]">
+						<Button variant="ghost" onClick={() => setSwitchTarget(null)}>
+							Cancel
+						</Button>
+						<Button
+							variant="outline"
+							onClick={() => {
+								const target = switchTarget;
+								setSwitchTarget(null);
+								if (target) void applyView(target);
+							}}
+							disabled={busy}
+						>
+							Discard and switch
+						</Button>
+						<Button onClick={() => void saveAndSwitch()} disabled={busy}>
+							{busy && <Spinner />} Save and switch
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}

--- a/src/components/connection-details/SavedViewsMenu.tsx
+++ b/src/components/connection-details/SavedViewsMenu.tsx
@@ -39,7 +39,16 @@ function errorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
 
-export function SavedViewsMenu({
+export function SavedViewsMenu(props: SavedViewsMenuProps) {
+	return (
+		<SavedViewsMenuContent
+			key={`${props.connectionUuid}:${props.tableName}`}
+			{...props}
+		/>
+	);
+}
+
+function SavedViewsMenuContent({
 	connectionUuid,
 	tableName,
 	currentState,

--- a/src/components/connection-details/TableFilterBar.test.tsx
+++ b/src/components/connection-details/TableFilterBar.test.tsx
@@ -64,6 +64,19 @@ function renderFilterBar(state: TableFilterState): string {
 }
 
 describe("TableFilterBar", () => {
+	test("uses the same horizontal inset as card content", () => {
+		const markup = renderFilterBar({
+			draft: {
+				kind: "structured",
+				value: { conjunction: "and", conditions: [] },
+			},
+			applied: null,
+		});
+
+		expect(markup).toContain("mx-4");
+		expect(markup).not.toContain("mx-6");
+	});
+
 	test("keeps the editor rendered when an active filter returns no rows", () => {
 		const filter = {
 			kind: "structured" as const,

--- a/src/components/connection-details/TableFilterBar.tsx
+++ b/src/components/connection-details/TableFilterBar.tsx
@@ -80,7 +80,7 @@ export function TableFilterBar({
 				);
 
 	return (
-		<div className="mx-6 mb-3 overflow-hidden rounded-xl border bg-muted/20 shadow-sm">
+		<div className="mx-4 mb-3 overflow-hidden rounded-xl border bg-muted/20 shadow-sm">
 			<div className="space-y-4 p-4">
 				<div className="flex flex-wrap items-center gap-2">
 					<fieldset className="flex rounded-lg bg-muted p-0.5">

--- a/src/components/data-table/ColumnResizeHandle.tsx
+++ b/src/components/data-table/ColumnResizeHandle.tsx
@@ -1,0 +1,56 @@
+import type { MouseEvent, TouchEvent } from "react";
+import {
+	DEFAULT_COLUMN_WIDTH,
+	MAX_COLUMN_WIDTH,
+	MIN_COLUMN_WIDTH,
+} from "../../lib/savedViews";
+
+interface ColumnResizeHandleProps {
+	columnLabel: string;
+	width: number;
+	isResizing: boolean;
+	onResizeStart: (event: MouseEvent | TouchEvent) => void;
+	onWidthChange: (width: number) => void;
+}
+
+export function ColumnResizeHandle({
+	columnLabel,
+	width,
+	isResizing,
+	onResizeStart,
+	onWidthChange,
+}: ColumnResizeHandleProps) {
+	return (
+		<div
+			role="separator"
+			aria-orientation="vertical"
+			aria-label={`Resize ${columnLabel} column`}
+			aria-valuemin={MIN_COLUMN_WIDTH}
+			aria-valuemax={MAX_COLUMN_WIDTH}
+			aria-valuenow={width}
+			tabIndex={0}
+			className="absolute inset-y-0 right-0 z-20 w-2 cursor-col-resize touch-none outline-none after:absolute after:inset-y-2 after:right-0 after:w-px after:bg-border after:opacity-0 after:transition-opacity hover:after:opacity-100 focus-visible:after:bg-ring focus-visible:after:opacity-100 data-[resizing=true]:after:bg-primary data-[resizing=true]:after:opacity-100"
+			data-resizing={isResizing}
+			onClick={(event) => event.stopPropagation()}
+			onDoubleClick={(event) => {
+				event.stopPropagation();
+				onWidthChange(DEFAULT_COLUMN_WIDTH);
+			}}
+			onMouseDown={(event) => {
+				event.stopPropagation();
+				onResizeStart(event);
+			}}
+			onTouchStart={(event) => {
+				event.stopPropagation();
+				onResizeStart(event);
+			}}
+			onKeyDown={(event) => {
+				if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+				event.preventDefault();
+				event.stopPropagation();
+				const step = event.shiftKey ? 25 : 10;
+				onWidthChange(width + (event.key === "ArrowRight" ? step : -step));
+			}}
+		/>
+	);
+}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+	return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+	className,
+	align = "center",
+	alignOffset = 0,
+	side = "bottom",
+	sideOffset = 4,
+	...props
+}: PopoverPrimitive.Popup.Props &
+	Pick<
+		PopoverPrimitive.Positioner.Props,
+		"align" | "alignOffset" | "side" | "sideOffset"
+	>) {
+	return (
+		<PopoverPrimitive.Portal>
+			<PopoverPrimitive.Positioner
+				align={align}
+				alignOffset={alignOffset}
+				side={side}
+				sideOffset={sideOffset}
+				className="isolate z-50"
+			>
+				<PopoverPrimitive.Popup
+					data-slot="popover-content"
+					className={cn(
+						"z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-xl bg-popover p-2.5 text-xs text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 motion-reduce:transform-none motion-reduce:duration-0",
+						className,
+					)}
+					{...props}
+				/>
+			</PopoverPrimitive.Positioner>
+		</PopoverPrimitive.Portal>
+	);
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="popover-header"
+			className={cn("flex flex-col gap-1 text-xs", className)}
+			{...props}
+		/>
+	);
+}
+
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+	return (
+		<PopoverPrimitive.Title
+			data-slot="popover-title"
+			className={cn("text-sm font-medium", className)}
+			{...props}
+		/>
+	);
+}
+
+function PopoverDescription({
+	className,
+	...props
+}: PopoverPrimitive.Description.Props) {
+	return (
+		<PopoverPrimitive.Description
+			data-slot="popover-description"
+			className={cn("text-xs/relaxed text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Popover,
+	PopoverContent,
+	PopoverDescription,
+	PopoverHeader,
+	PopoverTitle,
+	PopoverTrigger,
+};

--- a/src/hooks/useSavedViewApplication.test.ts
+++ b/src/hooks/useSavedViewApplication.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { createTableFilterState } from "../lib/resultFilters";
+import { captureSavedViewState, createColumnLayout } from "../lib/savedViews";
+import type { SavedView } from "../lib/tauri";
+import type { TableDataTab } from "../types/tabTypes";
+import { prepareSavedViewApplication } from "./useSavedViewApplication";
+
+function tableTab(): TableDataTab {
+	return {
+		id: "table-data-public.events",
+		type: "table-data",
+		title: "events",
+		tableName: "public.events",
+		data: null,
+		currentPage: 1,
+		loading: false,
+		filterState: createTableFilterState(),
+		foreignKeys: [],
+		columns: [],
+		sort: null,
+		columnLayout: createColumnLayout([]),
+		savedViewId: null,
+	};
+}
+
+describe("prepareSavedViewApplication", () => {
+	test("builds one atomic tab state for a compatible saved view", () => {
+		const tab = tableTab();
+		tab.currentPage = 4;
+		tab.columns = [
+			{
+				name: "id",
+				type: "text",
+				filter_kind: "text",
+				nullable: false,
+				default: null,
+				primary_key: true,
+			},
+		];
+		const filter = { kind: "advanced" as const, value: "id IS NOT NULL" };
+		const state = captureSavedViewState(
+			filter,
+			{ column: "id", direction: "desc" },
+			{ ...createColumnLayout(["id"]), columnWidths: { id: 220 } },
+		);
+		const view: SavedView = {
+			id: 7,
+			connection_uuid: "connection-1",
+			table_name: tab.tableName,
+			name: "Recent",
+			state: { status: "current", state },
+			created_at: "2026-07-26 12:00:00",
+			updated_at: "2026-07-26 12:00:00",
+		};
+
+		const result = prepareSavedViewApplication(tab, view);
+
+		expect(result.error).toBeNull();
+		expect(result.nextTab?.currentPage).toBe(1);
+		expect(result.nextTab?.filterState).toEqual({
+			draft: filter,
+			applied: filter,
+		});
+		expect(result.nextTab?.sort).toEqual(state.sort);
+		expect(result.nextTab?.columnLayout.columnWidths).toEqual({ id: 220 });
+	});
+
+	test("returns a compatibility error without creating a partial tab state", () => {
+		const tab = tableTab();
+		tab.columns = [];
+		const view: SavedView = {
+			id: 8,
+			connection_uuid: "connection-1",
+			table_name: tab.tableName,
+			name: "Future",
+			state: { status: "unsupported", version: 2 },
+			created_at: "2026-07-26 12:00:00",
+			updated_at: "2026-07-26 12:00:00",
+		};
+
+		const result = prepareSavedViewApplication(tab, view);
+
+		expect(result.nextTab).toBeNull();
+		expect(result.error).toContain("newer version");
+	});
+});

--- a/src/hooks/useSavedViewApplication.ts
+++ b/src/hooks/useSavedViewApplication.ts
@@ -1,0 +1,96 @@
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { createTableFilterState } from "../lib/resultFilters";
+import { reconcileSavedViewState } from "../lib/savedViews";
+import type { SavedView, TableDataResponse } from "../lib/tauri";
+import type { TableDataTab } from "../types/tabTypes";
+
+interface PreparedSavedViewApplication {
+	nextTab: TableDataTab | null;
+	warning: string | null;
+	error: string | null;
+}
+
+export function prepareSavedViewApplication(
+	tab: TableDataTab,
+	view: SavedView,
+): PreparedSavedViewApplication {
+	const reconciled = reconcileSavedViewState(
+		view.state,
+		tab.columns.map((column) => column.name),
+	);
+	if (!reconciled.state) {
+		return { nextTab: null, warning: null, error: reconciled.error };
+	}
+
+	const filterState = reconciled.state.filter
+		? {
+				draft: reconciled.state.filter,
+				applied: reconciled.state.filter,
+			}
+		: createTableFilterState();
+
+	return {
+		nextTab: {
+			...tab,
+			currentPage: 1,
+			filterState,
+			sort: reconciled.state.sort,
+			columnLayout: reconciled.layout,
+		},
+		warning: reconciled.warning,
+		error: null,
+	};
+}
+
+interface UseSavedViewApplicationOptions {
+	tab: TableDataTab | null;
+	requestTableData: (tab: TableDataTab) => Promise<TableDataResponse>;
+	updateTab: (id: string, updates: Partial<TableDataTab>) => void;
+}
+
+export function useSavedViewApplication({
+	tab,
+	requestTableData,
+	updateTab,
+}: UseSavedViewApplicationOptions) {
+	return useCallback(
+		async (view: SavedView) => {
+			if (!tab) return false;
+			const prepared = prepareSavedViewApplication(tab, view);
+			if (!prepared.nextTab) {
+				toast.error("Couldn’t apply saved view", {
+					description: prepared.error,
+				});
+				return false;
+			}
+
+			const nextTab = prepared.nextTab;
+			updateTab(tab.id, { loading: true });
+			try {
+				const data = await requestTableData(nextTab);
+				updateTab(tab.id, {
+					data,
+					currentPage: nextTab.currentPage,
+					filterState: nextTab.filterState,
+					sort: nextTab.sort,
+					columnLayout: nextTab.columnLayout,
+					loading: false,
+				});
+				if (prepared.warning) {
+					toast.warning("Saved view adjusted", {
+						description: prepared.warning,
+					});
+				}
+				return true;
+			} catch (error) {
+				toast.error("Couldn’t apply saved view", {
+					description: error instanceof Error ? error.message : String(error),
+				});
+				updateTab(tab.id, { loading: false });
+				return false;
+			}
+		},
+		[requestTableData, tab, updateTab],
+	);
+}

--- a/src/lib/savedViews.test.ts
+++ b/src/lib/savedViews.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import type { SavedViewStateV1 } from "./tauri";
 import {
 	captureSavedViewState,
 	createColumnLayout,
+	getSavedViewStatus,
+	hasUnappliedFilterDraft,
 	isSavedViewStateEqual,
 	moveColumn,
-	reorderColumn,
 	reconcileSavedViewState,
+	reorderColumn,
 } from "./savedViews";
+import type { SavedViewStateV1 } from "./tauri";
 
 describe("saved view state", () => {
 	test("captures the applied filter, sort, and normalized column layout", () => {
@@ -60,9 +62,7 @@ describe("saved view state", () => {
 				kind: "structured",
 				value: {
 					conjunction: "and",
-					conditions: [
-						{ column: "removed", operator: "equals", value: "x" },
-					],
+					conditions: [{ column: "removed", operator: "equals", value: "x" }],
 				},
 			},
 			sort: null,
@@ -114,5 +114,50 @@ describe("saved view state", () => {
 			hiddenColumns: [],
 			columnWidths: {},
 		});
+	});
+
+	test("marks only changes to the active saved snapshot as edited", () => {
+		const state = captureSavedViewState(null, null, createColumnLayout(["id"]));
+		const activeView = { id: 7, state };
+
+		expect(getSavedViewStatus(7, [activeView], state)).toEqual({
+			activeView,
+			isEdited: false,
+		});
+
+		const resized = captureSavedViewState(null, null, {
+			...createColumnLayout(["id"]),
+			columnWidths: { id: 220 },
+		});
+		expect(getSavedViewStatus(7, [activeView], resized).isEdited).toBe(true);
+	});
+
+	test("has no edited state when no saved view is selected", () => {
+		const state = captureSavedViewState(null, null, createColumnLayout(["id"]));
+		expect(getSavedViewStatus(null, [], state)).toEqual({
+			activeView: null,
+			isEdited: false,
+		});
+	});
+
+	test("ignores the empty initial filter draft but detects unapplied edits", () => {
+		expect(
+			hasUnappliedFilterDraft(
+				{ kind: "structured", value: { conjunction: "and", conditions: [] } },
+				null,
+			),
+		).toBe(false);
+		expect(
+			hasUnappliedFilterDraft(
+				{ kind: "advanced", value: "status = 'new'" },
+				null,
+			),
+		).toBe(true);
+		expect(
+			hasUnappliedFilterDraft(
+				{ kind: "advanced", value: "status = 'new'" },
+				{ kind: "advanced", value: "status = 'new'" },
+			),
+		).toBe(false);
 	});
 });

--- a/src/lib/savedViews.test.ts
+++ b/src/lib/savedViews.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import type { SavedViewStateV1 } from "./tauri";
+import {
+	captureSavedViewState,
+	createColumnLayout,
+	isSavedViewStateEqual,
+	moveColumn,
+	reorderColumn,
+	reconcileSavedViewState,
+} from "./savedViews";
+
+describe("saved view state", () => {
+	test("captures the applied filter, sort, and normalized column layout", () => {
+		const state = captureSavedViewState(
+			{ kind: "advanced", value: "status = 'open'" },
+			{ column: "created_at", direction: "desc" },
+			{
+				columnOrder: ["created_at", "id"],
+				hiddenColumns: ["id"],
+				columnWidths: { created_at: 220 },
+			},
+		);
+
+		expect(state).toEqual({
+			version: 1,
+			filter: { kind: "advanced", value: "status = 'open'" },
+			sort: { column: "created_at", direction: "desc" },
+			column_order: ["created_at", "id"],
+			hidden_columns: ["id"],
+			column_widths: { created_at: 220 },
+		});
+	});
+
+	test("reconciles layout drift and drops a vanished sort column", () => {
+		const saved: SavedViewStateV1 = {
+			version: 1,
+			filter: null,
+			sort: { column: "removed", direction: "asc" },
+			column_order: ["removed", "name", "id"],
+			hidden_columns: ["removed", "id"],
+			column_widths: { removed: 200, name: 900 },
+		};
+
+		const result = reconcileSavedViewState(saved, ["id", "name", "created_at"]);
+
+		expect(result.error).toBeNull();
+		expect(result.warning).toContain("sort column");
+		expect(result.state?.sort).toBeNull();
+		expect(result.layout).toEqual({
+			columnOrder: ["name", "id", "created_at"],
+			hiddenColumns: ["id"],
+			columnWidths: { name: 300 },
+		});
+	});
+
+	test("blocks a structured filter that references a vanished column", () => {
+		const saved: SavedViewStateV1 = {
+			version: 1,
+			filter: {
+				kind: "structured",
+				value: {
+					conjunction: "and",
+					conditions: [
+						{ column: "removed", operator: "equals", value: "x" },
+					],
+				},
+			},
+			sort: null,
+			column_order: [],
+			hidden_columns: [],
+			column_widths: {},
+		};
+
+		const result = reconcileSavedViewState(saved, ["id", "name"]);
+
+		expect(result.state).toBeNull();
+		expect(result.error).toContain("removed");
+	});
+
+	test("compares equivalent state independently of width insertion order", () => {
+		const left = captureSavedViewState(null, null, {
+			columnOrder: ["id", "name"],
+			hiddenColumns: [],
+			columnWidths: { id: 120, name: 200 },
+		});
+		const right = captureSavedViewState(null, null, {
+			columnOrder: ["id", "name"],
+			hiddenColumns: [],
+			columnWidths: { name: 200, id: 120 },
+		});
+
+		expect(isSavedViewStateEqual(left, right)).toBe(true);
+	});
+
+	test("moves columns without mutating the source order", () => {
+		const order = ["id", "name", "created_at"];
+		expect(moveColumn(order, "created_at", -1)).toEqual([
+			"id",
+			"created_at",
+			"name",
+		]);
+		expect(order).toEqual(["id", "name", "created_at"]);
+	});
+
+	test("reorders a dragged column at the hovered position", () => {
+		expect(
+			reorderColumn(["id", "name", "created_at"], "created_at", "id"),
+		).toEqual(["created_at", "id", "name"]);
+	});
+
+	test("creates an all-visible layout in schema order", () => {
+		expect(createColumnLayout(["id", "name"])).toEqual({
+			columnOrder: ["id", "name"],
+			hiddenColumns: [],
+			columnWidths: {},
+		});
+	});
+});

--- a/src/lib/savedViews.test.ts
+++ b/src/lib/savedViews.test.ts
@@ -43,7 +43,10 @@ describe("saved view state", () => {
 			column_widths: { removed: 200, name: 900 },
 		};
 
-		const result = reconcileSavedViewState(saved, ["id", "name", "created_at"]);
+		const result = reconcileSavedViewState(
+			{ status: "current", state: saved },
+			["id", "name", "created_at"],
+		);
 
 		expect(result.error).toBeNull();
 		expect(result.warning).toContain("sort column");
@@ -71,7 +74,10 @@ describe("saved view state", () => {
 			column_widths: {},
 		};
 
-		const result = reconcileSavedViewState(saved, ["id", "name"]);
+		const result = reconcileSavedViewState(
+			{ status: "current", state: saved },
+			["id", "name"],
+		);
 
 		expect(result.state).toBeNull();
 		expect(result.error).toContain("removed");
@@ -109,7 +115,7 @@ describe("saved view state", () => {
 
 	test("rejects a future state before reading version-specific fields", () => {
 		const result = reconcileSavedViewState(
-			{ version: 2 } as unknown as SavedViewStateV1,
+			{ status: "unsupported", version: 2 },
 			["id"],
 		);
 
@@ -143,7 +149,10 @@ describe("saved view state", () => {
 
 	test("marks only changes to the active saved snapshot as edited", () => {
 		const state = captureSavedViewState(null, null, createColumnLayout(["id"]));
-		const activeView = { id: 7, state };
+		const activeView = {
+			id: 7,
+			state: { status: "current" as const, state },
+		};
 
 		expect(getSavedViewStatus(7, [activeView], state)).toEqual({
 			activeView,

--- a/src/lib/savedViews.test.ts
+++ b/src/lib/savedViews.test.ts
@@ -92,6 +92,31 @@ describe("saved view state", () => {
 		expect(isSavedViewStateEqual(left, right)).toBe(true);
 	});
 
+	test("compares layouts by visible behavior instead of storage order", () => {
+		const saved = captureSavedViewState(null, null, {
+			columnOrder: ["id", "name", "created_at"],
+			hiddenColumns: ["name", "created_at"],
+			columnWidths: {},
+		});
+		const equivalent = captureSavedViewState(null, null, {
+			columnOrder: ["id", "name", "created_at"],
+			hiddenColumns: ["created_at", "name"],
+			columnWidths: { id: 150 },
+		});
+
+		expect(isSavedViewStateEqual(saved, equivalent)).toBe(true);
+	});
+
+	test("rejects a future state before reading version-specific fields", () => {
+		const result = reconcileSavedViewState(
+			{ version: 2 } as unknown as SavedViewStateV1,
+			["id"],
+		);
+
+		expect(result.state).toBeNull();
+		expect(result.error).toContain("newer version");
+	});
+
 	test("moves columns without mutating the source order", () => {
 		const order = ["id", "name", "created_at"];
 		expect(moveColumn(order, "created_at", -1)).toEqual([

--- a/src/lib/savedViews.ts
+++ b/src/lib/savedViews.ts
@@ -55,7 +55,10 @@ export function normalizeColumnLayout(
 			)
 			.map(([column, width]) => [
 				column,
-				Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, Math.round(width))),
+				Math.min(
+					MAX_COLUMN_WIDTH,
+					Math.max(MIN_COLUMN_WIDTH, Math.round(width)),
+				),
 			]),
 	);
 
@@ -142,7 +145,33 @@ export function isSavedViewStateEqual(
 		),
 	});
 
-	return JSON.stringify(canonicalize(left)) === JSON.stringify(canonicalize(right));
+	return (
+		JSON.stringify(canonicalize(left)) === JSON.stringify(canonicalize(right))
+	);
+}
+
+export function getSavedViewStatus<
+	T extends { id: number; state: SavedViewStateV1 },
+>(activeViewId: number | null, views: T[], currentState: SavedViewStateV1) {
+	const activeView = views.find((view) => view.id === activeViewId) ?? null;
+	return {
+		activeView,
+		isEdited: activeView
+			? !isSavedViewStateEqual(activeView.state, currentState)
+			: false,
+	};
+}
+
+export function hasUnappliedFilterDraft(
+	draft: TableFilter,
+	applied: TableFilter | null,
+): boolean {
+	if (!applied) {
+		return draft.kind === "advanced"
+			? Boolean(draft.value.trim())
+			: draft.value.conditions.length > 0;
+	}
+	return JSON.stringify(draft) !== JSON.stringify(applied);
 }
 
 export function moveColumn(

--- a/src/lib/savedViews.ts
+++ b/src/lib/savedViews.ts
@@ -70,20 +70,29 @@ export function captureSavedViewState(
 	sort: SortConfig | null,
 	layout: TableColumnLayout,
 ): SavedViewStateV1 {
-	return {
+	return canonicalizeSavedViewState({
 		version: 1,
 		filter,
 		sort,
 		column_order: [...layout.columnOrder],
 		hidden_columns: [...layout.hiddenColumns],
 		column_widths: { ...layout.columnWidths },
-	};
+	});
 }
 
 export function reconcileSavedViewState(
 	state: SavedViewStateV1,
 	columnNames: string[],
 ): ReconciledSavedView {
+	if ((state.version as number) !== 1) {
+		return {
+			state: null,
+			layout: createColumnLayout(columnNames),
+			warning: null,
+			error: "This view was created by a newer version of DBcooper.",
+		};
+	}
+
 	const layout = normalizeColumnLayout(
 		{
 			columnOrder: state.column_order,
@@ -92,15 +101,6 @@ export function reconcileSavedViewState(
 		},
 		columnNames,
 	);
-
-	if ((state.version as number) !== 1) {
-		return {
-			state: null,
-			layout,
-			warning: null,
-			error: "This view was created by a newer version of DBcooper.",
-		};
-	}
 
 	if (state.filter?.kind === "structured") {
 		const available = new Set(columnNames);
@@ -132,21 +132,27 @@ export function reconcileSavedViewState(
 	};
 }
 
+export function canonicalizeSavedViewState(
+	state: SavedViewStateV1,
+): SavedViewStateV1 {
+	return {
+		...state,
+		hidden_columns: [...new Set(state.hidden_columns)].sort(),
+		column_widths: Object.fromEntries(
+			Object.entries(state.column_widths)
+				.filter(([, width]) => width !== DEFAULT_COLUMN_WIDTH)
+				.sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey)),
+		),
+	};
+}
+
 export function isSavedViewStateEqual(
 	left: SavedViewStateV1,
 	right: SavedViewStateV1,
 ): boolean {
-	const canonicalize = (state: SavedViewStateV1) => ({
-		...state,
-		column_widths: Object.fromEntries(
-			Object.entries(state.column_widths).sort(([leftKey], [rightKey]) =>
-				leftKey.localeCompare(rightKey),
-			),
-		),
-	});
-
 	return (
-		JSON.stringify(canonicalize(left)) === JSON.stringify(canonicalize(right))
+		JSON.stringify(canonicalizeSavedViewState(left)) ===
+		JSON.stringify(canonicalizeSavedViewState(right))
 	);
 }
 

--- a/src/lib/savedViews.ts
+++ b/src/lib/savedViews.ts
@@ -1,0 +1,179 @@
+import type { TableFilter } from "@/lib/resultFilters";
+import type { SavedViewStateV1 } from "@/lib/tauri";
+import type { SortConfig } from "@/types/tabTypes";
+
+export const DEFAULT_COLUMN_WIDTH = 150;
+export const MIN_COLUMN_WIDTH = 80;
+export const MAX_COLUMN_WIDTH = 300;
+
+export interface TableColumnLayout {
+	columnOrder: string[];
+	hiddenColumns: string[];
+	columnWidths: Record<string, number>;
+}
+
+interface ReconciledSavedView {
+	state: SavedViewStateV1 | null;
+	layout: TableColumnLayout;
+	warning: string | null;
+	error: string | null;
+}
+
+export function createColumnLayout(columnNames: string[]): TableColumnLayout {
+	return {
+		columnOrder: [...columnNames],
+		hiddenColumns: [],
+		columnWidths: {},
+	};
+}
+
+export function normalizeColumnLayout(
+	layout: TableColumnLayout,
+	columnNames: string[],
+): TableColumnLayout {
+	const available = new Set(columnNames);
+	const ordered = layout.columnOrder.filter(
+		(column, index, order) =>
+			available.has(column) && order.indexOf(column) === index,
+	);
+	for (const column of columnNames) {
+		if (!ordered.includes(column)) ordered.push(column);
+	}
+
+	let hiddenColumns = layout.hiddenColumns.filter(
+		(column, index, hidden) =>
+			available.has(column) && hidden.indexOf(column) === index,
+	);
+	if (ordered.length > 0 && hiddenColumns.length === ordered.length) {
+		hiddenColumns = hiddenColumns.filter((column) => column !== ordered[0]);
+	}
+
+	const columnWidths = Object.fromEntries(
+		Object.entries(layout.columnWidths)
+			.filter(
+				([column, width]) => available.has(column) && Number.isFinite(width),
+			)
+			.map(([column, width]) => [
+				column,
+				Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, Math.round(width))),
+			]),
+	);
+
+	return { columnOrder: ordered, hiddenColumns, columnWidths };
+}
+
+export function captureSavedViewState(
+	filter: TableFilter | null,
+	sort: SortConfig | null,
+	layout: TableColumnLayout,
+): SavedViewStateV1 {
+	return {
+		version: 1,
+		filter,
+		sort,
+		column_order: [...layout.columnOrder],
+		hidden_columns: [...layout.hiddenColumns],
+		column_widths: { ...layout.columnWidths },
+	};
+}
+
+export function reconcileSavedViewState(
+	state: SavedViewStateV1,
+	columnNames: string[],
+): ReconciledSavedView {
+	const layout = normalizeColumnLayout(
+		{
+			columnOrder: state.column_order,
+			hiddenColumns: state.hidden_columns,
+			columnWidths: state.column_widths,
+		},
+		columnNames,
+	);
+
+	if ((state.version as number) !== 1) {
+		return {
+			state: null,
+			layout,
+			warning: null,
+			error: "This view was created by a newer version of DBcooper.",
+		};
+	}
+
+	if (state.filter?.kind === "structured") {
+		const available = new Set(columnNames);
+		const missing = state.filter.value.conditions.find(
+			(condition) => !available.has(condition.column),
+		)?.column;
+		if (missing) {
+			return {
+				state: null,
+				layout,
+				warning: null,
+				error: `The saved filter uses missing column “${missing}”.`,
+			};
+		}
+	}
+
+	const sort =
+		state.sort && columnNames.includes(state.sort.column) ? state.sort : null;
+	const warning =
+		state.sort && !sort
+			? `The saved sort column “${state.sort.column}” no longer exists.`
+			: null;
+
+	return {
+		state: captureSavedViewState(state.filter, sort, layout),
+		layout,
+		warning,
+		error: null,
+	};
+}
+
+export function isSavedViewStateEqual(
+	left: SavedViewStateV1,
+	right: SavedViewStateV1,
+): boolean {
+	const canonicalize = (state: SavedViewStateV1) => ({
+		...state,
+		column_widths: Object.fromEntries(
+			Object.entries(state.column_widths).sort(([leftKey], [rightKey]) =>
+				leftKey.localeCompare(rightKey),
+			),
+		),
+	});
+
+	return JSON.stringify(canonicalize(left)) === JSON.stringify(canonicalize(right));
+}
+
+export function moveColumn(
+	columnOrder: string[],
+	column: string,
+	direction: -1 | 1,
+): string[] {
+	const index = columnOrder.indexOf(column);
+	const target = index + direction;
+	if (index < 0 || target < 0 || target >= columnOrder.length) {
+		return [...columnOrder];
+	}
+
+	const next = [...columnOrder];
+	[next[index], next[target]] = [next[target], next[index]];
+	return next;
+}
+
+export function reorderColumn(
+	columnOrder: string[],
+	column: string,
+	targetColumn: string,
+): string[] {
+	const sourceIndex = columnOrder.indexOf(column);
+	const targetIndex = columnOrder.indexOf(targetColumn);
+	if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) {
+		return [...columnOrder];
+	}
+
+	const next = [...columnOrder];
+	next.splice(sourceIndex, 1);
+	next.splice(targetIndex, 0, column);
+	return next;
+}

--- a/src/lib/savedViews.ts
+++ b/src/lib/savedViews.ts
@@ -1,5 +1,5 @@
-import type { TableFilter } from "@/lib/resultFilters";
-import type { SavedViewStateV1 } from "@/lib/tauri";
+import type { TableFilter } from "./resultFilters";
+import type { SavedViewStatePayload, SavedViewStateV1 } from "@/lib/tauri";
 import type { SortConfig } from "@/types/tabTypes";
 
 export const DEFAULT_COLUMN_WIDTH = 150;
@@ -17,6 +17,23 @@ interface ReconciledSavedView {
 	layout: TableColumnLayout;
 	warning: string | null;
 	error: string | null;
+}
+
+interface DecodedSavedViewState {
+	state: SavedViewStateV1 | null;
+	error: string | null;
+}
+
+export function decodeSavedViewState(
+	payload: SavedViewStatePayload,
+): DecodedSavedViewState {
+	if (payload.status === "unsupported") {
+		return {
+			state: null,
+			error: "This view was created by a newer version of DBcooper.",
+		};
+	}
+	return { state: payload.state, error: null };
 }
 
 export function createColumnLayout(columnNames: string[]): TableColumnLayout {
@@ -81,17 +98,19 @@ export function captureSavedViewState(
 }
 
 export function reconcileSavedViewState(
-	state: SavedViewStateV1,
+	persistedState: SavedViewStatePayload,
 	columnNames: string[],
 ): ReconciledSavedView {
-	if ((state.version as number) !== 1) {
+	const decoded = decodeSavedViewState(persistedState);
+	if (!decoded.state) {
 		return {
 			state: null,
 			layout: createColumnLayout(columnNames),
 			warning: null,
-			error: "This view was created by a newer version of DBcooper.",
+			error: decoded.error,
 		};
 	}
+	const state = decoded.state;
 
 	const layout = normalizeColumnLayout(
 		{
@@ -157,13 +176,16 @@ export function isSavedViewStateEqual(
 }
 
 export function getSavedViewStatus<
-	T extends { id: number; state: SavedViewStateV1 },
+	T extends { id: number; state: SavedViewStatePayload },
 >(activeViewId: number | null, views: T[], currentState: SavedViewStateV1) {
 	const activeView = views.find((view) => view.id === activeViewId) ?? null;
+	const activeState = activeView
+		? decodeSavedViewState(activeView.state).state
+		: null;
 	return {
 		activeView,
-		isEdited: activeView
-			? !isSavedViewStateEqual(activeView.state, currentState)
+		isEdited: activeState
+			? !isSavedViewStateEqual(activeState, currentState)
 			: false,
 	};
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -149,12 +149,16 @@ export interface SavedViewStateV1 {
 	column_widths: Record<string, number>;
 }
 
+export type SavedViewStatePayload =
+	| { status: "current"; state: SavedViewStateV1 }
+	| { status: "unsupported"; version: number };
+
 export interface SavedView {
 	id: number;
 	connection_uuid: string;
 	table_name: string;
 	name: string;
-	state: SavedViewStateV1;
+	state: SavedViewStatePayload;
 	created_at: string;
 	updated_at: string;
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1,6 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
 import { isSqlFunction } from "@/lib/databaseCatalog";
-import type { FilterColumnKind, FilterExpression } from "@/lib/resultFilters";
+import type {
+	FilterColumnKind,
+	FilterExpression,
+	TableFilter,
+} from "@/lib/resultFilters";
 import type { Connection, ConnectionFormData } from "@/types/connection";
 import type {
 	DeleteConnectionResult,
@@ -134,6 +138,36 @@ export interface SavedQuery {
 export interface SavedQueryFormData {
 	name: string;
 	query: string;
+}
+
+export interface SavedViewStateV1 {
+	version: 1;
+	filter: TableFilter | null;
+	sort: { column: string; direction: "asc" | "desc" } | null;
+	column_order: string[];
+	hidden_columns: string[];
+	column_widths: Record<string, number>;
+}
+
+export interface SavedView {
+	id: number;
+	connection_uuid: string;
+	table_name: string;
+	name: string;
+	state: SavedViewStateV1;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface SavedViewFormData {
+	table_name: string;
+	name: string;
+	state: SavedViewStateV1;
+}
+
+export interface SavedViewUpdateData {
+	name: string;
+	state: SavedViewStateV1;
 }
 
 export interface QueryHistory {
@@ -708,6 +742,19 @@ export const api = {
 
 		clearHistory: (connectionUuid: string) =>
 			invoke<boolean>("clear_query_history", { connectionUuid }),
+	},
+
+	savedViews: {
+		list: (connectionUuid: string, tableName: string) =>
+			invoke<SavedView[]>("get_saved_views", { connectionUuid, tableName }),
+
+		create: (connectionUuid: string, data: SavedViewFormData) =>
+			invoke<SavedView>("create_saved_view", { connectionUuid, data }),
+
+		update: (id: number, data: SavedViewUpdateData) =>
+			invoke<SavedView>("update_saved_view", { id, data }),
+
+		delete: (id: number) => invoke<boolean>("delete_saved_view", { id }),
 	},
 
 	settings: {

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -38,6 +38,7 @@ import {
 	type QueryHistory,
 	type RedisKeyDetails,
 	type RedisKeyInfo,
+	type SavedView,
 	type TableInfo,
 } from "@/lib/tauri";
 import { listen } from "@tauri-apps/api/event";
@@ -145,6 +146,7 @@ import { FunctionDefinitionView } from "@/components/connection-details/Function
 import { ObjectExplorer } from "@/components/connection-details/ObjectExplorer";
 import { TableFilterBar } from "@/components/connection-details/TableFilterBar";
 import { ColumnLayoutPopover } from "@/components/connection-details/ColumnLayoutPopover";
+import { SavedViewsMenu } from "@/components/connection-details/SavedViewsMenu";
 import { ConnectionWelcome } from "@/components/connection-details/ConnectionWelcome";
 import { DisconnectedScreen } from "@/components/connection-details/DisconnectedScreen";
 import { CommandPalette } from "@/components/CommandPalette";
@@ -156,10 +158,16 @@ import { useSettings } from "@/contexts/SettingsContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import { getCreateTableDbType } from "@/lib/databaseCatalog";
 import {
+	createTableFilterState,
 	createCellFilter,
 	getFilterRequest,
 } from "@/lib/resultFilters";
-import { normalizeColumnLayout } from "@/lib/savedViews";
+import {
+	captureSavedViewState,
+	hasUnappliedFilterDraft,
+	normalizeColumnLayout,
+	reconcileSavedViewState,
+} from "@/lib/savedViews";
 
 const SchemaVisualizer = lazy(() =>
 	import("@/components/SchemaVisualizer").then((module) => ({
@@ -822,39 +830,41 @@ export function ConnectionDetails() {
 		[],
 	);
 
+	const requestTableData = useCallback(
+		async (tab: TableDataTab) => {
+			if (!uuid) throw new Error("Connection is unavailable");
+			const [schema, tableName] = tab.tableName.split(".");
+			const filterRequest = getFilterRequest(tab.filterState.applied);
+			return api.pool.getTableData(
+				uuid,
+				schema,
+				tableName,
+				tab.currentPage,
+				100,
+				filterRequest.filter,
+				filterRequest.structuredFilter,
+				tab.sort?.column,
+				tab.sort?.direction,
+			);
+		},
+		[uuid],
+	);
+
 	const fetchTableData = useCallback(
 		async (tab: TableDataTab) => {
-			if (!uuid) return;
-
 			updateTab<TableDataTab>(tab.id, { loading: true });
-
 			try {
-				const [schema, tableName] = tab.tableName.split(".");
-				const filterRequest = getFilterRequest(tab.filterState.applied);
-				const data = await api.pool.getTableData(
-					uuid,
-					schema,
-					tableName,
-					tab.currentPage,
-					100,
-					filterRequest.filter,
-					filterRequest.structuredFilter,
-					tab.sort?.column,
-					tab.sort?.direction,
-				);
-
+				const data = await requestTableData(tab);
 				updateTab<TableDataTab>(tab.id, { data, loading: false });
 			} catch (error) {
 				console.error("Failed to fetch table data:", error);
-				const errorMessage =
-					error instanceof Error ? error.message : String(error);
 				toast.error("Failed to load table data", {
-					description: errorMessage,
+					description: error instanceof Error ? error.message : String(error),
 				});
 				updateTab<TableDataTab>(tab.id, { data: null, loading: false });
 			}
 		},
-		[uuid, updateTab],
+		[requestTableData, updateTab],
 	);
 	const activeTableDataTab =
 		activeTab?.type === "table-data" ? activeTab : null;
@@ -873,6 +883,63 @@ export function ConnectionDetails() {
 		updateTab: updateTableDataTab,
 		fetchTableData,
 	});
+
+	const handleApplySavedView = useCallback(
+		async (view: SavedView) => {
+			const tab = activeTableDataTab;
+			if (!tab) return false;
+			const reconciled = reconcileSavedViewState(
+				view.state,
+				tab.columns.map((column) => column.name),
+			);
+			if (!reconciled.state) {
+				toast.error("Couldn’t apply saved view", {
+					description: reconciled.error,
+				});
+				return false;
+			}
+
+			const filterState = reconciled.state.filter
+				? {
+						draft: reconciled.state.filter,
+						applied: reconciled.state.filter,
+					}
+				: createTableFilterState();
+			const nextTab: TableDataTab = {
+				...tab,
+				currentPage: 1,
+				filterState,
+				sort: reconciled.state.sort,
+				columnLayout: reconciled.layout,
+			};
+
+			updateTab<TableDataTab>(tab.id, { loading: true });
+			try {
+				const data = await requestTableData(nextTab);
+				updateTab<TableDataTab>(tab.id, {
+					data,
+					currentPage: 1,
+					filterState,
+					sort: reconciled.state.sort,
+					columnLayout: reconciled.layout,
+					loading: false,
+				});
+				if (reconciled.warning) {
+					toast.warning("Saved view adjusted", {
+						description: reconciled.warning,
+					});
+				}
+				return true;
+			} catch (error) {
+				toast.error("Couldn’t apply saved view", {
+					description: error instanceof Error ? error.message : String(error),
+				});
+				updateTab<TableDataTab>(tab.id, { loading: false });
+				return false;
+			}
+		},
+		[activeTableDataTab, requestTableData, updateTab],
+	);
 
 	const fetchTableStructure = useCallback(
 		async (tab: TableStructureTab) => {
@@ -2563,6 +2630,25 @@ export function ConnectionDetails() {
 							</CardDescription>
 						</div>
 						<div className="flex items-center gap-2">
+							<SavedViewsMenu
+								connectionUuid={uuid ?? ""}
+								tableName={tab.tableName}
+								currentState={captureSavedViewState(
+									tab.filterState.applied,
+									tab.sort,
+									tab.columnLayout,
+								)}
+								activeViewId={tab.savedViewId}
+								loading={tab.loading}
+								hasUnappliedFilterDraft={hasUnappliedFilterDraft(
+									tab.filterState.draft,
+									tab.filterState.applied,
+								)}
+								onActiveViewChange={(savedViewId) =>
+									updateTab<TableDataTab>(tab.id, { savedViewId })
+								}
+								onApply={handleApplySavedView}
+							/>
 							<ColumnLayoutPopover
 								columns={tab.columns.map((column) => column.name)}
 								layout={tab.columnLayout}

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -144,6 +144,7 @@ import { ConnectionStatus } from "@/components/ConnectionStatus";
 import { FunctionDefinitionView } from "@/components/connection-details/FunctionDefinitionView";
 import { ObjectExplorer } from "@/components/connection-details/ObjectExplorer";
 import { TableFilterBar } from "@/components/connection-details/TableFilterBar";
+import { ColumnLayoutPopover } from "@/components/connection-details/ColumnLayoutPopover";
 import { ConnectionWelcome } from "@/components/connection-details/ConnectionWelcome";
 import { DisconnectedScreen } from "@/components/connection-details/DisconnectedScreen";
 import { CommandPalette } from "@/components/CommandPalette";
@@ -158,6 +159,7 @@ import {
 	createCellFilter,
 	getFilterRequest,
 } from "@/lib/resultFilters";
+import { normalizeColumnLayout } from "@/lib/savedViews";
 
 const SchemaVisualizer = lazy(() =>
 	import("@/components/SchemaVisualizer").then((module) => ({
@@ -967,18 +969,28 @@ export function ConnectionDetails() {
 					);
 
 					if (tableData) {
+						const columns = tableData.columns || [];
 						updateTab<TableDataTab>(tab.id, {
 							foreignKeys: tableData.foreign_keys || [],
-							columns: tableData.columns || [],
+							columns,
+							columnLayout: normalizeColumnLayout(
+								tab.columnLayout,
+								columns.map((column) => column.name),
+							),
 						});
 						return;
 					}
 				}
 
 				const data = await api.pool.getTableStructure(uuid, schema, tableName);
+				const columns = (data.columns as TableColumn[]) || [];
 				updateTab<TableDataTab>(tab.id, {
 					foreignKeys: (data.foreign_keys as ForeignKeyInfo[]) || [],
-					columns: (data.columns as TableColumn[]) || [],
+					columns,
+					columnLayout: normalizeColumnLayout(
+						tab.columnLayout,
+						columns.map((column) => column.name),
+					),
 				});
 			} catch (error) {
 				console.error("Failed to fetch foreign keys:", error);
@@ -2551,6 +2563,13 @@ export function ConnectionDetails() {
 							</CardDescription>
 						</div>
 						<div className="flex items-center gap-2">
+							<ColumnLayoutPopover
+								columns={tab.columns.map((column) => column.name)}
+								layout={tab.columnLayout}
+								onChange={(columnLayout) =>
+									updateTab<TableDataTab>(tab.id, { columnLayout })
+								}
+							/>
 							<Button
 								variant="default"
 								size="sm"
@@ -2648,6 +2667,10 @@ export function ConnectionDetails() {
 									highlightedTableRow?.tableName === tab.tableName &&
 									getPrimaryKeyRowKey(row, tab.columns) ===
 										highlightedTableRow.rowKey
+								}
+								columnLayout={tab.columnLayout}
+								onColumnLayoutChange={(columnLayout) =>
+									updateTab<TableDataTab>(tab.id, { columnLayout })
 								}
 							/>
 						</div>

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -38,7 +38,6 @@ import {
 	type QueryHistory,
 	type RedisKeyDetails,
 	type RedisKeyInfo,
-	type SavedView,
 	type TableInfo,
 } from "@/lib/tauri";
 import { listen } from "@tauri-apps/api/event";
@@ -136,6 +135,7 @@ import { SqlEditor } from "@/components/SqlEditor";
 import { TabBar } from "@/components/TabBar";
 import { useContextualSqlGeneration } from "@/hooks/useContextualSqlGeneration";
 import { useTableDataFilters } from "@/hooks/useTableDataFilters";
+import { useSavedViewApplication } from "@/hooks/useSavedViewApplication";
 import { RowEditSheet } from "@/components/RowEditSheet";
 import { RowInsertSheet } from "@/components/RowInsertSheet";
 import { InlineEditableCell } from "@/components/InlineEditableCell";
@@ -157,16 +157,11 @@ import {
 import { useSettings } from "@/contexts/SettingsContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import { getCreateTableDbType } from "@/lib/databaseCatalog";
-import {
-	createTableFilterState,
-	createCellFilter,
-	getFilterRequest,
-} from "@/lib/resultFilters";
+import { createCellFilter, getFilterRequest } from "@/lib/resultFilters";
 import {
 	captureSavedViewState,
 	hasUnappliedFilterDraft,
 	normalizeColumnLayout,
-	reconcileSavedViewState,
 } from "@/lib/savedViews";
 
 const SchemaVisualizer = lazy(() =>
@@ -884,62 +879,11 @@ export function ConnectionDetails() {
 		fetchTableData,
 	});
 
-	const handleApplySavedView = useCallback(
-		async (view: SavedView) => {
-			const tab = activeTableDataTab;
-			if (!tab) return false;
-			const reconciled = reconcileSavedViewState(
-				view.state,
-				tab.columns.map((column) => column.name),
-			);
-			if (!reconciled.state) {
-				toast.error("Couldn’t apply saved view", {
-					description: reconciled.error,
-				});
-				return false;
-			}
-
-			const filterState = reconciled.state.filter
-				? {
-						draft: reconciled.state.filter,
-						applied: reconciled.state.filter,
-					}
-				: createTableFilterState();
-			const nextTab: TableDataTab = {
-				...tab,
-				currentPage: 1,
-				filterState,
-				sort: reconciled.state.sort,
-				columnLayout: reconciled.layout,
-			};
-
-			updateTab<TableDataTab>(tab.id, { loading: true });
-			try {
-				const data = await requestTableData(nextTab);
-				updateTab<TableDataTab>(tab.id, {
-					data,
-					currentPage: 1,
-					filterState,
-					sort: reconciled.state.sort,
-					columnLayout: reconciled.layout,
-					loading: false,
-				});
-				if (reconciled.warning) {
-					toast.warning("Saved view adjusted", {
-						description: reconciled.warning,
-					});
-				}
-				return true;
-			} catch (error) {
-				toast.error("Couldn’t apply saved view", {
-					description: error instanceof Error ? error.message : String(error),
-				});
-				updateTab<TableDataTab>(tab.id, { loading: false });
-				return false;
-			}
-		},
-		[activeTableDataTab, requestTableData, updateTab],
-	);
+	const handleApplySavedView = useSavedViewApplication({
+		tab: activeTableDataTab,
+		requestTableData,
+		updateTab: updateTableDataTab,
+	});
 
 	const fetchTableStructure = useCallback(
 		async (tab: TableStructureTab) => {

--- a/src/types/tabTypes.ts
+++ b/src/types/tabTypes.ts
@@ -3,6 +3,10 @@ import {
 	createTableFilterState,
 	type TableFilterState,
 } from "@/lib/resultFilters";
+import {
+	createColumnLayout,
+	type TableColumnLayout,
+} from "@/lib/savedViews";
 import type {
 	ColumnInfo,
 	ForeignKeyInfo,
@@ -56,6 +60,8 @@ export interface TableDataTab extends BaseTab {
 	foreignKeys: ForeignKeyInfo[];
 	columns: TableColumn[];
 	sort: SortConfig | null;
+	columnLayout: TableColumnLayout;
+	savedViewId: number | null;
 }
 
 export interface TableStructureTab extends BaseTab {
@@ -137,6 +143,8 @@ export function createTableDataTab(tableName: string): TableDataTab {
 		foreignKeys: [],
 		columns: [],
 		sort: null,
+		columnLayout: createColumnLayout([]),
+		savedViewId: null,
 	};
 }
 


### PR DESCRIPTION
## Summary

- add persisted, per-table saved views for filters, sorting, column visibility, order, and widths
- add column-layout controls and saved-view lifecycle actions
- align schema iconography and filter/result panel insets
- mark saved views as released on the roadmap

## Implementation

- store versioned saved-view state in app data with validated Tauri commands
- decode future state versions explicitly and reconcile saved layouts with schema changes
- scope saved-view UI state to the active connection and table
- apply saved-view state atomically through a focused hook
- canonicalize layout state so equivalent column configurations do not appear edited
- model dialog state as a discriminated action

## Root causes fixed

- the filter panel used a 24px horizontal margin while table results used 16px card padding
- the saved-views menu could retain data when React reused it for another table
- versioned state was cast into the current schema before compatibility was checked
- equality compared storage ordering instead of visible behavior

## Validation

- `bun run check`
  - 78 frontend tests
  - TypeScript typecheck
  - ESLint
  - production Vite build
- `cargo fmt --check`
- `cargo test saved_view`
  - 3 unit tests
  - 3 app-data integration tests
- launched and verified the exact Tauri branch build from the isolated worktree on port 1421
