### PR TITLE
Preserve AI query generation across tabs

### DIFF
--- a/src/components/DataTable.test.tsx
+++ b/src/components/DataTable.test.tsx
@@ -43,6 +43,20 @@ const columns: ColumnDef<Row>[] = [
 ];
 
 describe("DataTable column layout", () => {
+	test("renders query results without a saved column layout", () => {
+		const markup = renderToStaticMarkup(
+			<DataTable
+				data={[{ id: 1, name: "Ada" }]}
+				columns={columns}
+				hidePagination
+			/>,
+		);
+
+		expect(markup).toContain(">ID<");
+		expect(markup).toContain(">Name<");
+		expect(markup).toContain(">Ada<");
+	});
+
 	test("renders controlled order, visibility, width, and an accessible resize handle", () => {
 		const markup = renderToStaticMarkup(
 			<DataTable

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -102,7 +102,7 @@ export function DataTable<TData>({
 		state: {
 			columnOrder: columnLayout?.columnOrder,
 			columnVisibility,
-			columnSizing: columnLayout?.columnWidths,
+			columnSizing: columnLayout?.columnWidths ?? {},
 		},
 		onColumnSizingChange: (updater) => {
 			if (!columnLayout || !onColumnLayoutChange) return;

--- a/src/components/SqlEditor.test.tsx
+++ b/src/components/SqlEditor.test.tsx
@@ -57,18 +57,25 @@ test("renders the AI prompt and draft owned by the selected query tab", () => {
 		value: "SELECT * FROM users",
 		onChange: () => {},
 		tables: [{ schema: "public", name: "users" }],
-		onGenerateSQL: async () => "SELECT * FROM users",
-		onAiStateChange: () => {},
+	};
+	const aiHandlers = {
+		configured: true,
+		onInstructionChange: () => {},
+		onGenerate: async () => {},
+		onDiscard: () => {},
 	};
 	const { rerender } = render(
 		<SqlEditor
 			{...commonProps}
-			aiState={{
-				instruction: "List active users",
-				draft: {
-					status: "generating",
-					requestId: "request-1",
-					sql: "SELECT *",
+			ai={{
+				...aiHandlers,
+				state: {
+					instruction: "List active users",
+					draft: {
+						status: "generating",
+						requestId: "request-1",
+						sql: "SELECT *",
+					},
 				},
 			}}
 		/>,
@@ -83,7 +90,10 @@ test("renders the AI prompt and draft owned by the selected query tab", () => {
 	rerender(
 		<SqlEditor
 			{...commonProps}
-			aiState={{ instruction: "", draft: { status: "idle" } }}
+			ai={{
+				...aiHandlers,
+				state: { instruction: "", draft: { status: "idle" } },
+			}}
 		/>,
 	);
 	expect(screen.queryByTestId("ai-draft")).toBeNull();
@@ -91,11 +101,14 @@ test("renders the AI prompt and draft owned by the selected query tab", () => {
 	rerender(
 		<SqlEditor
 			{...commonProps}
-			aiState={{
-				instruction: "List active users",
-				draft: {
-					status: "ready",
-					sql: "SELECT * FROM users WHERE active = true",
+			ai={{
+				...aiHandlers,
+				state: {
+					instruction: "List active users",
+					draft: {
+						status: "ready",
+						sql: "SELECT * FROM users WHERE active = true",
+					},
 				},
 			}}
 		/>,

--- a/src/components/SqlEditor.test.tsx
+++ b/src/components/SqlEditor.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import type { ComponentProps, ReactNode } from "react";
+
+if (!globalThis.document) GlobalRegistrator.register();
+
+mock.module("@codemirror/lang-sql", () => ({ sql: () => ({}) }));
+mock.module("@codemirror/state", () => ({
+	EditorState: { readOnly: { of: () => ({}) } },
+	Prec: { highest: (value: unknown) => value },
+}));
+mock.module("@codemirror/view", () => ({
+	EditorView: {
+		lineWrapping: {},
+		theme: () => ({}),
+		updateListener: { of: () => ({}) },
+	},
+	keymap: { of: () => ({}) },
+}));
+mock.module("@uiw/react-codemirror", () => ({
+	default: ({ value }: { value: string }) => <div>{value}</div>,
+}));
+mock.module("thememirror", () => ({ barf: {}, rosePineDawn: {} }));
+mock.module("@/lib/aiDraftState", () => ({
+	initialAiDraftState: { status: "idle" },
+	aiDraftReducer: (state: unknown) => state,
+}));
+mock.module("@/components/SqlAIPreview", () => ({
+	SqlAIPreview: ({
+		draft,
+	}: {
+		draft: { status: string; sql?: string; message?: string };
+	}) => <div data-testid="ai-draft">{draft.sql ?? draft.message}</div>,
+}));
+mock.module("@/components/ui/button", () => ({
+	Button: ({ children, ...props }: ComponentProps<"button">) => (
+		<button {...props}>{children}</button>
+	),
+}));
+mock.module("@/components/ui/input", () => ({
+	Input: (props: ComponentProps<"input">) => <input {...props} />,
+}));
+mock.module("@/components/ui/spinner", () => ({ Spinner: () => <span /> }));
+mock.module("@/components/ui/tooltip", () => ({
+	Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+	TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+	TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+const { cleanup, render, screen } = await import("@testing-library/react");
+const { SqlEditor } = await import("./SqlEditor");
+
+afterEach(cleanup);
+
+test("renders the AI prompt and draft owned by the selected query tab", () => {
+	const commonProps = {
+		value: "SELECT * FROM users",
+		onChange: () => {},
+		tables: [{ schema: "public", name: "users" }],
+		onGenerateSQL: async () => "SELECT * FROM users",
+		onAiStateChange: () => {},
+	};
+	const { rerender } = render(
+		<SqlEditor
+			{...commonProps}
+			aiState={{
+				instruction: "List active users",
+				draft: { status: "generating", sql: "SELECT *" },
+			}}
+		/>,
+	);
+
+	expect(
+		(screen.getByPlaceholderText("Ask for a query or change…") as HTMLInputElement)
+			.value,
+	).toBe("List active users");
+	expect(screen.getByTestId("ai-draft").textContent).toBe("SELECT *");
+
+	rerender(
+		<SqlEditor
+			{...commonProps}
+			aiState={{ instruction: "", draft: { status: "idle" } }}
+		/>,
+	);
+	expect(screen.queryByTestId("ai-draft")).toBeNull();
+
+	rerender(
+		<SqlEditor
+			{...commonProps}
+			aiState={{
+				instruction: "List active users",
+				draft: {
+					status: "ready",
+					sql: "SELECT * FROM users WHERE active = true",
+				},
+			}}
+		/>,
+	);
+	expect(screen.getByTestId("ai-draft").textContent).toContain(
+		"WHERE active = true",
+	);
+});

--- a/src/components/SqlEditor.test.tsx
+++ b/src/components/SqlEditor.test.tsx
@@ -65,7 +65,11 @@ test("renders the AI prompt and draft owned by the selected query tab", () => {
 			{...commonProps}
 			aiState={{
 				instruction: "List active users",
-				draft: { status: "generating", sql: "SELECT *" },
+				draft: {
+					status: "generating",
+					requestId: "request-1",
+					sql: "SELECT *",
+				},
 			}}
 		/>,
 	);

--- a/src/components/SqlEditor.tsx
+++ b/src/components/SqlEditor.tsx
@@ -14,7 +14,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import type { QueryAiState, QueryAiStateAction } from "@/lib/aiDraftState";
+import type { QueryAiState } from "@/lib/aiDraftState";
 
 const emptyAiState: QueryAiState = {
 	instruction: "",
@@ -31,6 +31,14 @@ interface TableSchema {
 	}>;
 }
 
+interface SqlEditorAiProps {
+	state: QueryAiState;
+	configured: boolean | null;
+	onInstructionChange: (instruction: string) => void;
+	onGenerate: () => Promise<void>;
+	onDiscard: () => void;
+}
+
 interface SqlEditorProps {
 	value: string;
 	onChange: (value: string) => void;
@@ -38,14 +46,7 @@ interface SqlEditorProps {
 	disabled?: boolean;
 	height?: string;
 	tables?: TableSchema[];
-	onGenerateSQL?: (
-		instruction: string,
-		existingSQL: string,
-		onPreview: (sql: string) => void,
-	) => Promise<string>;
-	aiState?: QueryAiState;
-	onAiStateChange?: (action: QueryAiStateAction) => void;
-	aiConfigured?: boolean | null;
+	ai?: SqlEditorAiProps;
 	onCursorActivity?: (line: number, char: number) => void;
 	cursorWarning?: string | null;
 }
@@ -56,10 +57,7 @@ export function SqlEditor({
 	onRunQuery,
 	height = "300px",
 	tables = [],
-	onGenerateSQL,
-	aiState = emptyAiState,
-	onAiStateChange,
-	aiConfigured = null,
+	ai,
 	onCursorActivity,
 	cursorWarning = null,
 	disabled = false,
@@ -67,7 +65,7 @@ export function SqlEditor({
 	const [isDark, setIsDark] = useState(false);
 	const [containerWidth, setContainerWidth] = useState<number | null>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
-	const { instruction, draft: aiDraft } = aiState;
+	const { instruction, draft: aiDraft } = ai?.state ?? emptyAiState;
 	const generating = aiDraft.status === "generating";
 
 	useEffect(() => {
@@ -177,67 +175,35 @@ export function SqlEditor({
 	);
 
 	const handleGenerate = async () => {
-		if (instruction.trim() && onGenerateSQL) {
-			const requestId = crypto.randomUUID();
-			onAiStateChange?.({
-				type: "update-draft",
-				action: { type: "start", requestId },
-			});
-			try {
-				const generatedSQL = await onGenerateSQL(instruction, value, (sql) =>
-					onAiStateChange?.({
-						type: "update-draft",
-						action: { type: "preview", requestId, sql },
-					}),
-				);
-				onAiStateChange?.({
-					type: "update-draft",
-					action: { type: "complete", requestId, sql: generatedSQL },
-				});
-			} catch (error) {
-				onAiStateChange?.({
-					type: "update-draft",
-					action: {
-						type: "fail",
-						requestId,
-						message: error instanceof Error ? error.message : String(error),
-					},
-				});
-			}
-		}
+		if (instruction.trim() && ai) await ai.onGenerate();
 	};
 
 	const isButtonDisabled =
-		!instruction.trim() || generating || aiConfigured === false;
+		!instruction.trim() || generating || ai?.configured === false;
 
 	return (
 		<div className="space-y-2">
-			{onGenerateSQL && tables.length > 0 && (
+			{ai && tables.length > 0 && (
 				<div className="space-y-2">
 					<div className="flex gap-1 rounded-xl border bg-muted/20 p-1 shadow-sm focus-within:border-ring">
 						<Sparkle className="ml-2 mt-2 size-4 shrink-0 text-primary" />
 						<Input
 							placeholder={
-								aiConfigured === false
+								ai.configured === false
 									? "Configure AI in Settings to enable generation"
 									: "Ask for a query or change…"
 							}
 							value={instruction}
-							onChange={(event) =>
-								onAiStateChange?.({
-									type: "set-instruction",
-									instruction: event.target.value,
-								})
-							}
+							onChange={(event) => ai.onInstructionChange(event.target.value)}
 							onKeyDown={(event) => {
 								if (
 									event.key === "Enter" &&
 									!generating &&
-									aiConfigured !== false
+									ai.configured !== false
 								)
 									void handleGenerate();
 							}}
-							disabled={generating || aiConfigured === false}
+							disabled={generating || ai.configured === false}
 							className="h-8 flex-1 border-0 bg-transparent shadow-none focus-visible:ring-0"
 						/>
 						<Tooltip>
@@ -253,7 +219,7 @@ export function SqlEditor({
 								{generating ? <Spinner /> : <Sparkle />}
 								Generate draft
 							</TooltipTrigger>
-							{aiConfigured === false && (
+							{ai.configured === false && (
 								<TooltipContent>
 									Configure an AI provider in Settings
 								</TooltipContent>
@@ -272,12 +238,7 @@ export function SqlEditor({
 										variant="ghost"
 										size="sm"
 										className="h-6 px-2 text-[11px]"
-										onClick={() =>
-											onAiStateChange?.({
-												type: "set-instruction",
-												instruction: prompt,
-											})
-										}
+										onClick={() => ai.onInstructionChange(prompt)}
 										disabled={generating}
 									>
 										{prompt}
@@ -288,31 +249,20 @@ export function SqlEditor({
 					</div>
 				</div>
 			)}
-			{aiDraft.status !== "idle" && (
+			{ai && aiDraft.status !== "idle" && (
 				<SqlAIPreview
 					draft={aiDraft}
 					hasExistingSql={Boolean(value.trim())}
-					onDiscard={() =>
-						onAiStateChange?.({
-							type: "update-draft",
-							action: { type: "discard" },
-						})
-					}
+					onDiscard={ai.onDiscard}
 					onAppend={() => {
 						if (aiDraft.status !== "ready") return;
 						onChange(`${value.trimEnd()}\n\n${aiDraft.sql}`);
-						onAiStateChange?.({
-							type: "update-draft",
-							action: { type: "discard" },
-						});
+						ai.onDiscard();
 					}}
 					onReplace={() => {
 						if (aiDraft.status !== "ready") return;
 						onChange(aiDraft.sql);
-						onAiStateChange?.({
-							type: "update-draft",
-							action: { type: "discard" },
-						});
+						ai.onDiscard();
 					}}
 				/>
 			)}

--- a/src/components/SqlEditor.tsx
+++ b/src/components/SqlEditor.tsx
@@ -3,7 +3,7 @@ import { EditorState, Prec } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
 import { Sparkle, Warning, WarningCircle } from "@phosphor-icons/react";
 import CodeMirror from "@uiw/react-codemirror";
-import { useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { barf, rosePineDawn } from "thememirror";
 import { SqlAIPreview } from "@/components/SqlAIPreview";
 import { Button } from "@/components/ui/button";
@@ -14,7 +14,12 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { aiDraftReducer, initialAiDraftState } from "@/lib/aiDraftState";
+import type { QueryAiState, QueryAiStateAction } from "@/lib/aiDraftState";
+
+const emptyAiState: QueryAiState = {
+	instruction: "",
+	draft: { status: "idle" },
+};
 
 interface TableSchema {
 	schema: string;
@@ -38,6 +43,8 @@ interface SqlEditorProps {
 		existingSQL: string,
 		onPreview: (sql: string) => void,
 	) => Promise<string>;
+	aiState?: QueryAiState;
+	onAiStateChange?: (action: QueryAiStateAction) => void;
 	aiConfigured?: boolean | null;
 	onCursorActivity?: (line: number, char: number) => void;
 	cursorWarning?: string | null;
@@ -50,6 +57,8 @@ export function SqlEditor({
 	height = "300px",
 	tables = [],
 	onGenerateSQL,
+	aiState = emptyAiState,
+	onAiStateChange,
 	aiConfigured = null,
 	onCursorActivity,
 	cursorWarning = null,
@@ -57,12 +66,8 @@ export function SqlEditor({
 }: SqlEditorProps) {
 	const [isDark, setIsDark] = useState(false);
 	const [containerWidth, setContainerWidth] = useState<number | null>(null);
-	const [instruction, setInstruction] = useState("");
-	const [aiDraft, dispatchAiDraft] = useReducer(
-		aiDraftReducer,
-		initialAiDraftState,
-	);
 	const containerRef = useRef<HTMLDivElement>(null);
+	const { instruction, draft: aiDraft } = aiState;
 	const generating = aiDraft.status === "generating";
 
 	useEffect(() => {
@@ -173,16 +178,28 @@ export function SqlEditor({
 
 	const handleGenerate = async () => {
 		if (instruction.trim() && onGenerateSQL) {
-			dispatchAiDraft({ type: "start" });
+			onAiStateChange?.({
+				type: "update-draft",
+				action: { type: "start" },
+			});
 			try {
 				const generatedSQL = await onGenerateSQL(instruction, value, (sql) =>
-					dispatchAiDraft({ type: "preview", sql }),
+					onAiStateChange?.({
+						type: "update-draft",
+						action: { type: "preview", sql },
+					}),
 				);
-				dispatchAiDraft({ type: "complete", sql: generatedSQL });
+				onAiStateChange?.({
+					type: "update-draft",
+					action: { type: "complete", sql: generatedSQL },
+				});
 			} catch (error) {
-				dispatchAiDraft({
-					type: "fail",
-					message: error instanceof Error ? error.message : String(error),
+				onAiStateChange?.({
+					type: "update-draft",
+					action: {
+						type: "fail",
+						message: error instanceof Error ? error.message : String(error),
+					},
 				});
 			}
 		}
@@ -204,7 +221,12 @@ export function SqlEditor({
 									: "Ask for a query or change…"
 							}
 							value={instruction}
-							onChange={(event) => setInstruction(event.target.value)}
+							onChange={(event) =>
+								onAiStateChange?.({
+									type: "set-instruction",
+									instruction: event.target.value,
+								})
+							}
 							onKeyDown={(event) => {
 								if (
 									event.key === "Enter" &&
@@ -248,7 +270,12 @@ export function SqlEditor({
 										variant="ghost"
 										size="sm"
 										className="h-6 px-2 text-[11px]"
-										onClick={() => setInstruction(prompt)}
+										onClick={() =>
+											onAiStateChange?.({
+												type: "set-instruction",
+												instruction: prompt,
+											})
+										}
 										disabled={generating}
 									>
 										{prompt}
@@ -263,16 +290,27 @@ export function SqlEditor({
 				<SqlAIPreview
 					draft={aiDraft}
 					hasExistingSql={Boolean(value.trim())}
-					onDiscard={() => dispatchAiDraft({ type: "discard" })}
+					onDiscard={() =>
+						onAiStateChange?.({
+							type: "update-draft",
+							action: { type: "discard" },
+						})
+					}
 					onAppend={() => {
 						if (aiDraft.status !== "ready") return;
 						onChange(`${value.trimEnd()}\n\n${aiDraft.sql}`);
-						dispatchAiDraft({ type: "discard" });
+						onAiStateChange?.({
+							type: "update-draft",
+							action: { type: "discard" },
+						});
 					}}
 					onReplace={() => {
 						if (aiDraft.status !== "ready") return;
 						onChange(aiDraft.sql);
-						dispatchAiDraft({ type: "discard" });
+						onAiStateChange?.({
+							type: "update-draft",
+							action: { type: "discard" },
+						});
 					}}
 				/>
 			)}

--- a/src/components/SqlEditor.tsx
+++ b/src/components/SqlEditor.tsx
@@ -178,26 +178,28 @@ export function SqlEditor({
 
 	const handleGenerate = async () => {
 		if (instruction.trim() && onGenerateSQL) {
+			const requestId = crypto.randomUUID();
 			onAiStateChange?.({
 				type: "update-draft",
-				action: { type: "start" },
+				action: { type: "start", requestId },
 			});
 			try {
 				const generatedSQL = await onGenerateSQL(instruction, value, (sql) =>
 					onAiStateChange?.({
 						type: "update-draft",
-						action: { type: "preview", sql },
+						action: { type: "preview", requestId, sql },
 					}),
 				);
 				onAiStateChange?.({
 					type: "update-draft",
-					action: { type: "complete", sql: generatedSQL },
+					action: { type: "complete", requestId, sql: generatedSQL },
 				});
 			} catch (error) {
 				onAiStateChange?.({
 					type: "update-draft",
 					action: {
 						type: "fail",
+						requestId,
 						message: error instanceof Error ? error.message : String(error),
 					},
 				});

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ComponentProps } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { QueryTab } from "../types/tabTypes";
+
+mock.module("@/components/ui/button", () => ({
+	Button: ({
+		children,
+		variant: _variant,
+		size: _size,
+		...props
+	}: ComponentProps<"button"> & { variant?: string; size?: string }) => (
+		<button {...props}>{children}</button>
+	),
+}));
+mock.module("@/components/ui/spinner", () => ({
+	Spinner: (props: ComponentProps<"span">) => <span role="status" {...props} />,
+}));
+mock.module("@/lib/utils", () => ({
+	cn: (...values: Array<string | false | null | undefined>) =>
+		values.filter(Boolean).join(" "),
+}));
+
+const { TabBar } = await import("./TabBar");
+
+const handlers = {
+	onTabSelect: () => {},
+	onTabClose: () => {},
+	onNewQuery: () => {},
+};
+
+function createQueryTab(): QueryTab {
+	return {
+		id: "query-1",
+		type: "query",
+		title: "New Query",
+		query: "",
+		ai: { instruction: "", draft: { status: "idle" } },
+		savedQueryId: null,
+		savedQueryName: null,
+		results: null,
+		error: null,
+		success: false,
+		executionTime: null,
+		affectedRows: null,
+		executing: false,
+		filterInput: "",
+		filter: "",
+		sort: null,
+		resultBaseQuery: null,
+	};
+}
+
+describe("TabBar query generation status", () => {
+	test("shows the close button for an idle query tab", () => {
+		const tab = createQueryTab();
+		const markup = renderToStaticMarkup(
+			<TabBar tabs={[tab]} activeTabId={tab.id} {...handlers} />,
+		);
+
+		expect(markup).toContain('aria-label="Close New Query"');
+	});
+
+	test("shows a spinner on an unfocused query tab while AI is generating", () => {
+		const tab = createQueryTab();
+		tab.ai.draft = {
+			status: "generating",
+			requestId: "request-1",
+			sql: "",
+		};
+
+		const markup = renderToStaticMarkup(
+			<TabBar tabs={[tab]} activeTabId={null} {...handlers} />,
+		);
+
+		expect(markup).toContain('aria-label="Generating New Query"');
+		expect(markup).not.toContain('aria-label="Close New Query"');
+	});
+});

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,6 +1,7 @@
 import { Code, Columns, Database, Plus, Table, X } from "@phosphor-icons/react";
 import { useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import type { Tab } from "@/types/tabTypes";
 
@@ -73,6 +74,8 @@ export function TabBar({
 			>
 				{tabs.map((tab) => {
 					const isActive = tab.id === activeTabId;
+					const isAiGenerating =
+						tab.type === "query" && tab.ai.draft.status === "generating";
 					return (
 						<div
 							key={tab.id}
@@ -98,19 +101,28 @@ export function TabBar({
 								{getTabIcon(tab)}
 								<span className="min-w-0 flex-1 truncate">{tab.title}</span>
 							</button>
-							<button
-								type="button"
-								onClick={() => onTabClose(tab.id)}
-								aria-label={`Close ${tab.title}`}
-								className={cn(
-									"mr-1 flex size-6 shrink-0 items-center justify-center rounded-md outline-none transition-[background-color,opacity] hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/50",
-									isActive
-										? "opacity-100"
-										: "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
-								)}
-							>
-								<X className="size-3" />
-							</button>
+							{isAiGenerating ? (
+								<span className="mr-1 flex size-6 shrink-0 items-center justify-center text-muted-foreground">
+									<Spinner
+										className="size-3"
+										aria-label={`Generating ${tab.title}`}
+									/>
+								</span>
+							) : (
+								<button
+									type="button"
+									onClick={() => onTabClose(tab.id)}
+									aria-label={`Close ${tab.title}`}
+									className={cn(
+										"mr-1 flex size-6 shrink-0 items-center justify-center rounded-md outline-none transition-[background-color,opacity] hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring/50",
+										isActive
+											? "opacity-100"
+											: "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
+									)}
+								>
+									<X className="size-3" />
+								</button>
+							)}
 						</div>
 					);
 				})}

--- a/src/hooks/useAIGeneration.ts
+++ b/src/hooks/useAIGeneration.ts
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
 	type AiGenerationListener,
+	AiGenerationSessionRegistry,
 	startAiGenerationSession,
 } from "@/lib/aiGenerationSession";
 import { api } from "@/lib/tauri";
@@ -14,12 +15,8 @@ interface TableSchema {
 }
 
 export function useAIGeneration() {
-	const [generating, setGenerating] = useState(false);
-	const [error, setError] = useState<string | null>(null);
 	const [isConfigured, setIsConfigured] = useState<boolean | null>(null);
-	const activeRequestRef = useRef<ReturnType<
-		typeof startAiGenerationSession
-	> | null>(null);
+	const activeRequestsRef = useRef(new AiGenerationSessionRegistry());
 
 	useEffect(() => {
 		const checkConfig = async () => {
@@ -38,15 +35,14 @@ export function useAIGeneration() {
 
 	useEffect(
 		() => () => {
-			const request = activeRequestRef.current;
-			activeRequestRef.current = null;
-			request?.cancel(new Error("AI generation was cancelled"));
+			activeRequestsRef.current.cancelAll();
 		},
 		[],
 	);
 
 	const generateSQL = useCallback(
 		async (
+			requestKey: string,
 			dbType: string,
 			instruction: string,
 			existingSQL: string,
@@ -54,14 +50,6 @@ export function useAIGeneration() {
 			onStream: (chunk: string) => void,
 			onComplete?: (sql: string) => void,
 		) => {
-			const previousRequest = activeRequestRef.current;
-			activeRequestRef.current = null;
-			previousRequest?.cancel(
-				new Error("A newer AI request replaced this one"),
-			);
-			setGenerating(true);
-			setError(null);
-
 			const sessionId = `ai-${Date.now()}-${crypto.randomUUID()}`;
 			const request = startAiGenerationSession({
 				sessionId,
@@ -78,28 +66,20 @@ export function useAIGeneration() {
 				onChunk: onStream,
 				onComplete: (sql) => onComplete?.(sql),
 			});
-			activeRequestRef.current = request;
+			activeRequestsRef.current.replace(requestKey, request);
 
 			try {
 				await request.promise;
-			} catch (requestError) {
-				if (activeRequestRef.current === request) {
-					setError(
-						requestError instanceof Error
-							? requestError.message
-							: String(requestError),
-					);
-				}
-				throw requestError;
 			} finally {
-				if (activeRequestRef.current === request) {
-					activeRequestRef.current = null;
-					setGenerating(false);
-				}
+				activeRequestsRef.current.deleteIfCurrent(requestKey, request);
 			}
 		},
 		[],
 	);
 
-	return { generateSQL, generating, error, isConfigured };
+	const cancelGeneration = useCallback((requestKey: string) => {
+		activeRequestsRef.current.cancel(requestKey);
+	}, []);
+
+	return { generateSQL, cancelGeneration, isConfigured };
 }

--- a/src/hooks/useContextualSqlGeneration.ts
+++ b/src/hooks/useContextualSqlGeneration.ts
@@ -17,10 +17,11 @@ export function useContextualSqlGeneration({
 	tableColumns,
 	schemaOverview,
 }: UseContextualSqlGenerationOptions) {
-	const { generateSQL, isConfigured } = useAIGeneration();
+	const { generateSQL, cancelGeneration, isConfigured } = useAIGeneration();
 
 	const generateDraft = useCallback(
 		async (
+			requestKey: string,
 			instruction: string,
 			existingSQL: string,
 			onPreview: (sql: string) => void,
@@ -48,6 +49,7 @@ export function useContextualSqlGeneration({
 			let accumulatedSQL = "";
 			let completedSQL = "";
 			await generateSQL(
+				requestKey,
 				dbType || "postgres",
 				instruction,
 				existingSQL,
@@ -71,5 +73,5 @@ export function useContextualSqlGeneration({
 		[dbType, generateSQL, schemaOverview, tableColumns, tables],
 	);
 
-	return { generateDraft, isConfigured };
+	return { generateDraft, cancelGeneration, isConfigured };
 }

--- a/src/hooks/useQueryAiGeneration.test.tsx
+++ b/src/hooks/useQueryAiGeneration.test.tsx
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import { useState } from "react";
+import { AiGenerationCancellationError } from "../lib/aiGenerationSession";
+import type { QueryTab, Tab, TableDataTab } from "../types/tabTypes";
+
+if (!globalThis.document) GlobalRegistrator.register();
+
+interface ToastOptions {
+	description?: string;
+	action?: { label: string; onClick: () => void };
+}
+
+const successToasts: Array<{ title: string; options?: ToastOptions }> = [];
+const errorToasts: Array<{ title: string; options?: ToastOptions }> = [];
+
+mock.module("sonner", () => ({
+	toast: {
+		success: (title: string, options?: ToastOptions) =>
+			successToasts.push({ title, options }),
+		error: (title: string, options?: ToastOptions) =>
+			errorToasts.push({ title, options }),
+	},
+}));
+
+const { act, cleanup, renderHook } = await import("@testing-library/react");
+const { useQueryAiGeneration } = await import("./useQueryAiGeneration");
+
+beforeEach(() => {
+	successToasts.length = 0;
+	errorToasts.length = 0;
+});
+
+afterEach(cleanup);
+
+function createQuery(): QueryTab {
+	return {
+		id: "query-1",
+		type: "query",
+		title: "Active users",
+		query: "SELECT * FROM users",
+		ai: { instruction: "List active users", draft: { status: "idle" } },
+		savedQueryId: null,
+		savedQueryName: null,
+		results: null,
+		error: null,
+		success: false,
+		executionTime: null,
+		affectedRows: null,
+		executing: false,
+		filterInput: "",
+		filter: "",
+		sort: null,
+		resultBaseQuery: null,
+	};
+}
+
+function createTable(): TableDataTab {
+	return {
+		id: "table-1",
+		type: "table-data",
+		title: "users",
+		tableName: "public.users",
+		data: null,
+		currentPage: 1,
+		loading: false,
+		filterState: {
+			draft: { kind: "advanced", value: "" },
+			applied: { kind: "advanced", value: "" },
+		},
+		foreignKeys: [],
+		columns: [],
+		sort: null,
+		columnLayout: {
+			columnOrder: [],
+			hiddenColumns: [],
+			columnWidths: {},
+		},
+		savedViewId: null,
+	};
+}
+
+test("preserves a completed background draft and navigates to it from the toast", async () => {
+	const queryTab = createQuery();
+	const tableTab = createTable();
+
+	let previewDraft: ((sql: string) => void) | undefined;
+	let resolveDraft: ((sql: string) => void) | undefined;
+	const generateDraft = (
+		_requestKey: string,
+		_instruction: string,
+		_existingSQL: string,
+		onPreview: (sql: string) => void,
+	) => {
+		previewDraft = onPreview;
+		return new Promise<string>((resolve) => {
+			resolveDraft = resolve;
+		});
+	};
+	const { result } = renderHook(() => {
+		const [tabs, setTabs] = useState<Tab[]>([queryTab, tableTab]);
+		const [activeTabId, setActiveTabId] = useState<string | null>(tableTab.id);
+		const queryAi = useQueryAiGeneration({
+			tabs,
+			activeTabId,
+			setTabs,
+			setActiveTabId,
+			generateDraft,
+			cancelGeneration: () => undefined,
+			isConfigured: true,
+		});
+		return { tabs, activeTabId, queryAi };
+	});
+
+	let generation: Promise<void> | undefined;
+	act(() => {
+		const tab = result.current.tabs[0];
+		if (tab?.type !== "query") throw new Error("Expected the first tab to be a query");
+		generation = result.current.queryAi.getEditorAiProps(tab).onGenerate();
+	});
+	expect(result.current.tabs[0]).toMatchObject({
+		type: "query",
+		ai: { draft: { status: "generating", sql: "" } },
+	});
+
+	act(() => previewDraft?.("SELECT *"));
+	expect(result.current.tabs[0]).toMatchObject({
+		type: "query",
+		ai: { draft: { status: "generating", sql: "SELECT *" } },
+	});
+
+	await act(async () => {
+		resolveDraft?.("SELECT * FROM users WHERE active = true");
+		await generation;
+	});
+	expect(result.current.tabs[0]).toMatchObject({
+		type: "query",
+		ai: {
+			draft: {
+				status: "ready",
+				sql: "SELECT * FROM users WHERE active = true",
+			},
+		},
+	});
+	expect(successToasts).toHaveLength(1);
+	expect(successToasts[0]?.title).toBe("AI query ready");
+	expect(successToasts[0]?.options?.action?.label).toBe("View query");
+	expect(errorToasts).toHaveLength(0);
+
+	const viewQuery = successToasts[0]?.options?.action?.onClick;
+	if (!viewQuery) throw new Error("Expected the toast to include a View query action");
+	act(viewQuery);
+	expect(result.current.activeTabId).toBe(queryTab.id);
+});
+
+test("cancels a generating tab without leaving state or showing a toast", async () => {
+	const queryTab = createQuery();
+	const tableTab = createTable();
+	let rejectDraft: ((error: Error) => void) | undefined;
+
+	const { result } = renderHook(() => {
+		const [tabs, setTabs] = useState<Tab[]>([queryTab, tableTab]);
+		const [activeTabId, setActiveTabId] = useState<string | null>(tableTab.id);
+		const queryAi = useQueryAiGeneration({
+			tabs,
+			activeTabId,
+			setTabs,
+			setActiveTabId,
+			generateDraft: () =>
+				new Promise<string>((_resolve, reject) => {
+					rejectDraft = reject;
+				}),
+			cancelGeneration: () =>
+				rejectDraft?.(new AiGenerationCancellationError("cancelled")),
+			isConfigured: true,
+		});
+		const closeTab = (tabId: string) => {
+			queryAi.cancelTabGeneration(tabId);
+			setTabs((currentTabs) =>
+				currentTabs.filter((tab) => tab.id !== tabId),
+			);
+		};
+		return { tabs, queryAi, closeTab };
+	});
+
+	let generation: Promise<void> | undefined;
+	act(() => {
+		const tab = result.current.tabs[0];
+		if (tab?.type !== "query") throw new Error("Expected the first tab to be a query");
+		generation = result.current.queryAi.getEditorAiProps(tab).onGenerate();
+	});
+
+	await act(async () => {
+		result.current.closeTab(queryTab.id);
+		await generation;
+	});
+	expect(result.current.tabs.map((tab) => tab.id)).toEqual([tableTab.id]);
+	expect(successToasts).toHaveLength(0);
+	expect(errorToasts).toHaveLength(0);
+});

--- a/src/hooks/useQueryAiGeneration.ts
+++ b/src/hooks/useQueryAiGeneration.ts
@@ -1,0 +1,145 @@
+import {
+	type Dispatch,
+	type SetStateAction,
+	useCallback,
+	useEffect,
+	useRef,
+} from "react";
+import { toast } from "sonner";
+import {
+	queryAiStateReducer,
+	type QueryAiStateAction,
+} from "../lib/aiDraftState";
+import { isAiGenerationCancellation } from "../lib/aiGenerationSession";
+import type { QueryTab, Tab } from "../types/tabTypes";
+
+type GenerateDraft = (
+	requestKey: string,
+	instruction: string,
+	existingSQL: string,
+	onPreview: (sql: string) => void,
+) => Promise<string>;
+
+interface UseQueryAiGenerationOptions {
+	tabs: Tab[];
+	activeTabId: string | null;
+	setTabs: Dispatch<SetStateAction<Tab[]>>;
+	setActiveTabId: Dispatch<SetStateAction<string | null>>;
+	generateDraft: GenerateDraft;
+	cancelGeneration: (requestKey: string) => void;
+	isConfigured: boolean | null;
+}
+
+export function useQueryAiGeneration({
+	tabs,
+	activeTabId,
+	setTabs,
+	setActiveTabId,
+	generateDraft,
+	cancelGeneration,
+	isConfigured,
+}: UseQueryAiGenerationOptions) {
+	const tabsRef = useRef(tabs);
+	const activeTabIdRef = useRef(activeTabId);
+	useEffect(() => {
+		tabsRef.current = tabs;
+		activeTabIdRef.current = activeTabId;
+	}, [activeTabId, tabs]);
+
+	const updateAiState = useCallback(
+		(tabId: string, action: QueryAiStateAction) => {
+			setTabs((currentTabs) =>
+				currentTabs.map((tab) =>
+					tab.id === tabId && tab.type === "query"
+						? { ...tab, ai: queryAiStateReducer(tab.ai, action) }
+						: tab,
+				),
+			);
+		},
+		[setTabs],
+	);
+
+	const generateForTab = useCallback(
+		async (tabId: string, instruction: string, existingSQL: string) => {
+			const requestId = crypto.randomUUID();
+			updateAiState(tabId, {
+				type: "update-draft",
+				action: { type: "start", requestId },
+			});
+
+			const viewQuery = () => {
+				if (tabsRef.current.some((tab) => tab.id === tabId)) {
+					setActiveTabId(tabId);
+				}
+			};
+
+			try {
+				const sql = await generateDraft(
+					tabId,
+					instruction,
+					existingSQL,
+					(previewSql) =>
+						updateAiState(tabId, {
+							type: "update-draft",
+							action: { type: "preview", requestId, sql: previewSql },
+						}),
+				);
+				updateAiState(tabId, {
+					type: "update-draft",
+					action: { type: "complete", requestId, sql },
+				});
+
+				const completedTab = tabsRef.current.find((tab) => tab.id === tabId);
+				if (completedTab && activeTabIdRef.current !== tabId) {
+					toast.success("AI query ready", {
+						description: `Generated SQL is ready in ${completedTab.title}.`,
+						action: { label: "View query", onClick: viewQuery },
+					});
+				}
+			} catch (error) {
+				updateAiState(tabId, {
+					type: "update-draft",
+					action: {
+						type: "fail",
+						requestId,
+						message: error instanceof Error ? error.message : String(error),
+					},
+				});
+
+				const failedTab = tabsRef.current.find((tab) => tab.id === tabId);
+				if (
+					!isAiGenerationCancellation(error) &&
+					failedTab &&
+					activeTabIdRef.current !== tabId
+				) {
+					toast.error("AI query generation failed", {
+						description: error instanceof Error ? error.message : String(error),
+						action: { label: "View query", onClick: viewQuery },
+					});
+				}
+			}
+		},
+		[generateDraft, setActiveTabId, updateAiState],
+	);
+
+	const getEditorAiProps = useCallback(
+		(tab: QueryTab) => ({
+			state: tab.ai,
+			configured: isConfigured,
+			onInstructionChange: (instruction: string) =>
+				updateAiState(tab.id, { type: "set-instruction", instruction }),
+			onGenerate: () => generateForTab(tab.id, tab.ai.instruction, tab.query),
+			onDiscard: () =>
+				updateAiState(tab.id, {
+					type: "update-draft",
+					action: { type: "discard" },
+				}),
+		}),
+		[generateForTab, isConfigured, updateAiState],
+	);
+
+	return {
+		getEditorAiProps,
+		cancelTabGeneration: cancelGeneration,
+	};
+}

--- a/src/lib/aiDraftState.test.ts
+++ b/src/lib/aiDraftState.test.ts
@@ -8,25 +8,42 @@ import {
 
 describe("aiDraftReducer", () => {
 	test("moves a streamed request from loading to a ready draft", () => {
-		const generating = aiDraftReducer(initialAiDraftState, { type: "start" });
+		const generating = aiDraftReducer(initialAiDraftState, {
+			type: "start",
+			requestId: "request-1",
+		});
 		const streaming = aiDraftReducer(generating, {
 			type: "preview",
+			requestId: "request-1",
 			sql: "SELECT *",
 		});
 		const ready = aiDraftReducer(streaming, {
 			type: "complete",
+			requestId: "request-1",
 			sql: "SELECT * FROM users",
 		});
 
-		expect(generating).toEqual({ status: "generating", sql: "" });
-		expect(streaming).toEqual({ status: "generating", sql: "SELECT *" });
+		expect(generating).toEqual({
+			status: "generating",
+			requestId: "request-1",
+			sql: "",
+		});
+		expect(streaming).toEqual({
+			status: "generating",
+			requestId: "request-1",
+			sql: "SELECT *",
+		});
 		expect(ready).toEqual({ status: "ready", sql: "SELECT * FROM users" });
 	});
 
 	test("shows a terminal error instead of leaving an empty loading draft", () => {
-		const generating = aiDraftReducer(initialAiDraftState, { type: "start" });
+		const generating = aiDraftReducer(initialAiDraftState, {
+			type: "start",
+			requestId: "request-1",
+		});
 		const failed = aiDraftReducer(generating, {
 			type: "fail",
+			requestId: "request-1",
 			message: "Provider unavailable",
 		});
 
@@ -37,10 +54,10 @@ describe("aiDraftReducer", () => {
 	});
 
 	test("rejects an empty completed response", () => {
-		expect(
+			expect(
 			aiDraftReducer(
-				{ status: "generating", sql: "" },
-				{ type: "complete", sql: "" },
+				{ status: "generating", requestId: "request-1", sql: "" },
+				{ type: "complete", requestId: "request-1", sql: "" },
 			),
 		).toEqual({
 			status: "error",
@@ -55,7 +72,11 @@ describe("aiDraftReducer", () => {
 		};
 
 		expect(
-			aiDraftReducer(failed, { type: "preview", sql: "SELECT 1" }),
+			aiDraftReducer(failed, {
+				type: "preview",
+				requestId: "request-1",
+				sql: "SELECT 1",
+			}),
 		).toEqual(failed);
 	});
 
@@ -77,12 +98,13 @@ describe("queryAiStateReducer", () => {
 		});
 		first = queryAiStateReducer(first, {
 			type: "update-draft",
-			action: { type: "start" },
+			action: { type: "start", requestId: "request-1" },
 		});
 		first = queryAiStateReducer(first, {
 			type: "update-draft",
 			action: {
 				type: "complete",
+				requestId: "request-1",
 				sql: "SELECT * FROM users WHERE active = true",
 			},
 		});
@@ -95,5 +117,41 @@ describe("queryAiStateReducer", () => {
 			},
 		});
 		expect(second).toEqual({ instruction: "", draft: initialAiDraftState });
+	});
+
+	test("ignores stale outcomes after a request is replaced", () => {
+		let state = createQueryAiState();
+		state = queryAiStateReducer(state, {
+			type: "update-draft",
+			action: { type: "start", requestId: "request-1" },
+		});
+		state = queryAiStateReducer(state, {
+			type: "update-draft",
+			action: { type: "start", requestId: "request-2" },
+		});
+		state = queryAiStateReducer(state, {
+			type: "update-draft",
+			action: {
+				type: "fail",
+				requestId: "request-1",
+				message: "A newer AI request replaced this one",
+			},
+		});
+
+		expect(state.draft).toEqual({
+			status: "generating",
+			requestId: "request-2",
+			sql: "",
+		});
+
+		state = queryAiStateReducer(state, {
+			type: "update-draft",
+			action: {
+				type: "complete",
+				requestId: "request-2",
+				sql: "SELECT 2",
+			},
+		});
+		expect(state.draft).toEqual({ status: "ready", sql: "SELECT 2" });
 	});
 });

--- a/src/lib/aiDraftState.test.ts
+++ b/src/lib/aiDraftState.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { aiDraftReducer, initialAiDraftState } from "./aiDraftState";
+import {
+	aiDraftReducer,
+	createQueryAiState,
+	initialAiDraftState,
+	queryAiStateReducer,
+} from "./aiDraftState";
 
 describe("aiDraftReducer", () => {
 	test("moves a streamed request from loading to a ready draft", () => {
@@ -58,5 +63,37 @@ describe("aiDraftReducer", () => {
 		expect(
 			aiDraftReducer({ status: "ready", sql: "SELECT 1" }, { type: "discard" }),
 		).toEqual(initialAiDraftState);
+	});
+});
+
+describe("queryAiStateReducer", () => {
+	test("keeps each query tab's prompt and draft independent", () => {
+		let first = createQueryAiState();
+		const second = createQueryAiState();
+
+		first = queryAiStateReducer(first, {
+			type: "set-instruction",
+			instruction: "List active users",
+		});
+		first = queryAiStateReducer(first, {
+			type: "update-draft",
+			action: { type: "start" },
+		});
+		first = queryAiStateReducer(first, {
+			type: "update-draft",
+			action: {
+				type: "complete",
+				sql: "SELECT * FROM users WHERE active = true",
+			},
+		});
+
+		expect(first).toEqual({
+			instruction: "List active users",
+			draft: {
+				status: "ready",
+				sql: "SELECT * FROM users WHERE active = true",
+			},
+		});
+		expect(second).toEqual({ instruction: "", draft: initialAiDraftState });
 	});
 });

--- a/src/lib/aiDraftState.ts
+++ b/src/lib/aiDraftState.ts
@@ -1,14 +1,14 @@
 export type AiDraftState =
 	| { status: "idle" }
-	| { status: "generating"; sql: string }
+	| { status: "generating"; requestId: string; sql: string }
 	| { status: "ready"; sql: string }
 	| { status: "error"; message: string };
 
 export type AiDraftAction =
-	| { type: "start" }
-	| { type: "preview"; sql: string }
-	| { type: "complete"; sql: string }
-	| { type: "fail"; message: string }
+	| { type: "start"; requestId: string }
+	| { type: "preview"; requestId: string; sql: string }
+	| { type: "complete"; requestId: string; sql: string }
+	| { type: "fail"; requestId: string; message: string }
 	| { type: "discard" };
 
 export interface QueryAiState {
@@ -43,13 +43,18 @@ export function aiDraftReducer(
 ): AiDraftState {
 	switch (action.type) {
 		case "start":
-			return { status: "generating", sql: "" };
+			return { status: "generating", requestId: action.requestId, sql: "" };
 		case "preview":
-			return state.status === "generating"
-				? { status: "generating", sql: action.sql }
+			return state.status === "generating" &&
+				state.requestId === action.requestId
+				? { status: "generating", requestId: action.requestId, sql: action.sql }
 				: state;
 		case "complete":
-			if (state.status !== "generating") return state;
+			if (
+				state.status !== "generating" ||
+				state.requestId !== action.requestId
+			)
+				return state;
 			return action.sql.trim()
 				? { status: "ready", sql: action.sql }
 				: {
@@ -57,7 +62,8 @@ export function aiDraftReducer(
 						message: "The AI provider returned an empty response",
 					};
 		case "fail":
-			return state.status === "generating"
+			return state.status === "generating" &&
+				state.requestId === action.requestId
 				? { status: "error", message: action.message }
 				: state;
 		case "discard":

--- a/src/lib/aiDraftState.ts
+++ b/src/lib/aiDraftState.ts
@@ -11,7 +11,31 @@ export type AiDraftAction =
 	| { type: "fail"; message: string }
 	| { type: "discard" };
 
+export interface QueryAiState {
+	instruction: string;
+	draft: AiDraftState;
+}
+
+export type QueryAiStateAction =
+	| { type: "set-instruction"; instruction: string }
+	| { type: "update-draft"; action: AiDraftAction };
+
 export const initialAiDraftState: AiDraftState = { status: "idle" };
+
+export function createQueryAiState(): QueryAiState {
+	return { instruction: "", draft: initialAiDraftState };
+}
+
+export function queryAiStateReducer(
+	state: QueryAiState,
+	action: QueryAiStateAction,
+): QueryAiState {
+	if (action.type === "set-instruction") {
+		return { ...state, instruction: action.instruction };
+	}
+
+	return { ...state, draft: aiDraftReducer(state.draft, action.action) };
+}
 
 export function aiDraftReducer(
 	state: AiDraftState,

--- a/src/lib/aiGenerationSession.test.ts
+++ b/src/lib/aiGenerationSession.test.ts
@@ -2,8 +2,57 @@ import { describe, expect, test } from "bun:test";
 import {
 	type AiGenerationEvent,
 	type AiGenerationListener,
+	AiGenerationSessionRegistry,
+	shouldNotifyAiTabCompletion,
 	startAiGenerationSession,
 } from "./aiGenerationSession";
+
+describe("AiGenerationSessionRegistry", () => {
+	test("replaces requests only within the same query tab", () => {
+		const registry = new AiGenerationSessionRegistry();
+		const cancellations: string[] = [];
+		const firstTabRequest = {
+			promise: Promise.resolve(),
+			cancel: () => cancellations.push("first-tab-old"),
+		};
+		const secondTabRequest = {
+			promise: Promise.resolve(),
+			cancel: () => cancellations.push("second-tab"),
+		};
+		const replacement = {
+			promise: Promise.resolve(),
+			cancel: () => cancellations.push("first-tab-new"),
+		};
+
+		registry.replace("query-1", firstTabRequest);
+		registry.replace("query-2", secondTabRequest);
+		registry.replace("query-1", replacement);
+
+		expect(cancellations).toEqual(["first-tab-old"]);
+		expect(registry.isCurrent("query-1", replacement)).toBe(true);
+		expect(registry.isCurrent("query-2", secondTabRequest)).toBe(true);
+
+		registry.cancel("query-2");
+		expect(cancellations).toEqual(["first-tab-old", "second-tab"]);
+		expect(registry.isCurrent("query-1", replacement)).toBe(true);
+	});
+});
+
+describe("shouldNotifyAiTabCompletion", () => {
+	test("notifies only for an existing background tab", () => {
+		const tabs = [{ id: "query-1" }, { id: "query-2" }];
+
+		expect(shouldNotifyAiTabCompletion(tabs, "query-2", "query-1")).toBe(
+			true,
+		);
+		expect(shouldNotifyAiTabCompletion(tabs, "query-1", "query-1")).toBe(
+			false,
+		);
+		expect(shouldNotifyAiTabCompletion(tabs, "query-2", "closed")).toBe(
+			false,
+		);
+	});
+});
 
 describe("startAiGenerationSession", () => {
 	test("streams only matching events and cleans up every listener", async () => {

--- a/src/lib/aiGenerationSession.test.ts
+++ b/src/lib/aiGenerationSession.test.ts
@@ -5,7 +5,6 @@ import {
 	AiGenerationCancellationError,
 	AiGenerationSessionRegistry,
 	isAiGenerationCancellation,
-	shouldNotifyAiTabCompletion,
 	startAiGenerationSession,
 } from "./aiGenerationSession";
 
@@ -61,22 +60,6 @@ describe("AiGenerationSessionRegistry", () => {
 		if (!(cancellations[1] instanceof AiGenerationCancellationError)) return;
 		expect(cancellations[0].reason).toBe("replaced");
 		expect(cancellations[1].reason).toBe("cancelled");
-	});
-});
-
-describe("shouldNotifyAiTabCompletion", () => {
-	test("notifies only for an existing background tab", () => {
-		const tabs = [{ id: "query-1" }, { id: "query-2" }];
-
-		expect(shouldNotifyAiTabCompletion(tabs, "query-2", "query-1")).toBe(
-			true,
-		);
-		expect(shouldNotifyAiTabCompletion(tabs, "query-1", "query-1")).toBe(
-			false,
-		);
-		expect(shouldNotifyAiTabCompletion(tabs, "query-2", "closed")).toBe(
-			false,
-		);
 	});
 });
 

--- a/src/lib/aiGenerationSession.test.ts
+++ b/src/lib/aiGenerationSession.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
 	type AiGenerationEvent,
 	type AiGenerationListener,
+	AiGenerationCancellationError,
 	AiGenerationSessionRegistry,
+	isAiGenerationCancellation,
 	shouldNotifyAiTabCompletion,
 	startAiGenerationSession,
 } from "./aiGenerationSession";
@@ -35,6 +37,30 @@ describe("AiGenerationSessionRegistry", () => {
 		registry.cancel("query-2");
 		expect(cancellations).toEqual(["first-tab-old", "second-tab"]);
 		expect(registry.isCurrent("query-1", replacement)).toBe(true);
+	});
+
+	test("uses typed reasons when requests are replaced or cancelled", () => {
+		const registry = new AiGenerationSessionRegistry();
+		const cancellations: unknown[] = [];
+		const session = () => ({
+			promise: Promise.resolve(),
+			cancel: (error: Error) => cancellations.push(error),
+		});
+
+		registry.replace("query-1", session());
+		registry.replace("query-1", session());
+		registry.replace("query-2", session());
+		registry.cancel("query-2");
+
+		expect(cancellations).toHaveLength(2);
+		expect(cancellations[0]).toBeInstanceOf(AiGenerationCancellationError);
+		expect(cancellations[1]).toBeInstanceOf(AiGenerationCancellationError);
+		expect(isAiGenerationCancellation(cancellations[0])).toBe(true);
+		expect(isAiGenerationCancellation(cancellations[1])).toBe(true);
+		if (!(cancellations[0] instanceof AiGenerationCancellationError)) return;
+		if (!(cancellations[1] instanceof AiGenerationCancellationError)) return;
+		expect(cancellations[0].reason).toBe("replaced");
+		expect(cancellations[1].reason).toBe("cancelled");
 	});
 });
 

--- a/src/lib/aiGenerationSession.ts
+++ b/src/lib/aiGenerationSession.ts
@@ -38,9 +38,51 @@ interface StartAiGenerationSessionOptions {
 	onComplete: (sql: string) => void;
 }
 
-interface AiGenerationSession {
+export interface AiGenerationSession {
 	promise: Promise<void>;
 	cancel: (error: Error) => void;
+}
+
+export class AiGenerationSessionRegistry {
+	private readonly sessions = new Map<string, AiGenerationSession>();
+
+	replace(key: string, session: AiGenerationSession): void {
+		this.cancel(key, new Error("A newer AI request replaced this one"));
+		this.sessions.set(key, session);
+	}
+
+	isCurrent(key: string, session: AiGenerationSession): boolean {
+		return this.sessions.get(key) === session;
+	}
+
+	deleteIfCurrent(key: string, session: AiGenerationSession): void {
+		if (this.isCurrent(key, session)) this.sessions.delete(key);
+	}
+
+	cancel(
+		key: string,
+		error: Error = new Error("AI generation was cancelled"),
+	): void {
+		const session = this.sessions.get(key);
+		if (!session) return;
+		this.sessions.delete(key);
+		session.cancel(error);
+	}
+
+	cancelAll(): void {
+		for (const key of this.sessions.keys()) this.cancel(key);
+	}
+}
+
+export function shouldNotifyAiTabCompletion(
+	tabs: ReadonlyArray<{ id: string }>,
+	activeTabId: string | null,
+	completedTabId: string,
+): boolean {
+	return (
+		activeTabId !== completedTabId &&
+		tabs.some((tab) => tab.id === completedTabId)
+	);
 }
 
 export function startAiGenerationSession({

--- a/src/lib/aiGenerationSession.ts
+++ b/src/lib/aiGenerationSession.ts
@@ -96,17 +96,6 @@ export class AiGenerationSessionRegistry {
 	}
 }
 
-export function shouldNotifyAiTabCompletion(
-	tabs: ReadonlyArray<{ id: string }>,
-	activeTabId: string | null,
-	completedTabId: string,
-): boolean {
-	return (
-		activeTabId !== completedTabId &&
-		tabs.some((tab) => tab.id === completedTabId)
-	);
-}
-
 export function startAiGenerationSession({
 	sessionId,
 	listen,

--- a/src/lib/aiGenerationSession.ts
+++ b/src/lib/aiGenerationSession.ts
@@ -43,11 +43,33 @@ export interface AiGenerationSession {
 	cancel: (error: Error) => void;
 }
 
+export type AiGenerationCancellationReason = "cancelled" | "replaced";
+
+export class AiGenerationCancellationError extends Error {
+	readonly reason: AiGenerationCancellationReason;
+
+	constructor(reason: AiGenerationCancellationReason) {
+		super(
+			reason === "replaced"
+				? "A newer AI request replaced this one"
+				: "AI generation was cancelled",
+		);
+		this.name = "AiGenerationCancellationError";
+		this.reason = reason;
+	}
+}
+
+export function isAiGenerationCancellation(
+	error: unknown,
+): error is AiGenerationCancellationError {
+	return error instanceof AiGenerationCancellationError;
+}
+
 export class AiGenerationSessionRegistry {
 	private readonly sessions = new Map<string, AiGenerationSession>();
 
 	replace(key: string, session: AiGenerationSession): void {
-		this.cancel(key, new Error("A newer AI request replaced this one"));
+		this.cancel(key, new AiGenerationCancellationError("replaced"));
 		this.sessions.set(key, session);
 	}
 
@@ -61,7 +83,7 @@ export class AiGenerationSessionRegistry {
 
 	cancel(
 		key: string,
-		error: Error = new Error("AI generation was cancelled"),
+		error: Error = new AiGenerationCancellationError("cancelled"),
 	): void {
 		const session = this.sessions.get(key);
 		if (!session) return;

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -163,6 +163,11 @@ import {
 	hasUnappliedFilterDraft,
 	normalizeColumnLayout,
 } from "@/lib/savedViews";
+import {
+	queryAiStateReducer,
+	type QueryAiStateAction,
+} from "@/lib/aiDraftState";
+import { shouldNotifyAiTabCompletion } from "@/lib/aiGenerationSession";
 
 const SchemaVisualizer = lazy(() =>
 	import("@/components/SchemaVisualizer").then((module) => ({
@@ -267,6 +272,14 @@ function formatQuerySuccessDetail(affectedRows: number | null): string {
 	if (affectedRows === null) return "No rows returned";
 
 	return `${affectedRows} row${affectedRows !== 1 ? "s" : ""} affected`;
+}
+
+function isAiGenerationCancellation(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		(error.message === "AI generation was cancelled" ||
+			error.message === "A newer AI request replaced this one")
+	);
 }
 
 // Header component that uses useSidebar for conditional padding
@@ -447,6 +460,10 @@ export function ConnectionDetails() {
 	// Tab state
 	const [tabs, setTabs] = useState<Tab[]>([]);
 	const [activeTabId, setActiveTabId] = useState<string | null>(null);
+	const tabsRef = useRef(tabs);
+	const activeTabIdRef = useRef(activeTabId);
+	tabsRef.current = tabs;
+	activeTabIdRef.current = activeTabId;
 
 	// Redis-specific state (no tabs for Redis)
 	const [redisPattern, setRedisPattern] = useState("*");
@@ -548,13 +565,71 @@ export function ConnectionDetails() {
 	const [showQueryDeleteDialog, setShowQueryDeleteDialog] = useState(false);
 
 	// AI generation
-	const { generateDraft, isConfigured: aiConfigured } =
+	const {
+		generateDraft,
+		cancelGeneration,
+		isConfigured: aiConfigured,
+	} =
 		useContextualSqlGeneration({
 			dbType: connection?.db_type,
 			tables,
 			tableColumns,
 			schemaOverview,
 		});
+
+	const generateDraftForTab = useCallback(
+		async (
+			tabId: string,
+			tabTitle: string,
+			instruction: string,
+			existingSQL: string,
+			onPreview: (sql: string) => void,
+		) => {
+			const viewQuery = () => {
+				if (tabsRef.current.some((tab) => tab.id === tabId)) {
+					setActiveTabId(tabId);
+				}
+			};
+
+			try {
+				const sql = await generateDraft(
+					tabId,
+					instruction,
+					existingSQL,
+					onPreview,
+				);
+				if (
+					shouldNotifyAiTabCompletion(
+						tabsRef.current,
+						activeTabIdRef.current,
+						tabId,
+					)
+				) {
+					toast.success("AI query ready", {
+						description: `Generated SQL is ready in ${tabTitle}.`,
+						action: { label: "View query", onClick: viewQuery },
+					});
+				}
+				return sql;
+			} catch (error) {
+				if (
+					!isAiGenerationCancellation(error) &&
+					shouldNotifyAiTabCompletion(
+						tabsRef.current,
+						activeTabIdRef.current,
+						tabId,
+					)
+				) {
+					toast.error("AI query generation failed", {
+						description: error instanceof Error ? error.message : String(error),
+						action: { label: "View query", onClick: viewQuery },
+					});
+				}
+				throw error;
+			}
+		},
+		[generateDraft],
+	);
 
 	// Row edit state
 	const [rowEditSheetOpen, setRowEditSheetOpen] = useState(false);
@@ -820,6 +895,19 @@ export function ConnectionDetails() {
 		<T extends Tab>(tabId: string, updates: Partial<T>) => {
 			setTabs((prev) =>
 				prev.map((t) => (t.id === tabId ? { ...t, ...updates } : t)),
+			);
+		},
+		[],
+	);
+
+	const updateQueryAiState = useCallback(
+		(tabId: string, action: QueryAiStateAction) => {
+			setTabs((prev) =>
+				prev.map((tab) =>
+					tab.id === tabId && tab.type === "query"
+						? { ...tab, ai: queryAiStateReducer(tab.ai, action) }
+						: tab,
+				),
 			);
 		},
 		[],
@@ -1184,6 +1272,7 @@ export function ConnectionDetails() {
 
 	const handleCloseTab = useCallback(
 		(tabId: string) => {
+			cancelGeneration(tabId);
 			setTabs((prev) => {
 				const newTabs = prev.filter((t) => t.id !== tabId);
 
@@ -1199,7 +1288,7 @@ export function ConnectionDetails() {
 				return newTabs;
 			});
 		},
-		[activeTabId],
+		[activeTabId, cancelGeneration],
 	);
 
 	const handleTabSelect = useCallback((tabId: string) => {
@@ -3097,7 +3186,17 @@ export function ConnectionDetails() {
 							name: t.name,
 							columns: tableColumns[`${t.schema}.${t.name}`],
 						}))}
-						onGenerateSQL={generateDraft}
+						aiState={tab.ai}
+						onAiStateChange={(action) => updateQueryAiState(tab.id, action)}
+						onGenerateSQL={(instruction, existingSQL, onPreview) =>
+							generateDraftForTab(
+								tab.id,
+								tab.title,
+								instruction,
+								existingSQL,
+								onPreview,
+							)
+						}
 						aiConfigured={aiConfigured}
 						onCursorActivity={(line, char) => {
 							setCursorLine(line);

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -167,7 +167,10 @@ import {
 	queryAiStateReducer,
 	type QueryAiStateAction,
 } from "@/lib/aiDraftState";
-import { shouldNotifyAiTabCompletion } from "@/lib/aiGenerationSession";
+import {
+	isAiGenerationCancellation,
+	shouldNotifyAiTabCompletion,
+} from "@/lib/aiGenerationSession";
 
 const SchemaVisualizer = lazy(() =>
 	import("@/components/SchemaVisualizer").then((module) => ({
@@ -272,14 +275,6 @@ function formatQuerySuccessDetail(affectedRows: number | null): string {
 	if (affectedRows === null) return "No rows returned";
 
 	return `${affectedRows} row${affectedRows !== 1 ? "s" : ""} affected`;
-}
-
-function isAiGenerationCancellation(error: unknown): boolean {
-	return (
-		error instanceof Error &&
-		(error.message === "AI generation was cancelled" ||
-			error.message === "A newer AI request replaced this one")
-	);
 }
 
 // Header component that uses useSidebar for conditional padding

--- a/src/pages/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails.tsx
@@ -134,6 +134,7 @@ import { QueryResultSheet } from "@/components/QueryResultSheet";
 import { SqlEditor } from "@/components/SqlEditor";
 import { TabBar } from "@/components/TabBar";
 import { useContextualSqlGeneration } from "@/hooks/useContextualSqlGeneration";
+import { useQueryAiGeneration } from "@/hooks/useQueryAiGeneration";
 import { useTableDataFilters } from "@/hooks/useTableDataFilters";
 import { useSavedViewApplication } from "@/hooks/useSavedViewApplication";
 import { RowEditSheet } from "@/components/RowEditSheet";
@@ -163,14 +164,6 @@ import {
 	hasUnappliedFilterDraft,
 	normalizeColumnLayout,
 } from "@/lib/savedViews";
-import {
-	queryAiStateReducer,
-	type QueryAiStateAction,
-} from "@/lib/aiDraftState";
-import {
-	isAiGenerationCancellation,
-	shouldNotifyAiTabCompletion,
-} from "@/lib/aiGenerationSession";
 
 const SchemaVisualizer = lazy(() =>
 	import("@/components/SchemaVisualizer").then((module) => ({
@@ -455,10 +448,6 @@ export function ConnectionDetails() {
 	// Tab state
 	const [tabs, setTabs] = useState<Tab[]>([]);
 	const [activeTabId, setActiveTabId] = useState<string | null>(null);
-	const tabsRef = useRef(tabs);
-	const activeTabIdRef = useRef(activeTabId);
-	tabsRef.current = tabs;
-	activeTabIdRef.current = activeTabId;
 
 	// Redis-specific state (no tabs for Redis)
 	const [redisPattern, setRedisPattern] = useState("*");
@@ -572,59 +561,15 @@ export function ConnectionDetails() {
 			schemaOverview,
 		});
 
-	const generateDraftForTab = useCallback(
-		async (
-			tabId: string,
-			tabTitle: string,
-			instruction: string,
-			existingSQL: string,
-			onPreview: (sql: string) => void,
-		) => {
-			const viewQuery = () => {
-				if (tabsRef.current.some((tab) => tab.id === tabId)) {
-					setActiveTabId(tabId);
-				}
-			};
-
-			try {
-				const sql = await generateDraft(
-					tabId,
-					instruction,
-					existingSQL,
-					onPreview,
-				);
-				if (
-					shouldNotifyAiTabCompletion(
-						tabsRef.current,
-						activeTabIdRef.current,
-						tabId,
-					)
-				) {
-					toast.success("AI query ready", {
-						description: `Generated SQL is ready in ${tabTitle}.`,
-						action: { label: "View query", onClick: viewQuery },
-					});
-				}
-				return sql;
-			} catch (error) {
-				if (
-					!isAiGenerationCancellation(error) &&
-					shouldNotifyAiTabCompletion(
-						tabsRef.current,
-						activeTabIdRef.current,
-						tabId,
-					)
-				) {
-					toast.error("AI query generation failed", {
-						description: error instanceof Error ? error.message : String(error),
-						action: { label: "View query", onClick: viewQuery },
-					});
-				}
-				throw error;
-			}
-		},
-		[generateDraft],
-	);
+	const { getEditorAiProps, cancelTabGeneration } = useQueryAiGeneration({
+		tabs,
+		activeTabId,
+		setTabs,
+		setActiveTabId,
+		generateDraft,
+		cancelGeneration,
+		isConfigured: aiConfigured,
+	});
 
 	// Row edit state
 	const [rowEditSheetOpen, setRowEditSheetOpen] = useState(false);
@@ -890,19 +835,6 @@ export function ConnectionDetails() {
 		<T extends Tab>(tabId: string, updates: Partial<T>) => {
 			setTabs((prev) =>
 				prev.map((t) => (t.id === tabId ? { ...t, ...updates } : t)),
-			);
-		},
-		[],
-	);
-
-	const updateQueryAiState = useCallback(
-		(tabId: string, action: QueryAiStateAction) => {
-			setTabs((prev) =>
-				prev.map((tab) =>
-					tab.id === tabId && tab.type === "query"
-						? { ...tab, ai: queryAiStateReducer(tab.ai, action) }
-						: tab,
-				),
 			);
 		},
 		[],
@@ -1267,7 +1199,7 @@ export function ConnectionDetails() {
 
 	const handleCloseTab = useCallback(
 		(tabId: string) => {
-			cancelGeneration(tabId);
+			cancelTabGeneration(tabId);
 			setTabs((prev) => {
 				const newTabs = prev.filter((t) => t.id !== tabId);
 
@@ -1283,7 +1215,7 @@ export function ConnectionDetails() {
 				return newTabs;
 			});
 		},
-		[activeTabId, cancelGeneration],
+		[activeTabId, cancelTabGeneration],
 	);
 
 	const handleTabSelect = useCallback((tabId: string) => {
@@ -3181,18 +3113,7 @@ export function ConnectionDetails() {
 							name: t.name,
 							columns: tableColumns[`${t.schema}.${t.name}`],
 						}))}
-						aiState={tab.ai}
-						onAiStateChange={(action) => updateQueryAiState(tab.id, action)}
-						onGenerateSQL={(instruction, existingSQL, onPreview) =>
-							generateDraftForTab(
-								tab.id,
-								tab.title,
-								instruction,
-								existingSQL,
-								onPreview,
-							)
-						}
-						aiConfigured={aiConfigured}
+						ai={getEditorAiProps(tab)}
 						onCursorActivity={(line, char) => {
 							setCursorLine(line);
 							setCursorChar(char);

--- a/src/types/tabTypes.ts
+++ b/src/types/tabTypes.ts
@@ -1,4 +1,5 @@
 import type { TableDataResponse } from "./tableData";
+import { createQueryAiState, type QueryAiState } from "@/lib/aiDraftState";
 import {
 	createTableFilterState,
 	type TableFilterState,
@@ -74,6 +75,7 @@ export interface TableStructureTab extends BaseTab {
 export interface QueryTab extends BaseTab {
 	type: "query";
 	query: string;
+	ai: QueryAiState;
 	savedQueryId: number | null;
 	savedQueryName: string | null;
 	results: Record<string, unknown>[] | null;
@@ -169,6 +171,7 @@ export function createQueryTab(
 		type: "query",
 		title: savedQueryName || "New Query",
 		query,
+		ai: createQueryAiState(),
 		savedQueryId,
 		savedQueryName,
 		results: null,


### PR DESCRIPTION
## Summary

- keep AI instructions, streaming previews, and completed drafts in each query tab instead of editor-local state
- allow generation sessions to continue independently when users switch to another query or table tab
- notify users when generation finishes in a background tab, with a **View query** action
- isolate the lifecycle in a focused hook with request identity and typed cancellation handling

## Root cause

The AI prompt and draft were owned by the mounted `SqlEditor`. Switching tabs unmounted that editor, discarded its local state, and tied the active request lifecycle to the visible tab.

## Validation

- `bun run check`
  - 85 tests passed
  - TypeScript checks passed
  - ESLint passed
  - production build passed
- integration coverage verifies background completion, toast navigation, stale-request isolation, and closing a generating tab
- the local browser shell loaded, but the complete database flow requires Tauri's native bridge and cannot run in a standalone browser preview
