### PR TITLE
Support isolated local store directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,35 @@
-## DBcooper
+# DBcooper
 
-- Do not add unnecessary comments unless absolutely necessary
-- The project uses tauri for the backend (https://v2.tauri.app/)
-- The project uses bun + react (ts) for the frontend
-- The project uses sqlite as the primary database
-- The project uses sqlx as the querybuilder and for database connections (https://sqlx.io/)
-- For loading state, use shadcn spinner. If the button text is 'Test', the loading state should be '<Spinner> Test'. Do not alter the text
-- Do not add any gap between icon and text in button, as the component already has it
-- Run shadcn commands inside the src/ directory. Use shadcn cli to install components.
-- Make sure components files don't get too big, split into multiple files if needed.
-- Release PRs should have the `release` tag/label.
+## Architecture
+
+- The backend is Rust with Tauri v2. The frontend is React, TypeScript, and Vite, with Bun as the package manager and script runner.
+- Run JavaScript commands from the repository root unless a command explicitly targets another directory.
+- SQLite is DBcooper's internal application-state store. The app connects to PostgreSQL, SQLite, Redis, and ClickHouse databases.
+- SQLx provides the internal SQLite store plus PostgreSQL and SQLite connections. Redis and ClickHouse use their dedicated drivers; do not describe SQLx as a query builder or universal database driver.
+- The default application database is `<data_local_dir>/dbcooper/db.sqlite3`. `DBCOOPER_LOCAL_STORE` accepts a store directory or an exact path ending in `.db`, `.sqlite`, or `.sqlite3`.
+
+## UI conventions
+
+- Do not add comments unless they explain non-obvious intent or constraints.
+- Use the shared shadcn `Spinner` for loading states. Preserve the existing button label and prefix it with `<Spinner />`; for example, `Test Connection` must remain `Test Connection` while loading.
+- Do not add manual spacing between a button icon or spinner and its label. The shared `Button` component already supplies the gap.
+- Run shadcn CLI commands from `src/`, where `components.json` lives.
+- Keep components focused. Do not add unrelated responsibilities to oversized files such as `ConnectionDetails.tsx`; extract cohesive components or hooks while keeping changes surgical.
+
+## Verification
+
+- Use `bun install --frozen-lockfile` when dependencies need to be synchronized.
+- For frontend changes, run `bun run check` from the repository root. It covers tests, type checking, linting, and the production build.
+- For Rust changes, run focused tests first. The CI-equivalent backend command is `cd src-tauri && cargo test -- --test-threads=1`; integration tests require the PostgreSQL, Redis, and ClickHouse services defined by CI or `docker-compose.yml`.
+- For manual Tauri verification, use `bun run tauri dev` and confirm the running executable belongs to the intended checkout, not an older `/Applications/DBcooper.app` installation.
+
+## Local data and migrations
+
+- SQLx migrations are embedded into the binary. A database whose migration ledger is newer than the running binary will fail during startup.
+- When testing a custom branch or worktree, always launch it with a unique branch-specific store, for example `DBCOOPER_LOCAL_STORE=custom_path bun run tauri dev`. Never share a custom store between concurrently tested branches or point them at the real application database.
+- Never remove tables or `_sqlx_migrations` rows from the real database without explicit user approval. Inventory affected rows, create and verify a recoverable full backup, make the rollback transactionally, and finish with `PRAGMA integrity_check` plus a ledger check.
+
+## Releases
+
+- Every successful merge to `main` produces a canary build. Stable remains the default updater channel; canary updates require explicit opt-in in Settings.
+- Stable release PRs must update `src-tauri/tauri.conf.json` and carry the `release` label. After merge, `tag-on-merge.yml` creates the stable tag and `publish.yml` creates the draft release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - Run JavaScript commands from the repository root unless a command explicitly targets another directory.
 - SQLite is DBcooper's internal application-state store. The app connects to PostgreSQL, SQLite, Redis, and ClickHouse databases.
 - SQLx provides the internal SQLite store plus PostgreSQL and SQLite connections. Redis and ClickHouse use their dedicated drivers; do not describe SQLx as a query builder or universal database driver.
-- The default application database is `<data_local_dir>/dbcooper/db.sqlite3`. `DBCOOPER_LOCAL_STORE` accepts a store directory or an exact path ending in `.db`, `.sqlite`, or `.sqlite3`.
+- The default application database is `<data_local_dir>/dbcooper/db.sqlite3`. `DBCOOPER_LOCAL_STORE` overrides the store directory; DBcooper creates `db.sqlite3` inside it.
 
 ## UI conventions
 
@@ -26,7 +26,7 @@
 ## Local data and migrations
 
 - SQLx migrations are embedded into the binary. A database whose migration ledger is newer than the running binary will fail during startup.
-- When testing a custom branch or worktree, always launch it with a unique branch-specific store, for example `DBCOOPER_LOCAL_STORE=custom_path bun run tauri dev`. Never share a custom store between concurrently tested branches or point them at the real application database.
+- When testing a custom branch or worktree, always launch it with a unique branch-specific store outside the checkout, for example `DBCOOPER_LOCAL_STORE=/private/tmp/dbcooper-feature-name bun run tauri dev` after replacing `feature-name` with the branch name. Never share a custom store between concurrently tested branches or point them at the real application database.
 - Never remove tables or `_sqlx_migrations` rows from the real database without explicit user approval. Inventory affected rows, create and verify a recoverable full backup, make the rollback transactionally, and finish with `PRAGMA integrity_check` plus a ledger check.
 
 ## Releases

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1,4 +1,4 @@
-use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
@@ -28,35 +28,17 @@ pub enum DbError {
 
 pub type DbResult<T> = Result<T, DbError>;
 
-fn is_explicit_database_file(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| {
-            ["db", "sqlite", "sqlite3"]
-                .iter()
-                .any(|candidate| extension.eq_ignore_ascii_case(candidate))
-        })
-}
-
 fn resolve_db_path(
     custom_store: Option<OsString>,
     data_local_dir: Option<PathBuf>,
 ) -> DbResult<PathBuf> {
-    match custom_store {
+    let store_dir = match custom_store {
         Some(path) if path.is_empty() => Err(DbError::InvalidLocalStore),
-        Some(path) => {
-            let path = PathBuf::from(path);
-            if is_explicit_database_file(&path) {
-                Ok(path)
-            } else {
-                Ok(path.join("db.sqlite3"))
-            }
-        }
-        None => Ok(data_local_dir
-            .ok_or(DbError::DataDir)?
-            .join("dbcooper")
-            .join("db.sqlite3")),
-    }
+        Some(path) => Ok(PathBuf::from(path)),
+        None => Ok(data_local_dir.ok_or(DbError::DataDir)?.join("dbcooper")),
+    }?;
+
+    Ok(store_dir.join("db.sqlite3"))
 }
 
 fn prepare_db_path(db_path: &Path) -> DbResult<()> {
@@ -73,14 +55,14 @@ fn prepare_db_path(db_path: &Path) -> DbResult<()> {
 }
 
 fn get_db_path() -> DbResult<PathBuf> {
-    let db_path = resolve_db_path(std::env::var_os(LOCAL_STORE_ENV), dirs::data_local_dir())?;
-    prepare_db_path(&db_path)?;
-    Ok(db_path)
+    resolve_db_path(std::env::var_os(LOCAL_STORE_ENV), dirs::data_local_dir())
 }
 
-pub async fn init_pool() -> DbResult<SqlitePool> {
-    let db_path = get_db_path()?;
-    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+async fn init_pool_at(db_path: &Path) -> DbResult<SqlitePool> {
+    prepare_db_path(db_path)?;
+    let options = SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(true);
 
     let pool = SqlitePoolOptions::new()
         .max_connections(5)
@@ -101,7 +83,7 @@ pub async fn init_pool() -> DbResult<SqlitePool> {
                 Ok(())
             })
         })
-        .connect(&db_url)
+        .connect_with(options)
         .await?;
 
     sqlx::migrate!("./migrations").run(&pool).await?;
@@ -109,9 +91,14 @@ pub async fn init_pool() -> DbResult<SqlitePool> {
     Ok(pool)
 }
 
+pub async fn init_pool() -> DbResult<SqlitePool> {
+    let db_path = get_db_path()?;
+    init_pool_at(&db_path).await
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{prepare_db_path, resolve_db_path, DbError};
+    use super::{init_pool_at, prepare_db_path, resolve_db_path, DbError};
     use std::ffi::OsString;
     use std::path::PathBuf;
 
@@ -134,20 +121,15 @@ mod tests {
     }
 
     #[test]
-    fn preserves_explicit_sqlite_database_filenames() {
-        for path in [
-            "custom_path/branch.db",
-            "custom_path/branch.sqlite",
-            "custom_path/branch.sqlite3",
-            "custom_path/branch.SQLITE3",
-        ] {
+    fn treats_custom_stores_as_directories_regardless_of_extension() {
+        for path in ["custom_path/branch", "custom_path/branch.sqlite3"] {
             let resolved = resolve_db_path(
                 Some(OsString::from(path)),
                 Some(PathBuf::from("/application-data")),
             )
             .unwrap();
 
-            assert_eq!(resolved, PathBuf::from(path));
+            assert_eq!(resolved, PathBuf::from(path).join("db.sqlite3"));
         }
     }
 
@@ -182,5 +164,20 @@ mod tests {
         let error = prepare_db_path(&db_path).unwrap_err();
 
         assert!(matches!(error, DbError::LocalStore { .. }));
+    }
+
+    #[tokio::test]
+    async fn opens_database_at_a_store_path_with_url_special_characters() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir
+            .path()
+            .join("branch%2Fname?draft")
+            .join("db.sqlite3");
+
+        let pool = init_pool_at(&db_path).await.unwrap();
+        pool.close().await;
+
+        assert!(db_path.is_file());
+        assert!(!temp_dir.path().join("branch/name").exists());
     }
 }

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1,6 +1,9 @@
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
-use std::path::PathBuf;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
+
+const LOCAL_STORE_ENV: &str = "DBCOOPER_LOCAL_STORE";
 
 pub mod models;
 pub mod settings;
@@ -13,15 +16,66 @@ pub enum DbError {
     Migration(#[from] sqlx::migrate::MigrateError),
     #[error("Failed to get data directory")]
     DataDir,
+    #[error("DBCOOPER_LOCAL_STORE cannot be empty")]
+    InvalidLocalStore,
+    #[error("Failed to prepare local store directory {path}: {source}")]
+    LocalStore {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 pub type DbResult<T> = Result<T, DbError>;
 
+fn is_explicit_database_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            ["db", "sqlite", "sqlite3"]
+                .iter()
+                .any(|candidate| extension.eq_ignore_ascii_case(candidate))
+        })
+}
+
+fn resolve_db_path(
+    custom_store: Option<OsString>,
+    data_local_dir: Option<PathBuf>,
+) -> DbResult<PathBuf> {
+    match custom_store {
+        Some(path) if path.is_empty() => Err(DbError::InvalidLocalStore),
+        Some(path) => {
+            let path = PathBuf::from(path);
+            if is_explicit_database_file(&path) {
+                Ok(path)
+            } else {
+                Ok(path.join("db.sqlite3"))
+            }
+        }
+        None => Ok(data_local_dir
+            .ok_or(DbError::DataDir)?
+            .join("dbcooper")
+            .join("db.sqlite3")),
+    }
+}
+
+fn prepare_db_path(db_path: &Path) -> DbResult<()> {
+    if let Some(parent) = db_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent).map_err(|source| DbError::LocalStore {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(())
+}
+
 fn get_db_path() -> DbResult<PathBuf> {
-    let data_dir = dirs::data_local_dir().ok_or(DbError::DataDir)?;
-    let app_dir = data_dir.join("dbcooper");
-    std::fs::create_dir_all(&app_dir).ok();
-    Ok(app_dir.join("db.sqlite3"))
+    let db_path = resolve_db_path(std::env::var_os(LOCAL_STORE_ENV), dirs::data_local_dir())?;
+    prepare_db_path(&db_path)?;
+    Ok(db_path)
 }
 
 pub async fn init_pool() -> DbResult<SqlitePool> {
@@ -53,4 +107,80 @@ pub async fn init_pool() -> DbResult<SqlitePool> {
     sqlx::migrate!("./migrations").run(&pool).await?;
 
     Ok(pool)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{prepare_db_path, resolve_db_path, DbError};
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    #[test]
+    fn uses_the_default_application_store_when_no_override_is_set() {
+        let path = resolve_db_path(None, Some(PathBuf::from("/application-data"))).unwrap();
+
+        assert_eq!(path, PathBuf::from("/application-data/dbcooper/db.sqlite3"));
+    }
+
+    #[test]
+    fn appends_the_database_filename_to_a_custom_store_directory() {
+        let path = resolve_db_path(
+            Some(OsString::from("custom_path")),
+            Some(PathBuf::from("/application-data")),
+        )
+        .unwrap();
+
+        assert_eq!(path, PathBuf::from("custom_path/db.sqlite3"));
+    }
+
+    #[test]
+    fn preserves_explicit_sqlite_database_filenames() {
+        for path in [
+            "custom_path/branch.db",
+            "custom_path/branch.sqlite",
+            "custom_path/branch.sqlite3",
+            "custom_path/branch.SQLITE3",
+        ] {
+            let resolved = resolve_db_path(
+                Some(OsString::from(path)),
+                Some(PathBuf::from("/application-data")),
+            )
+            .unwrap();
+
+            assert_eq!(resolved, PathBuf::from(path));
+        }
+    }
+
+    #[test]
+    fn rejects_an_empty_custom_store() {
+        let error = resolve_db_path(
+            Some(OsString::new()),
+            Some(PathBuf::from("/application-data")),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, DbError::InvalidLocalStore));
+    }
+
+    #[test]
+    fn creates_nested_directories_for_the_database() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("branches/feature/db.sqlite3");
+
+        prepare_db_path(&db_path).unwrap();
+
+        assert!(temp_dir.path().join("branches/feature").is_dir());
+    }
+
+    #[test]
+    fn reports_when_the_custom_store_directory_cannot_be_created() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let blocking_file = temp_dir.path().join("blocking-file");
+        std::fs::write(&blocking_file, "not a directory").unwrap();
+        let db_path = blocking_file.join("branch/db.sqlite3");
+
+        let error = prepare_db_path(&db_path).unwrap_err();
+
+        assert!(matches!(error, DbError::LocalStore { .. }));
+    }
 }


### PR DESCRIPTION
## Summary

- add `DBCOOPER_LOCAL_STORE` as a directory override for DBcooper's internal SQLite store
- create `db.sqlite3` inside the selected directory and preserve filesystem paths with typed SQLx connection options
- reject empty overrides and surface directory-creation failures
- document branch-specific stores outside the checkout in `AGENTS.md`

## Why

DBcooper embeds SQLx migrations in each binary. Running branches with different migration sets against the same application database can crash at startup or risk local data. This gives every branch or worktree an explicit isolated store without changing the default application path.

## Verification

- `cargo fmt --check`
- `cargo check`
- `cargo test --lib` — 53 passed
- `bun run check` — 78 frontend tests, type checking, linting, and production build passed
- runtime smoke with `DBCOOPER_LOCAL_STORE=/private/tmp/dbcooper-local-store-fix... bun run tauri dev`
- confirmed the running executable came from this worktree
- confirmed all 8 migrations succeeded and `PRAGMA integrity_check` returned `ok`
- regression coverage opens a real SQLite database under a path containing `%2F` and `?`

## Integration-test note

`cargo test -- --test-threads=1` passed the unit and SQLite application-data suites, then reached the unchanged ClickHouse integration suite. Those tests could not run because the local ClickHouse service was not running (`docker compose ps clickhouse` was empty).