### PR TITLE
Replace startup spinners with connection skeletons

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import type { ReactNode } from "react";
+
+if (!globalThis.document) GlobalRegistrator.register();
+
+mock.module("@/components/ui/sonner", () => ({
+	Toaster: () => null,
+}));
+mock.module("@/components/ui/spinner", () => ({
+	Spinner: () => <span role="status" aria-label="Loading route" />,
+}));
+mock.module("@/contexts/SettingsContext", () => ({
+	SettingsProvider: ({ children }: { children: ReactNode }) => children,
+}));
+mock.module("@/contexts/ThemeContext", () => ({
+	ThemeProvider: ({ children }: { children: ReactNode }) => children,
+}));
+mock.module("@/pages/Connections", () => ({
+	Connections: () => <h1>Connections</h1>,
+}));
+
+const { cleanup, render, screen } = await import("@testing-library/react");
+const { App } = await import("./App");
+
+beforeEach(() => {
+	window.location.href = "http://localhost/";
+});
+
+afterEach(() => {
+	cleanup();
+});
+
+test("renders the root route without a suspense loading state", () => {
+	render(<App />);
+
+	expect(screen.getByRole("heading", { name: "Connections" })).not.toBeNull();
+	expect(screen.queryByRole("status", { name: "Loading route" })).toBeNull();
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,8 @@ import { Toaster } from "@/components/ui/sonner";
 import { Spinner } from "@/components/ui/spinner";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { SettingsProvider } from "@/contexts/SettingsContext";
+import { Connections } from "@/pages/Connections";
 
-const Connections = lazy(() =>
-	import("@/pages/Connections").then((module) => ({
-		default: module.Connections,
-	})),
-);
 const ConnectionDetails = lazy(() =>
 	import("@/pages/ConnectionDetails").then((module) => ({
 		default: module.ConnectionDetails,

--- a/src/components/connections/ConnectionCard.tsx
+++ b/src/components/connections/ConnectionCard.tsx
@@ -13,11 +13,16 @@ import { DuckdbIcon } from "@/components/icons/duckdb";
 import { CloudflareIcon } from "@/components/icons/cloudflare";
 import { Badge } from "@/components/ui/badge";
 import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu";
+import { Skeleton } from "@/components/ui/skeleton";
 import { getConnectionDatabaseDisplay } from "@/lib/connectionPresentation";
 import type { Connection } from "@/lib/tauri";
+import { cn } from "@/lib/utils";
 import type { DockerConnectionState } from "@/types/docker";
 
 type DockerAction = "start" | "stop" | "restart";
+
+const CONNECTION_CARD_FRAME_CLASS =
+	"workspace-panel relative overflow-hidden rounded-lg border p-3.5 shadow-sm";
 
 interface ConnectionCardProps {
 	connection: Connection;
@@ -29,6 +34,26 @@ interface ConnectionCardProps {
 	onDuplicate: () => void;
 	onExport: () => void;
 	onDelete: () => void;
+}
+
+export function ConnectionCardSkeleton() {
+	return (
+		<div
+			data-slot="connection-card-skeleton"
+			className={CONNECTION_CARD_FRAME_CLASS}
+			aria-hidden="true"
+		>
+			<Skeleton className="absolute inset-y-3 left-0 w-0.5 rounded-r-full" />
+			<div className="flex items-center gap-3 pl-1">
+				<Skeleton className="size-9 shrink-0 rounded-md" />
+				<div className="min-w-0 flex-1 space-y-1.5">
+					<Skeleton className="h-4 w-32 rounded" />
+					<Skeleton className="h-3 w-44 max-w-full rounded" />
+				</div>
+				<Skeleton className="size-7 shrink-0 rounded-md" />
+			</div>
+		</div>
+	);
 }
 
 function dbTypeConfig(type: string) {
@@ -117,7 +142,12 @@ export function ConnectionCard({
 	return (
 		<ContextMenu>
 			<ContextMenuTrigger>
-				<div className="group workspace-panel relative overflow-hidden rounded-lg border p-3.5 shadow-sm transition-[border-color,box-shadow,transform] duration-150 hover:-translate-y-px hover:border-foreground/20 hover:shadow-md focus-within:ring-2 focus-within:ring-ring/40">
+				<div
+					className={cn(
+						CONNECTION_CARD_FRAME_CLASS,
+						"group transition-[border-color,box-shadow,transform] duration-150 hover:-translate-y-px hover:border-foreground/20 hover:shadow-md focus-within:ring-2 focus-within:ring-ring/40",
+					)}
+				>
 					<button
 						type="button"
 						onClick={onOpen}

--- a/src/pages/Connections.test.tsx
+++ b/src/pages/Connections.test.tsx
@@ -1,14 +1,18 @@
 import { afterEach, expect, mock, test } from "bun:test";
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { ComponentProps, ReactNode } from "react";
-import { DOCKER_DATABASE_ENGINES } from "../types/docker";
+import type { Connection } from "../lib/tauri";
+import {
+	DOCKER_DATABASE_ENGINES,
+	type DockerConnectionState,
+} from "../types/docker";
 
 if (!globalThis.document) GlobalRegistrator.register();
 
-let listConnections: () => Promise<unknown[]> = () =>
-	new Promise<unknown[]>(() => {});
-let listDockerStates: () => Promise<unknown[]> = () =>
-	new Promise<unknown[]>(() => {});
+const pending = <T,>() => new Promise<T>(() => {});
+
+let listConnections: () => Promise<Connection[]> = () => pending();
+let listDockerStates: () => Promise<DockerConnectionState[]> = () => pending();
 
 mock.module("@tauri-apps/plugin-dialog", () => ({
 	open: async () => null,
@@ -32,8 +36,11 @@ mock.module("@/components/ConnectionForm", () => ({
 	ConnectionForm: () => null,
 }));
 mock.module("@/components/connections/ConnectionCard", () => ({
-	ConnectionCard: ({ connection }: { connection: { name: string } }) => (
+	ConnectionCard: ({ connection }: { connection: Connection }) => (
 		<div>{connection.name}</div>
+	),
+	ConnectionCardSkeleton: () => (
+		<div data-slot="connection-card-skeleton" aria-hidden="true" />
 	),
 }));
 mock.module("@/components/UpdateChecker", () => ({
@@ -79,9 +86,6 @@ mock.module("@/components/ui/skeleton", () => ({
 		<div data-slot="skeleton" className={className} {...props} />
 	),
 }));
-mock.module("@/components/ui/spinner", () => ({
-	Spinner: () => <span data-testid="spinner" />,
-}));
 mock.module("@/lib/tauri", () => ({
 	DOCKER_DATABASE_ENGINES,
 	api: {
@@ -100,8 +104,8 @@ const { Connections } = await import("./Connections");
 
 afterEach(() => {
 	cleanup();
-	listConnections = () => new Promise<unknown[]>(() => {});
-	listDockerStates = () => new Promise<unknown[]>(() => {});
+	listConnections = () => pending();
+	listDockerStates = () => pending();
 });
 
 function renderConnections() {
@@ -112,12 +116,10 @@ function renderConnections() {
 	);
 }
 
-test("keeps the page layout visible while connections load", () => {
+test("keeps the page shell interactive while connections load", () => {
 	renderConnections();
 
-	expect(
-		screen.getByRole("heading", { name: "Connections" }),
-	).not.toBeNull();
+	expect(screen.getByRole("heading", { name: "Connections" })).not.toBeNull();
 	expect(
 		screen.getByRole("heading", { name: "Your databases" }),
 	).not.toBeNull();
@@ -127,7 +129,17 @@ test("keeps the page layout visible while connections load", () => {
 	expect(
 		document.querySelectorAll('[data-slot="connection-card-skeleton"]'),
 	).toHaveLength(4);
-	expect(screen.queryByTestId("spinner")).toBeNull();
+
+	for (const name of [
+		"Connect Docker",
+		"Create database",
+		"Import",
+		"New connection",
+	]) {
+		expect(
+			(screen.getByRole("button", { name }) as HTMLButtonElement).disabled,
+		).toBe(false);
+	}
 });
 
 test("shows the existing empty state after loading finishes", async () => {
@@ -143,10 +155,6 @@ test("shows the existing empty state after loading finishes", async () => {
 	expect(
 		screen.getByRole("button", { name: "Create database" }),
 	).not.toBeNull();
-	expect(
-		screen.getByRole("button", { name: "Connect Docker" }),
-	).not.toBeNull();
-	expect(
-		screen.getByRole("button", { name: "New connection" }),
-	).not.toBeNull();
+	expect(screen.getByRole("button", { name: "Connect Docker" })).not.toBeNull();
+	expect(screen.getByRole("button", { name: "New connection" })).not.toBeNull();
 });

--- a/src/pages/Connections.test.tsx
+++ b/src/pages/Connections.test.tsx
@@ -1,0 +1,152 @@
+import { afterEach, expect, mock, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+import type { ComponentProps, ReactNode } from "react";
+import { DOCKER_DATABASE_ENGINES } from "../types/docker";
+
+if (!globalThis.document) GlobalRegistrator.register();
+
+let listConnections: () => Promise<unknown[]> = () =>
+	new Promise<unknown[]>(() => {});
+let listDockerStates: () => Promise<unknown[]> = () =>
+	new Promise<unknown[]>(() => {});
+
+mock.module("@tauri-apps/plugin-dialog", () => ({
+	open: async () => null,
+	save: async () => null,
+}));
+mock.module("@tauri-apps/plugin-fs", () => ({
+	readTextFile: async () => "",
+	writeTextFile: async () => undefined,
+}));
+mock.module("@tauri-apps/plugin-opener", () => ({
+	revealItemInDir: async () => undefined,
+}));
+mock.module("sonner", () => ({
+	toast: {
+		error: () => undefined,
+		success: () => undefined,
+		warning: () => undefined,
+	},
+}));
+mock.module("@/components/ConnectionForm", () => ({
+	ConnectionForm: () => null,
+}));
+mock.module("@/components/connections/ConnectionCard", () => ({
+	ConnectionCard: ({ connection }: { connection: { name: string } }) => (
+		<div>{connection.name}</div>
+	),
+}));
+mock.module("@/components/UpdateChecker", () => ({
+	UpdateChecker: () => null,
+}));
+mock.module("@/components/connections/DeleteConnectionDialog", () => ({
+	DeleteConnectionDialog: () => null,
+}));
+mock.module("@/components/docker/ConnectDockerDialog", () => ({
+	ConnectDockerDialog: () => null,
+}));
+mock.module("@/components/docker/CreateDatabaseDialog", () => ({
+	CreateDatabaseDialog: () => null,
+}));
+mock.module("@/components/EmptyState", () => ({
+	EmptyState: ({
+		title,
+		actions,
+	}: {
+		title: string;
+		actions: Array<{ label: string }>;
+	}) => (
+		<div>
+			<h2>{title}</h2>
+			{actions.map((action) => (
+				<button type="button" key={action.label}>
+					{action.label}
+				</button>
+			))}
+		</div>
+	),
+}));
+mock.module("@/components/ui/badge", () => ({
+	Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+mock.module("@/components/ui/button", () => ({
+	Button: ({ children, ...props }: ComponentProps<"button">) => (
+		<button {...props}>{children}</button>
+	),
+}));
+mock.module("@/components/ui/skeleton", () => ({
+	Skeleton: ({ className, ...props }: ComponentProps<"div">) => (
+		<div data-slot="skeleton" className={className} {...props} />
+	),
+}));
+mock.module("@/components/ui/spinner", () => ({
+	Spinner: () => <span data-testid="spinner" />,
+}));
+mock.module("@/lib/tauri", () => ({
+	DOCKER_DATABASE_ENGINES,
+	api: {
+		connections: {
+			list: () => listConnections(),
+		},
+		docker: {
+			states: () => listDockerStates(),
+		},
+	},
+}));
+
+const { cleanup, render, screen } = await import("@testing-library/react");
+const { MemoryRouter } = await import("react-router-dom");
+const { Connections } = await import("./Connections");
+
+afterEach(() => {
+	cleanup();
+	listConnections = () => new Promise<unknown[]>(() => {});
+	listDockerStates = () => new Promise<unknown[]>(() => {});
+});
+
+function renderConnections() {
+	return render(
+		<MemoryRouter>
+			<Connections />
+		</MemoryRouter>,
+	);
+}
+
+test("keeps the page layout visible while connections load", () => {
+	renderConnections();
+
+	expect(
+		screen.getByRole("heading", { name: "Connections" }),
+	).not.toBeNull();
+	expect(
+		screen.getByRole("heading", { name: "Your databases" }),
+	).not.toBeNull();
+	expect(
+		screen.getByRole("status", { name: "Loading connections" }),
+	).not.toBeNull();
+	expect(
+		document.querySelectorAll('[data-slot="connection-card-skeleton"]'),
+	).toHaveLength(4);
+	expect(screen.queryByTestId("spinner")).toBeNull();
+});
+
+test("shows the existing empty state after loading finishes", async () => {
+	listConnections = async () => [];
+	listDockerStates = async () => [];
+
+	renderConnections();
+
+	expect(await screen.findByText("No connections yet")).not.toBeNull();
+	expect(
+		screen.queryByRole("status", { name: "Loading connections" }),
+	).toBeNull();
+	expect(
+		screen.getByRole("button", { name: "Create database" }),
+	).not.toBeNull();
+	expect(
+		screen.getByRole("button", { name: "Connect Docker" }),
+	).not.toBeNull();
+	expect(
+		screen.getByRole("button", { name: "New connection" }),
+	).not.toBeNull();
+});

--- a/src/pages/Connections.tsx
+++ b/src/pages/Connections.tsx
@@ -9,11 +9,14 @@ import {
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { ConnectionForm } from "@/components/ConnectionForm";
-import { ConnectionCard } from "@/components/connections/ConnectionCard";
+import {
+	ConnectionCard,
+	ConnectionCardSkeleton,
+} from "@/components/connections/ConnectionCard";
 import { DeleteConnectionDialog } from "@/components/connections/DeleteConnectionDialog";
 import { ConnectDockerDialog } from "@/components/docker/ConnectDockerDialog";
 import { CreateDatabaseDialog } from "@/components/docker/CreateDatabaseDialog";
@@ -30,22 +33,30 @@ import {
 	type DockerConnectionState,
 } from "@/lib/tauri";
 
-function ConnectionCardSkeleton() {
+function ConnectionGrid({
+	loading,
+	children,
+}: {
+	loading: boolean;
+	children: ReactNode;
+}) {
 	return (
 		<div
-			data-slot="connection-card-skeleton"
-			className="workspace-panel relative overflow-hidden rounded-lg border p-3.5 shadow-sm"
-			aria-hidden="true"
+			className="grid grid-cols-1 gap-2.5 lg:grid-cols-2"
+			role={loading ? "status" : undefined}
+			aria-label={loading ? "Loading connections" : undefined}
+			aria-busy={loading || undefined}
 		>
-			<Skeleton className="absolute inset-y-3 left-0 w-0.5 rounded-r-full" />
-			<div className="flex items-center gap-3 pl-1">
-				<Skeleton className="size-9 shrink-0 rounded-md" />
-				<div className="min-w-0 flex-1 space-y-1.5">
-					<Skeleton className="h-4 w-32 rounded" />
-					<Skeleton className="h-3 w-44 max-w-full rounded" />
-				</div>
-				<Skeleton className="size-7 shrink-0 rounded-md" />
-			</div>
+			{loading ? (
+				<>
+					<span className="sr-only">Loading connections</span>
+					{Array.from({ length: 4 }, (_, index) => (
+						<ConnectionCardSkeleton key={index} />
+					))}
+				</>
+			) : (
+				children
+			)}
 		</div>
 	);
 }
@@ -370,16 +381,11 @@ export function Connections() {
 										onClick={() => setConnectDockerOpen(true)}
 										size="sm"
 										variant="outline"
-										disabled={loading}
 									>
 										<Cube className="size-4" />
 										Connect Docker
 									</Button>
-									<Button
-										onClick={() => setCreateDatabaseOpen(true)}
-										size="sm"
-										disabled={loading}
-									>
+									<Button onClick={() => setCreateDatabaseOpen(true)} size="sm">
 										<Plus className="size-4" weight="bold" />
 										Create database
 									</Button>
@@ -387,7 +393,6 @@ export function Connections() {
 										onClick={handleImportConnections}
 										size="sm"
 										variant="outline"
-										disabled={loading}
 									>
 										<UploadSimple className="size-4" />
 										Import
@@ -396,7 +401,6 @@ export function Connections() {
 										onClick={() => setIsFormOpen(true)}
 										size="sm"
 										variant="outline"
-										disabled={loading}
 									>
 										<Plus className="size-4" weight="bold" />
 										New connection
@@ -404,42 +408,26 @@ export function Connections() {
 								</div>
 							</div>
 
-							<div
-								className="grid grid-cols-1 gap-2.5 lg:grid-cols-2"
-								role={loading ? "status" : undefined}
-								aria-label={loading ? "Loading connections" : undefined}
-								aria-busy={loading || undefined}
-							>
-								{loading ? (
-									<>
-										<span className="sr-only">Loading connections</span>
-										{Array.from({ length: 4 }, (_, index) => (
-											<ConnectionCardSkeleton key={index} />
-										))}
-									</>
-								) : (
-									connections.map((connection) => (
-										<ConnectionCard
-											key={connection.id}
-											connection={connection}
-											dockerState={dockerStates[connection.uuid]}
-											onOpen={() => navigate(`/connections/${connection.uuid}`)}
-											onCopyConnectionString={() =>
-												handleCopyConnectionString(connection)
-											}
-											onDockerAction={(action) =>
-												handleDockerAction(connection, action)
-											}
-											onEdit={() => handleEditConnection(connection)}
-											onDuplicate={() =>
-												handleDuplicateConnection(connection)
-											}
-											onExport={() => handleExportConnection(connection)}
-											onDelete={() => handleDeleteClick(connection)}
-										/>
-									))
-								)}
-							</div>
+							<ConnectionGrid loading={loading}>
+								{connections.map((connection) => (
+									<ConnectionCard
+										key={connection.id}
+										connection={connection}
+										dockerState={dockerStates[connection.uuid]}
+										onOpen={() => navigate(`/connections/${connection.uuid}`)}
+										onCopyConnectionString={() =>
+											handleCopyConnectionString(connection)
+										}
+										onDockerAction={(action) =>
+											handleDockerAction(connection, action)
+										}
+										onEdit={() => handleEditConnection(connection)}
+										onDuplicate={() => handleDuplicateConnection(connection)}
+										onExport={() => handleExportConnection(connection)}
+										onDelete={() => handleDeleteClick(connection)}
+									/>
+								))}
+							</ConnectionGrid>
 						</div>
 					)}
 				</div>

--- a/src/pages/Connections.tsx
+++ b/src/pages/Connections.tsx
@@ -21,7 +21,7 @@ import { EmptyState } from "@/components/EmptyState";
 import { UpdateChecker } from "@/components/UpdateChecker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
 	api,
 	type Connection,
@@ -29,6 +29,26 @@ import {
 	type ConnectionsExport,
 	type DockerConnectionState,
 } from "@/lib/tauri";
+
+function ConnectionCardSkeleton() {
+	return (
+		<div
+			data-slot="connection-card-skeleton"
+			className="workspace-panel relative overflow-hidden rounded-lg border p-3.5 shadow-sm"
+			aria-hidden="true"
+		>
+			<Skeleton className="absolute inset-y-3 left-0 w-0.5 rounded-r-full" />
+			<div className="flex items-center gap-3 pl-1">
+				<Skeleton className="size-9 shrink-0 rounded-md" />
+				<div className="min-w-0 flex-1 space-y-1.5">
+					<Skeleton className="h-4 w-32 rounded" />
+					<Skeleton className="h-3 w-44 max-w-full rounded" />
+				</div>
+				<Skeleton className="size-7 shrink-0 rounded-md" />
+			</div>
+		</div>
+	);
+}
 
 export function Connections() {
 	const navigate = useNavigate();
@@ -259,19 +279,6 @@ export function Connections() {
 		}
 	};
 
-	if (loading) {
-		return (
-			<div className="workspace-canvas flex min-h-screen items-center justify-center">
-				<div className="workspace-panel flex min-w-56 items-center rounded-lg border px-4 py-3 shadow-sm">
-					<Spinner className="size-4" />
-					<p className="ml-3 text-sm text-muted-foreground">
-						Loading connections…
-					</p>
-				</div>
-			</div>
-		);
-	}
-
 	return (
 		<div className="workspace-canvas flex min-h-screen flex-col">
 			<header
@@ -280,8 +287,16 @@ export function Connections() {
 			>
 				<div className="flex items-center gap-2 pl-4">
 					<h1 className="text-sm font-semibold text-foreground">Connections</h1>
-					<Badge variant="secondary" className="h-5 px-1.5 text-[10px]">
-						{connections.length}
+					<Badge
+						variant="secondary"
+						className="h-5 min-w-5 px-1.5 text-[10px]"
+						aria-label={loading ? "Loading connection count" : undefined}
+					>
+						{loading ? (
+							<Skeleton className="h-2.5 w-2.5 rounded-sm" aria-hidden="true" />
+						) : (
+							connections.length
+						)}
 					</Badge>
 				</div>
 				<div className="flex items-center gap-1">
@@ -311,7 +326,7 @@ export function Connections() {
 
 			<main className="flex-1 overflow-auto p-5 md:p-8">
 				<div className="mx-auto max-w-5xl">
-					{connections.length === 0 ? (
+					{!loading && connections.length === 0 ? (
 						<div className="flex min-h-[calc(100vh-8rem)] items-center justify-center">
 							<EmptyState
 								title="No connections yet"
@@ -355,11 +370,16 @@ export function Connections() {
 										onClick={() => setConnectDockerOpen(true)}
 										size="sm"
 										variant="outline"
+										disabled={loading}
 									>
 										<Cube className="size-4" />
 										Connect Docker
 									</Button>
-									<Button onClick={() => setCreateDatabaseOpen(true)} size="sm">
+									<Button
+										onClick={() => setCreateDatabaseOpen(true)}
+										size="sm"
+										disabled={loading}
+									>
 										<Plus className="size-4" weight="bold" />
 										Create database
 									</Button>
@@ -367,6 +387,7 @@ export function Connections() {
 										onClick={handleImportConnections}
 										size="sm"
 										variant="outline"
+										disabled={loading}
 									>
 										<UploadSimple className="size-4" />
 										Import
@@ -375,6 +396,7 @@ export function Connections() {
 										onClick={() => setIsFormOpen(true)}
 										size="sm"
 										variant="outline"
+										disabled={loading}
 									>
 										<Plus className="size-4" weight="bold" />
 										New connection
@@ -382,25 +404,41 @@ export function Connections() {
 								</div>
 							</div>
 
-							<div className="grid grid-cols-1 gap-2.5 lg:grid-cols-2">
-								{connections.map((connection) => (
-									<ConnectionCard
-										key={connection.id}
-										connection={connection}
-										dockerState={dockerStates[connection.uuid]}
-										onOpen={() => navigate(`/connections/${connection.uuid}`)}
-										onCopyConnectionString={() =>
-											handleCopyConnectionString(connection)
-										}
-										onDockerAction={(action) =>
-											handleDockerAction(connection, action)
-										}
-										onEdit={() => handleEditConnection(connection)}
-										onDuplicate={() => handleDuplicateConnection(connection)}
-										onExport={() => handleExportConnection(connection)}
-										onDelete={() => handleDeleteClick(connection)}
-									/>
-								))}
+							<div
+								className="grid grid-cols-1 gap-2.5 lg:grid-cols-2"
+								role={loading ? "status" : undefined}
+								aria-label={loading ? "Loading connections" : undefined}
+								aria-busy={loading || undefined}
+							>
+								{loading ? (
+									<>
+										<span className="sr-only">Loading connections</span>
+										{Array.from({ length: 4 }, (_, index) => (
+											<ConnectionCardSkeleton key={index} />
+										))}
+									</>
+								) : (
+									connections.map((connection) => (
+										<ConnectionCard
+											key={connection.id}
+											connection={connection}
+											dockerState={dockerStates[connection.uuid]}
+											onOpen={() => navigate(`/connections/${connection.uuid}`)}
+											onCopyConnectionString={() =>
+												handleCopyConnectionString(connection)
+											}
+											onDockerAction={(action) =>
+												handleDockerAction(connection, action)
+											}
+											onEdit={() => handleEditConnection(connection)}
+											onDuplicate={() =>
+												handleDuplicateConnection(connection)
+											}
+											onExport={() => handleExportConnection(connection)}
+											onDelete={() => handleDeleteClick(connection)}
+										/>
+									))
+								)}
 							</div>
 						</div>
 					)}


### PR DESCRIPTION
## Summary

- load the root Connections route eagerly so the startup layout renders without a Suspense spinner
- keep the page shell and workspace actions available while connection data loads
- replace the connection fetch spinner with card-shaped skeletons that share the canonical card frame
- add App-level and page-level regression coverage for the startup and loading states

## Root cause

The Connections route was code-split behind the app-wide Suspense fallback even though it is the initial local route. After that chunk resolved, the page replaced the entire layout with a second spinner while it fetched connections, producing two consecutive loading states.

## User impact

The application layout now appears immediately. Only connection-specific content uses a loading skeleton, while navigation and workspace actions remain available.

## Testing

- `bun run check`
  - 115 tests passed
  - TypeScript checks passed
  - ESLint passed
  - production Vite build passed
- mutation-checked the App regression test by temporarily restoring the lazy root route and confirming it failed on the Suspense fallback
