### PR TITLE
Fix stable release workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -219,6 +219,8 @@ jobs:
   verify:
     name: Run release verification
     needs: validate
+    permissions:
+      contents: write
     uses: ./.github/workflows/test.yml
     with:
       ref: ${{ needs.validate.outputs.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     services:
       postgres:


### PR DESCRIPTION
## Summary

- allow the stable-release verification call to satisfy the reusable workflow's maximum contents permission
- keep the integration test job explicitly read-only
- prevent pull-request close events from failing during workflow initialization

## Root cause

The stable release workflow called test.yml with contents: read, while the reusable workflow also contains skipped canary jobs that declare contents: write. GitHub validates the full reusable workflow permission graph before evaluating job conditions, so the run failed at startup with no jobs.

## Testing

- actionlint -shellcheck shellcheck
- git diff --check
- direct YAML assertion for verify contents: write and test contents: read
- git verify-commit HEAD

Fixes the startup failure in https://github.com/amalshaji/dbcooper/actions/runs/30792073533
