### PR TITLE
Restore tag-on-merge release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,117 +1,63 @@
-name: Build stable release
+name: 'publish'
 
 on:
-  pull_request_target:
-    types: [closed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v1.2.3)'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+    secrets:
+      TAURI_SIGNING_PRIVATE_KEY:
+        required: true
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
+        required: true
+  push:
+    tags:
+      - 'v*'
+      - '!v*-canary.*'
 
 permissions:
-  contents: read
-
-concurrency:
-  group: stable-release
-  cancel-in-progress: false
+  contents: write
 
 jobs:
-  validate:
-    name: Validate merged release
-    if: >-
-      ${{
-        github.event_name == 'pull_request_target' &&
-        github.event.pull_request.merged &&
-        github.event.pull_request.base.ref == 'main' &&
-        contains(github.event.pull_request.labels.*.name, 'release')
-      }}
-    runs-on: ubuntu-latest
-    outputs:
-      sha: ${{ steps.release.outputs.sha }}
-      tag: ${{ steps.release.outputs.tag }}
-      version: ${{ steps.release.outputs.version }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-          fetch-depth: 0
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Validate version and release state
-        id: release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
-        run: |
-          set -euo pipefail
-
-          version="$(bun -e "console.log((await Bun.file('./src-tauri/tauri.conf.json').json()).version)")"
-          if ! echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Invalid stable version: $version"
-            exit 1
-          fi
-
-          tag="v$version"
-          release_json="$(
-            gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" |
-              jq --slurp --compact-output --arg tag "$tag" \
-                'add | map(select(.tag_name == $tag)) | first // empty'
-          )"
-
-          tag_sha="$(git ls-remote origin "refs/tags/$tag^{}" | awk 'NR == 1 { print $1 }')"
-          if [ -z "$tag_sha" ]; then
-            tag_sha="$(git ls-remote origin "refs/tags/$tag" | awk 'NR == 1 { print $1 }')"
-          fi
-
-          if [ -n "$release_json" ]; then
-            if [ "$(jq -r '.draft' <<< "$release_json")" != "true" ]; then
-              echo "Release $tag is already published."
-              exit 1
-            fi
-
-            if [ -n "$tag_sha" ]; then
-              if [ "$tag_sha" != "$SOURCE_SHA" ]; then
-                echo "Existing tag $tag points to $tag_sha, not $SOURCE_SHA."
-                exit 1
-              fi
-            elif [ "$(jq -r '.target_commitish' <<< "$release_json")" != "$SOURCE_SHA" ]; then
-              echo "Existing draft $tag targets a different commit."
-              exit 1
-            fi
-
-            echo "Resuming existing draft release $tag."
-          elif [ -n "$tag_sha" ]; then
-            echo "Tag $tag already exists without a matching draft release."
-            exit 1
-          fi
-
-          {
-            echo "sha=$SOURCE_SHA"
-            echo "tag=$tag"
-            echo "version=$version"
-          } >> "$GITHUB_OUTPUT"
-
-  verify:
-    name: Run release verification
-    needs: validate
-    permissions:
-      contents: write
-    uses: ./.github/workflows/test.yml
-    with:
-      ref: ${{ needs.validate.outputs.sha }}
-
-  release:
-    name: Build signed release draft
-    needs: [validate, verify]
+  macos:
     permissions:
       contents: write
     runs-on: macos-26
+
     steps:
-      - uses: actions/checkout@v6
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            tag="${GITHUB_REF_NAME}"
+          else
+            tag="${{ inputs.tag }}"
+          fi
+
+          if [ -z "$tag" ]; then
+            echo "Error: tag input required"
+            exit 1
+          fi
+          if ! echo "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: stable releases require a vMAJOR.MINOR.PATCH tag"
+            exit 1
+          fi
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.validate.outputs.sha }}
+          ref: ${{ steps.tag.outputs.tag }}
           fetch-depth: 0
 
-      - name: Setup Bun
+      - name: Setup bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
@@ -129,115 +75,18 @@ jobs:
       - name: Install frontend dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build, sign, and prepare draft release
-        id: tauri
-        uses: tauri-apps/tauri-action@v0
+      - name: Run frontend checks
+        run: bun run check
+
+      - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          retryAttempts: 3
-          tagName: ${{ needs.validate.outputs.tag }}
-          releaseName: ${{ needs.validate.outputs.tag }}
-          releaseBody: See the assets to download this version and install.
-          releaseCommitish: ${{ needs.validate.outputs.sha }}
+          tagName: ${{ steps.tag.outputs.tag }}
+          releaseName: ${{ steps.tag.outputs.tag }}
+          releaseBody: 'See the assets to download this version and install.'
           releaseDraft: true
           prerelease: false
           args: '--target aarch64-apple-darwin'
-
-      - name: Validate draft release assets
-        id: draft
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_ID: ${{ steps.tauri.outputs.releaseId }}
-          RELEASE_URL: ${{ steps.tauri.outputs.releaseHtmlUrl }}
-          SOURCE_SHA: ${{ needs.validate.outputs.sha }}
-          TAG: ${{ needs.validate.outputs.tag }}
-          VERSION: ${{ needs.validate.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          if ! echo "$RELEASE_ID" | grep -Eq '^[0-9]+$'; then
-            echo "Tauri action did not return a valid release ID."
-            exit 1
-          fi
-          if [ -z "$RELEASE_URL" ]; then
-            echo "Tauri action did not return a release URL."
-            exit 1
-          fi
-
-          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
-          if [ "$(jq -r '.tag_name' <<< "$release_json")" != "$TAG" ]; then
-            echo "Release $RELEASE_ID does not belong to $TAG."
-            exit 1
-          fi
-          if [ "$(jq -r '.draft' <<< "$release_json")" != "true" ]; then
-            echo "Release $TAG is not a draft."
-            exit 1
-          fi
-
-          tag_sha="$(git ls-remote origin "refs/tags/$TAG^{}" | awk 'NR == 1 { print $1 }')"
-          if [ -z "$tag_sha" ]; then
-            tag_sha="$(git ls-remote origin "refs/tags/$TAG" | awk 'NR == 1 { print $1 }')"
-          fi
-          if [ -n "$tag_sha" ] && [ "$tag_sha" != "$SOURCE_SHA" ]; then
-            echo "Draft tag $TAG points to $tag_sha, not $SOURCE_SHA."
-            exit 1
-          fi
-          if [ -z "$tag_sha" ] && [ "$(jq -r '.target_commitish' <<< "$release_json")" != "$SOURCE_SHA" ]; then
-            echo "Draft release $TAG targets a different commit."
-            exit 1
-          fi
-
-          assets_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets?per_page=100")"
-          expected_assets=(
-            "DBcooper_${VERSION}_aarch64.dmg"
-            "DBcooper_aarch64.app.tar.gz"
-            "DBcooper_aarch64.app.tar.gz.sig"
-            "latest.json"
-          )
-          for asset in "${expected_assets[@]}"; do
-            if ! jq -e --arg asset "$asset" 'any(.[]; .name == $asset and .state == "uploaded")' \
-              <<< "$assets_json" >/dev/null; then
-              echo "Draft release is missing uploaded asset $asset."
-              exit 1
-            fi
-          done
-
-          manifest_asset_id="$(
-            jq -r '.[] | select(.name == "latest.json") | .id' <<< "$assets_json"
-          )"
-          manifest_path="$RUNNER_TEMP/latest.json"
-          gh api \
-            -H 'Accept: application/octet-stream' \
-            "repos/$GITHUB_REPOSITORY/releases/assets/$manifest_asset_id" \
-            > "$manifest_path"
-
-          archive_url="https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG/DBcooper_aarch64.app.tar.gz"
-          jq -e \
-            --arg version "$VERSION" \
-            --arg archive_url "$archive_url" \
-            '.version == $version and
-             .platforms["darwin-aarch64"].url == $archive_url and
-             (.platforms["darwin-aarch64"].signature | length > 0)' \
-            "$manifest_path" >/dev/null
-
-          echo "url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
-
-      - name: Summarize release draft
-        env:
-          RELEASE_URL: ${{ steps.draft.outputs.url }}
-          SOURCE_SHA: ${{ needs.validate.outputs.sha }}
-          TAG: ${{ needs.validate.outputs.tag }}
-        run: |
-          {
-            echo "## Stable release draft ready"
-            echo
-            echo "- Release: [$TAG]($RELEASE_URL)"
-            echo "- Source commit: \`$SOURCE_SHA\`"
-            echo "- Signed updater manifest: validated"
-            echo
-            echo "Review the notes and assets, smoke-test the DMG, then publish the draft."
-            echo "Publishing the release will trigger the existing Homebrew cask update."
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,0 +1,70 @@
+name: tag-on-merge
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: >-
+      ${{
+        github.event.pull_request.merged &&
+        github.event.pull_request.base.ref == 'main' &&
+        contains(github.event.pull_request.labels.*.name, 'release')
+      }}
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+      tag_created: ${{ steps.tag.outputs.tag_created }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Create and push tag
+        id: tag
+        run: |
+          version=$(node -p "require('./src-tauri/tauri.conf.json').version")
+          if [ -z "$version" ]; then
+            echo "Error: Could not extract version from tauri.conf.json"
+            exit 1
+          fi
+          if ! echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: Invalid version format: $version"
+            exit 1
+          fi
+          tag="v$version"
+
+          if git ls-remote --tags origin "refs/tags/$tag" | grep -q "$tag"; then
+            echo "Tag $tag already exists. Skipping."
+            echo "tag_created=false" >> "$GITHUB_OUTPUT"
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "Release $tag" "${{ github.event.pull_request.merge_commit_sha }}"
+          git push origin "$tag"
+          echo "tag_created=true" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: tag
+    if: needs.tag.outputs.tag_created == 'true'
+    uses: ./.github/workflows/publish.yml
+    secrets: inherit
+    with:
+      tag: ${{ needs.tag.outputs.tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,17 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_call:
-    inputs:
-      ref:
-        required: false
-        type: string
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     services:
       postgres:
@@ -89,8 +82,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/README.md
+++ b/README.md
@@ -134,15 +134,13 @@ The app is configured to build for macOS ARM (Apple Silicon). The build process:
 
 ## Releases
 
-Stable releases are built and signed successfully before their tag is created.
-To publish a new version:
+Releases are automated via GitHub Actions. To publish a new version:
 
-1. Update `src-tauri/tauri.conf.json` to the next stable version
-2. Open a pull request to `main` and apply the `release` label
-3. Review and merge the release PR
-4. Wait for verification and the signed build to finish; the workflow then
-   creates the tag (for example, `v1.2.3`) and draft release
-5. Review the notes and assets, smoke-test the DMG, then publish the draft
+1. Update `version` in `src-tauri/tauri.conf.json`
+2. Open a PR and add the `release` label
+3. Merge the PR into `main`
+4. GitHub Actions will create and push the tag (e.g., `v0.0.42`), then build a draft release
+5. Review and publish the release
 
 ### Canary releases
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "vite build",
     "build:macos-icons": "./scripts/build-macos-icons.sh",
-		"test": "bun test src",
+    "test": "bun test src",
     "test:d1-local": "./scripts/test-d1-local.sh",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.node.json --noEmit",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary

- restore the pre-#157 tag-on-merge release workflow byte-for-byte
- create the stable tag when a release-labeled pull request merges
- build the signed draft release from that tag
- restore the original integration workflow and release documentation

This PR is intentionally not labeled release, so merging it will not create another stable release. The v0.0.66 release started by PR #159 remains independent.

## Behavior

1. Update the version in src-tauri/tauri.conf.json.
2. Open a pull request and add the release label.
3. Merge the pull request into main.
4. tag-on-merge creates vX.Y.Z and invokes publish.yml.
5. publish.yml builds the signed draft release from the tag.

## Testing

- verified restored file hashes against pre-#157 commit 7939963
- actionlint workflow syntax validation
- bunx bun@1.3.14 run check (154 tests, typecheck, lint, production build)
- git diff --check
- git verify-commit HEAD
